### PR TITLE
kong: Refactor to support mount multiple plugin dir

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -180,11 +180,21 @@ The name of the service used for the ingress controller's validation webhook
 - name: kong-plugin-{{ .pluginName }}
   configMap:
     name: {{ .name }}
+{{- range .subdirectories }}
+- name: {{ .name }}
+  configMap:
+    name: {{ .name }}
+{{- end }}
 {{- end }}
 {{- range .Values.plugins.secrets }}
 - name: kong-plugin-{{ .pluginName }}
   secret:
     secretName: {{ .name }}
+{{- range .subdirectories }}
+- name: {{ .name }}
+  secret:
+    secretName: {{ .name }}
+{{- end }}
 {{- end }}
 - name: custom-nginx-template-volume
   configMap:
@@ -226,14 +236,26 @@ The name of the service used for the ingress controller's validation webhook
   mountPath: /etc/secrets/{{ . }}
 {{- end }}
 {{- range .Values.plugins.configMaps }}
+{{- $mountPath := printf "/opt/kong/plugins/%s" .pluginName }}
 - name:  kong-plugin-{{ .pluginName }}
-  mountPath: /opt/kong/plugins/{{ .pluginName }}
+  mountPath: {{ $mountPath }}
+  readOnly: true
+{{- range .subdirectories }}
+- name: {{ .name }}
+  mountPath: {{ printf "%s/%s" $mountPath .path }}
   readOnly: true
 {{- end }}
+{{- end }}
 {{- range .Values.plugins.secrets }}
+{{- $mountPath := printf "/opt/kong/plugins/%s" .pluginName }}
 - name:  kong-plugin-{{ .pluginName }}
-  mountPath: /opt/kong/plugins/{{ .pluginName }}
+  mountPath: {{ $mountPath }}
   readOnly: true
+{{- range .subdirectories }}
+- name: {{ .name }}
+  mountPath: {{ printf "%s/%s" $mountPath .path }}
+  readOnly: true
+{{- end }}
 {{- end }}
 {{- end -}}
 
@@ -245,7 +267,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- range .Values.plugins.secrets -}}
   {{ $myList = append $myList .pluginName -}}
 {{- end }}
-{{- $myList | join "," -}}
+{{- $myList | uniq | join "," -}}
 {{- end -}}
 
 {{- define "kong.wait-for-db" -}}
@@ -336,7 +358,7 @@ the template that it itself is using form the above sections.
 */}}
 {{- $autoEnv := dict -}}
 
-{{- $_ := set $autoEnv "KONG_LUA_PACKAGE_PATH" "/opt/?.lua;;" -}}
+{{- $_ := set $autoEnv "KONG_LUA_PACKAGE_PATH" "/opt/?.lua;/opt/?/init.lua;;" -}}
 
 {{- if .Values.admin.useTLS }}
   {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "0.0.0.0:%d ssl" (int64 .Values.admin.containerPort)) -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -241,8 +241,8 @@ The name of the service used for the ingress controller's validation webhook
   mountPath: {{ $mountPath }}
   readOnly: true
 {{- range .subdirectories }}
-- name: {{ .name }}
-  mountPath: {{ printf "%s/%s" $mountPath .path }}
+- name: {{ .name  }}
+  mountPath: {{ printf "%s/%s" $mountPath ( .path | default .name ) }}
   readOnly: true
 {{- end }}
 {{- end }}
@@ -267,7 +267,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- range .Values.plugins.secrets -}}
   {{ $myList = append $myList .pluginName -}}
 {{- end }}
-{{- $myList | uniq | join "," -}}
+{{- $myList | join "," -}}
 {{- end -}}
 
 {{- define "kong.wait-for-db" -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -134,11 +134,16 @@ proxy:
 # namespace as Kong is being installed.
 # The `name` property refers to the name of the ConfigMap or Secret
 # itself, while the pluginName refers to the name of the plugin as it appears
+# Sub dicrectories are also supported, the example below show how they can be
+# mounted.
 # in Kong.
 plugins: {}
   # configMaps:
   # - pluginName: rewriter
   #   name: kong-plugin-rewriter
+  #   subdirectories:
+  #   - name: kong-plugin-rewriter-migrations
+  #     path: migrations # Under the path /opt/kong/rewriter/
   # secrets:
   # - pluginName: rewriter
   #   name: kong-plugin-rewriter

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -135,9 +135,9 @@ proxy:
 # The `name` property refers to the name of the ConfigMap or Secret
 # itself, while the pluginName refers to the name of the plugin as it appears
 # in Kong.
-# Subdirectories require separate ConfigMaps/Secrets. "path" indicates their
-# directory under the main plugin directory: the example below will mount the
-# contents of kong-plugin-rewriter-migrations at "/opt/kong/rewriter/migrations".
+# Subdirectories (which are optional) require separate ConfigMaps/Secrets.
+# "path" indicates their directory under the main plugin directory: the example
+# below will mount the contents of kong-plugin-rewriter-migrations at "/opt/kong/rewriter/migrations".
 plugins: {}
   # configMaps:
   # - pluginName: rewriter

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -134,16 +134,17 @@ proxy:
 # namespace as Kong is being installed.
 # The `name` property refers to the name of the ConfigMap or Secret
 # itself, while the pluginName refers to the name of the plugin as it appears
-# Sub dicrectories are also supported, the example below show how they can be
-# mounted.
 # in Kong.
+# Subdirectories require separate ConfigMaps/Secrets. "path" indicates their
+# directory under the main plugin directory: the example below will mount the
+# contents of kong-plugin-rewriter-migrations at "/opt/kong/rewriter/migrations".
 plugins: {}
   # configMaps:
   # - pluginName: rewriter
   #   name: kong-plugin-rewriter
   #   subdirectories:
   #   - name: kong-plugin-rewriter-migrations
-  #     path: migrations # Under the path /opt/kong/rewriter/
+  #     path: migrations
   # secrets:
   # - pluginName: rewriter
   #   name: kong-plugin-rewriter


### PR DESCRIPTION
Commit is as a result of discussion in PR #13

Add functionality that allows mounting additional directories for plugins. The
commit allow includes functionality ability to mount library volumes (either
configmaps or secrets).

Since this is a breaking change, I've also written a simple Python script to migrate from old syntax to new. -> https://gist.github.com/yasn77/ea8cdb6900443ce93b24a1cd731e0991
