### PR TITLE
[kong] Rework listener handling

### DIFF
--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 1.1.0
+version: 1.2.0
 appVersion: 1.4

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -1,16 +1,18 @@
-To connect to Kong, please execute the following command
+To connect to Kong, please execute the following commands:
 
-
-{{- if contains "LoadBalancer" .Values.proxy.type }}
-  HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].port}')
+{{ if contains "LoadBalancer" .Values.proxy.type }}
+HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].port}')
 {{- else if contains "NodePort" .Values.proxy.type -}}
-  HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
-  PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
 {{- end -}}
 export PROXY_IP=${HOST}:${PORT}
 curl $PROXY_IP
 
 Once installed, please follow along the getting started guide to start using Kong:
 https://bit.ly/k4k8s-get-started
-
+{{ if .Values.admin.containerPort -}} {{/* Legacy admin listener */}}
+WARNING: You are currently using a legacy admin listener configuration. Support for this will be removed in a future release.
+You should update your values.yaml to use separate "http" and "tls" subsections, as shown in https://github.com/helm/charts/blob/master/stable/kong/values.yaml
+{{- end -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -53,18 +53,18 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Create the KONG_PROXY_LISTEN value string
+Create KONG_SERVICE_LISTEN strings
 */}}
-{{- define "kong.kongProxyListenValue" -}}
+{{- define "kong.listen" -}}
 
-{{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled -}}
-   0.0.0.0:{{ .Values.proxy.http.containerPort }},0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl
+{{- if and .http.enabled .tls.enabled -}}
+   0.0.0.0:{{ .http.containerPort }},0.0.0.0:{{ .tls.containerPort }} ssl
 {{- else -}}
-{{- if .Values.proxy.http.enabled -}}
-   0.0.0.0:{{ .Values.proxy.http.containerPort }}
+{{- if .http.enabled -}}
+   0.0.0.0:{{ .http.containerPort }}
 {{- end -}}
-{{- if .Values.proxy.tls.enabled -}}
-   0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl
+{{- if .tls.enabled -}}
+   0.0.0.0:{{ .tls.containerPort }} ssl
 {{- end -}}
 {{- end -}}
 
@@ -338,56 +338,56 @@ the template that it itself is using form the above sections.
 
 {{- $_ := set $autoEnv "KONG_LUA_PACKAGE_PATH" "/opt/?.lua;;" -}}
 
-{{- if .Values.admin.useTLS }}
-  {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "0.0.0.0:%d ssl" (int64 .Values.admin.containerPort)) -}}
-{{- else }}
-  {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "0.0.0.0:%d" (int64 .Values.admin.containerPort)) -}}
+{{/*
+TODO: Remove legacy behavior at a later date. Prior to chart version 1.2.0, admin configuration in values.yaml used a
+format unique to it. 1.2.0 onward use a unified listener template for all listeners, but still retains support for the
+legacy admin listener configuration.
+*/}}
+
+{{- if .Values.admin.containerPort -}} {{/* Legacy admin listener */}}
+  {{- if .Values.admin.useTLS -}}
+    {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "0.0.0.0:%d ssl" (int64 .Values.admin.containerPort)) -}}
+  {{- else -}}
+    {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "0.0.0.0:%d" (int64 .Values.admin.containerPort)) -}}
+  {{- end -}}
+{{- else -}} {{/* Modern admin listener */}}
+  {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (include "kong.listen" .Values.admin) -}}
 {{- end -}}
 
