### PR TITLE
Create CI configuration for "next" branch

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,7 +16,7 @@ jobs:
         id: lint
         uses: helm/chart-testing-action@v1.0.0-alpha.3
         with:
-          command: lint
+          command: lint --config=ct-master.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-alpha.3
@@ -27,4 +27,4 @@ jobs:
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0-alpha.3
         with:
-          command: install
+          command: install --config=ct-master.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -15,8 +15,6 @@ jobs:
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@v1.0.0-alpha.3
-        env:
-          CT_CHECK_VERSION_INCREMENT: "false"
         with:
           command: lint
 

--- a/.github/workflows/next-lint-test.yaml
+++ b/.github/workflows/next-lint-test.yaml
@@ -1,0 +1,30 @@
+name: Lint and Test Charts
+
+on:
+  pull_request:
+    branches:
+      - next
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        with:
+          command: lint --check-version-increment=false
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0-alpha.3
+        with:
+          install_local_path_provisioner: true
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        with:
+          command: install

--- a/.github/workflows/next-lint-test.yaml
+++ b/.github/workflows/next-lint-test.yaml
@@ -16,7 +16,7 @@ jobs:
         id: lint
         uses: helm/chart-testing-action@v1.0.0-alpha.3
         with:
-          command: lint --check-version-increment=false
+          command: lint
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-alpha.3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         env:
           CT_CHECK_VERSION_INCREMENT: "false"
         with:
-          command: lint
+          command: lint --config=ct-master.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-alpha.3
@@ -29,7 +29,7 @@ jobs:
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0-alpha.3
         with:
-          command: install
+          command: install --config=ct-master.yaml
   release:
     needs: lint-test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,6 @@ jobs:
       - name: Run chart-testing (lint)
         id: lint
         uses: helm/chart-testing-action@v1.0.0-alpha.3
-        env:
-          CT_CHECK_VERSION_INCREMENT: "false"
         with:
           command: lint --config=ct-master.yaml
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+Welcome to the Kong/charts repo! We're currently in the process of writing a more detailed CONTRIBUTING guide.
+
+In lieu of a complete guide, please base your pull requests off the `next` branch and do not increment your chart's version number as part of your changes. The repo maintainers will bundle changes together periodically and bump the version when merging changes from `next` into `master`.

--- a/ct-master.yaml
+++ b/ct-master.yaml
@@ -4,4 +4,4 @@ chart-dirs:
   - charts
 chart-repos: []
 helm-extra-args: --timeout 200
-check-version-increment: false
+check-version-increment: true


### PR DESCRIPTION
Creates a workflow for checking PRs to the `next` branch that skips the version increment check in `ct lint`. Remove the existing configuration we added to `master`, which should be kept as-is.

Tested locally to confirm desired effect: https://gist.github.com/rainest/95149d16e4f683d282a4777e68278ec7