### PR TITLE
Disable helm lint check for version increment

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -15,6 +15,8 @@ jobs:
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@v1.0.0-alpha.3
+        env:
+          CT_CHECK_VERSION_INCREMENT: "false"
         with:
           command: lint
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,8 @@ jobs:
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@v1.0.0-alpha.3
+        env:
+          CT_CHECK_VERSION_INCREMENT: "false"
         with:
           command: lint
 


### PR DESCRIPTION
Every PR requires that it contains a bump to the Chart version. Since releases
are not created per PR and it can lead t potential conflicts, it doesn't make
much sense to include a check for it. So disable the check, allowing PRs not to
error.