### PR TITLE
[kong] Support for plugin with multiple configmaps

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -177,7 +177,7 @@ The name of the service used for the ingress controller's validation webhook
 - name: {{ template "kong.fullname" . }}-tmp
   emptyDir: {}
 {{- range .Values.plugins.configMaps }}
-- name: kong-plugin-{{ .pluginName }}
+- name: kong-plugin-{{ empty .path | ternary .pluginName .name }}
   configMap:
     name: {{ .name }}
 {{- end }}
@@ -226,13 +226,13 @@ The name of the service used for the ingress controller's validation webhook
   mountPath: /etc/secrets/{{ . }}
 {{- end }}
 {{- range .Values.plugins.configMaps }}
-- name:  kong-plugin-{{ .pluginName }}
-  mountPath: /opt/kong/plugins/{{ .pluginName }}
+- name: kong-plugin-{{ empty .path | ternary .pluginName .name }}
+  mountPath: /opt/kong/plugins/{{ coalesce .path .pluginName }}
   readOnly: true
 {{- end }}
 {{- range .Values.plugins.secrets }}
-- name:  kong-plugin-{{ .pluginName }}
-  mountPath: /opt/kong/plugins/{{ .pluginName }}
+- name: kong-plugin-{{ empty .path | ternary .pluginName .name }}
+  mountPath: /opt/kong/plugins/{{ coalesce .path .pluginName }}
   readOnly: true
 {{- end }}
 {{- end -}}
@@ -245,7 +245,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- range .Values.plugins.secrets -}}
   {{ $myList = append $myList .pluginName -}}
 {{- end }}
-{{- $myList | join "," -}}
+{{- $myList | uniq | join "," -}}
 {{- end -}}
 
 {{- define "kong.wait-for-db" -}}


### PR DESCRIPTION
This change is from an internal project PR, which I believe would be useful to include upstream. Credit goes to @cewood who initially raised it. 

For context, below is text from the internal PR:

> It's quite common for Kong plugins to require a folder of database initialisation and migration files under `migrations/*.lua`, in addition to the normal daos.lua, handler.lua, and schema.lua files. However the current implementation for plugins support in kong-app unfortunately doesn't take this into account.
> 
> My thinking was to add a path parameter to these `configMaps` items, and use that for the path instead of the pluginName as is currently the case. If the path isn't supplied, then fallback to the pluginName as a default. Then just run a unique filter over the KONG_PLUGINS list to remove possible duplicates, and you should be golden.
> 
> So an example configuration would look like:
> 
> ```
> plugins: {}
>   configMaps:
>   - name: key-auth-secret-root
>     pluginName: key-auth-secret
>   - name: key-auth-secret-migrations
>     pluginName: key-auth-secret
>     path: key-auth-secret/migrations  # defaults to pluginName if not specified
> ```
> 
> Also the `KONG_PLUGINS` environment variable shouldn't be required anymore, since everything is already on the default lua path of kong. I've tested this thoroughly whilst working with these custom plugins.
> 
