### PR TITLE
[kong] Add warning regarding punctuation in secretVolume names

### DIFF
--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 1.1.1
+version: 1.1.2
 appVersion: 1.4

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 1.1.2
+version: 1.1.1
 appVersion: 1.4

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -143,7 +143,9 @@ plugins: {}
   # - pluginName: rewriter
   #   name: kong-plugin-rewriter
 # Inject specified secrets as a volume in Kong Container at path /etc/secrets/{secret-name}/
-# This can be used to override default SSL certificates
+# This can be used to override default SSL certificates.
+# Be aware that the secret name will be used verbatim, and that certain types
+# of punctuation (e.g. `.`) can cause issues.
 # Example configuration
 # secretVolumes:
 # - kong-proxy-tls


### PR DESCRIPTION
Using certain punctuation in these secret names can cause issues in
deploying the chart, since the name is used verbatim when creating the
corresponding directory. An alternative could be to add something like
a `| replace "." "-"` to the `_helper.tpl` file, but I don't exactly
know how.

Adds information relating to, and thus closing #16.