### PR TITLE
Fix typo in .Release.Namespace

### DIFF
--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.4

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -463,6 +463,10 @@ value is your SMTP password.
 
 ## Changelog
 
+### 1.0.1
+
+Fixed invalid namespace variable name causing ServiceAccount and Role to be generated in other namespace than desired.
+
 ### 1.0.0
 
 There are not code changes between `1.0.0` and `0.36.5`.

--- a/charts/kong/templates/controller-service-account.yaml
+++ b/charts/kong/templates/controller-service-account.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kong.serviceAccountName" . }}
-  namespace: {{ .Release.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
Helm requires .Release.Namespace instead of "namespace" to properly render namespace in output manifest. This PR fixes a typo in Service Account manifest.