-{{- if .Values.admin.ingress.enabled }}
-  {{- $_ := set $autoEnv "KONG_ADMIN_API_URI" (include "kong.ingress.serviceUrl" .Values.admin.ingress) -}}
-{{- end -}}
-
-{{- if not .Values.env.proxy_listen }}
-  {{- $_ := set $autoEnv "KONG_PROXY_LISTEN" (include "kong.kongProxyListenValue" .) -}}
-{{- end -}}
-
-{{- if and (not .Values.env.admin_gui_listen) (.Values.enterprise.enabled) }}
-  {{- $_ := set $autoEnv "KONG_ADMIN_GUI_LISTEN" (include "kong.kongManagerListenValue" .) -}}
-{{- end -}}
-
-{{- if and (.Values.manager.ingress.enabled) (.Values.enterprise.enabled) }}
-  {{- $_ := set $autoEnv "KONG_ADMIN_GUI_URL" (include "kong.ingress.serviceUrl" .Values.manager.ingress) -}}
-{{- end -}}
-
-{{- if and (not .Values.env.portal_gui_listen) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
-  {{- $_ := set $autoEnv "KONG_PORTAL_GUI_LISTEN" (include "kong.kongPortalListenValue" .) -}}
-{{- end }}
-
-{{- if and (.Values.portal.ingress.enabled) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
-  {{- $_ := set $autoEnv "KONG_PORTAL_GUI_HOST" .Values.portal.ingress.hostname -}}
-  {{- if .Values.portal.ingress.tls }}
-    {{- $_ := set $autoEnv "KONG_PORTAL_GUI_PROTOCOL" "https" -}}
-  {{- else }}
-    {{- $_ := set $autoEnv "KONG_PORTAL_GUI_PROTOCOL" "http" -}}
-  {{- end }}
-{{- end }}
-
-{{- if and (not .Values.env.portal_api_listen) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
-  {{- $_ := set $autoEnv "KONG_PORTAL_API_LISTEN" (include "kong.kongPortalApiListenValue" .) -}}
-{{- end }}
-
-{{- if and (.Values.portalapi.ingress.enabled) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
-  {{- $_ := set $autoEnv "KONG_PORTAL_API_URL" (include "kong.ingress.serviceUrl" .Values.portalapi.ingress) -}}
-{{- end }}
+{{- $_ := set $autoEnv "KONG_PROXY_LISTEN" (include "kong.listen" .Values.proxy) -}}
 
 {{- if .Values.enterprise.enabled }}
+  {{- if .Values.admin.ingress.enabled }}
+    {{- $_ := set $autoEnv "KONG_ADMIN_API_URI" (include "kong.ingress.serviceUrl" .Values.admin.ingress) -}}
+  {{- end -}}
+
+  {{- $_ := set $autoEnv "KONG_ADMIN_GUI_LISTEN" (include "kong.listen" .Values.manager) -}}
+  {{- if and (.Values.manager.ingress.enabled) (.Values.enterprise.enabled) }}
+    {{- $_ := set $autoEnv "KONG_ADMIN_GUI_URL" (include "kong.ingress.serviceUrl" .Values.manager.ingress) -}}
+  {{- end -}}
+
   {{- if not .Values.enterprise.vitals.enabled }}
     {{- $_ := set $autoEnv "KONG_VITALS" "off" -}}
   {{- end }}
 
   {{- if .Values.enterprise.portal.enabled }}
     {{- $_ := set $autoEnv "KONG_PORTAL" "on" -}}
+    {{- $_ := set $autoEnv "KONG_PORTAL_GUI_LISTEN" (include "kong.listen" .Values.portal) -}}
+    {{- $_ := set $autoEnv "KONG_PORTAL_API_LISTEN" (include "kong.listen" .Values.portalapi) -}}
+
+    {{- if and (.Values.portal.ingress.enabled) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
+      {{- $_ := set $autoEnv "KONG_PORTAL_GUI_HOST" .Values.portal.ingress.hostname -}}
+      {{- if .Values.portal.ingress.tls }}
+        {{- $_ := set $autoEnv "KONG_PORTAL_GUI_PROTOCOL" "https" -}}
+      {{- else }}
+        {{- $_ := set $autoEnv "KONG_PORTAL_GUI_PROTOCOL" "http" -}}
+      {{- end }}
+    {{- end }}
+
+    {{- if and (.Values.portalapi.ingress.enabled) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
+      {{- $_ := set $autoEnv "KONG_PORTAL_API_URL" (include "kong.ingress.serviceUrl" .Values.portalapi.ingress) -}}
+    {{- end }}
+
     {{- if .Values.enterprise.portal.portal_auth }}
       {{- $_ := set $autoEnv "KONG_PORTAL_AUTH" .Values.enterprise.portal.portal_auth -}}
       {{- $portalSession := include "secretkeyref" (dict "name" .Values.enterprise.portal.session_conf_secret "key" "portal_session_conf") -}}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -60,12 +60,31 @@ spec:
             exec:
               command: [ "/bin/sh", "-c", "kong quit" ]
         ports:
+        {{/* TODO: remove legacy admin port template */}}
+        {{- if .Values.admin.containerPort }}
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           {{- if .Values.admin.hostPort }}
           hostPort: {{ .Values.admin.hostPort }}
           {{- end}}
           protocol: TCP
+        {{- end }}
+        {{- if .Values.admin.http.enabled }}
+        - name: admin
+          containerPort: {{ .Values.admin.http.containerPort }}
+          {{- if .Values.admin.http.hostPort }}
+          hostPort: {{ .Values.admin.http.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.admin.tls.enabled }}
+        - name: admin-tls
+          containerPort: {{ .Values.admin.tls.containerPort }}
+          {{- if .Values.admin.tls.hostPort }}
+          hostPort: {{ .Values.admin.tls.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
         {{- if .Values.proxy.http.enabled }}
         - name: proxy
           containerPort: {{ .Values.proxy.http.containerPort }}

--- a/charts/kong/templates/ingress-admin.yaml
+++ b/charts/kong/templates/ingress-admin.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.admin.ingress.enabled -}}
+{{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := .Values.admin.servicePort -}}
 {{- $path := .Values.admin.ingress.path -}}
@@ -29,4 +30,36 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- else -}} {{/* Modern admin handler */}}
+{{- $serviceName := include "kong.fullname" . -}}
+{{- $servicePort := include "kong.ingress.servicePort" .Values.admin -}}
+{{- $path := .Values.admin.ingress.path -}}
+{{- $tls := .Values.admin.ingress.tls -}}
+{{- $hostname := .Values.admin.ingress.hostname -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "kong.fullname" . }}-admin
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.admin.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  - host: {{ $hostname }}
+    http:
+      paths:
+        - path: {{ $path }}
+          backend:
+            serviceName: {{ $serviceName }}-admin
+            servicePort: {{ $servicePort }}
+  {{- if $tls }}
+  tls:
+  - hosts:
+    - {{ $hostname }}
+    secretName: {{ $tls }}
+  {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.admin.enabled -}}
+{{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,4 +33,54 @@ spec:
     protocol: TCP
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- else -}} {{/* Modern admin handler */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-admin
+  annotations:
+    {{- range $key, $value := .Values.admin.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.admin.type }}
+  {{- if eq .Values.admin.type "LoadBalancer" }}
+  {{- if .Values.admin.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.admin.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.admin.loadBalancerSourceRanges }}
+  - {{ $cidr }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  externalIPs:
+  {{- range $ip := .Values.admin.externalIPs }}
+  - {{ $ip }}
+  {{- end }}
+  ports:
+  {{- if .Values.admin.http.enabled }}
+  - name: kong-admin
+    port: {{ .Values.admin.http.servicePort }}
+    targetPort: {{ .Values.admin.http.containerPort }}
+  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.http.nodePort))) }}
+    nodePort: {{ .Values.admin.http.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  {{- if or .Values.admin.tls.enabled }}
+  - name: kong-admin-tls
+    port: {{ .Values.admin.tls.servicePort }}
+    targetPort: {{ .Values.admin.tls.containerPort }}
+  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.tls.nodePort))) }}
+    nodePort: {{ .Values.admin.tls.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  selector:
+    {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -46,8 +46,9 @@ image:
   #   - myRegistrKeySecretName
 
 # Specify Kong admin service configuration
-# Note: It is recommended to not use the Admin API to configure Kong
-# when using Kong as an Ingress Controller.
+# Enabling this service exposes the admin API to other pods. It is disabled by default, as
+# the ingress controller (also enabled by default) runs within the same pod.
+# If you disable the ingress controller, you will typically enable this service.
 admin:
   enabled: false
   # If you want to specify annotations for the admin service, uncomment the following
@@ -55,15 +56,23 @@ admin:
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # HTTPS traffic on the admin port
-  # if set to false also set readinessProbe and livenessProbe httpGet scheme's to 'HTTP'
-  useTLS: true
-  servicePort: 8444
-  containerPort: 8444
-  # Kong admin service type
+  http:
+    enabled: false
+    servicePort: 8001
+    containerPort: 8001
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32081
+
+  # Enable HTTPS for the admin API
+  tls:
+    enabled: true
+    servicePort: 8444
+    containerPort: 8444
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32444
+
   type: NodePort
-  # Set a nodePort which is available
-  # nodePort: 32444
+
   # Kong admin ingress settings. Useful if you want to expose the Admin
   # API of Kong outside the k8s cluster.
   ingress:


### PR DESCRIPTION
#### What this PR does / why we need it:

This change reworks and consolidate listener configuration:
* Replace separate per-service listener templates with a single context-based template.
* Update admin API listener handling to support the new unified template, and update its values.yaml block accordingly. The legacy single-stack admin API listener configuration is still supported, but generates a deprecation warning in NOTES.txt if found.
* Move Enterprise listener-related variables under Enterprise block in kong.env template.
* Remove checks for user-provided listener configuration around auto-generated listener configuration. This is now handled automatically for all environment variables. Remove related documentation from README, as user-provided listener overrides should be rare.
* Remove some obsolete documentation regarding the old special-case listener overrides. These are now handled by general-purpose variable overrides, and shouldn't be common enough to need documentation.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/mychartname]`)
