### PR TITLE
[kong] add hook to init migrations job

### DIFF
--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -30,3 +30,42 @@ If you do, then please delete the release, delete the volume, and then
 do a fresh installation. PersistentVolumes can remain in the cluster even if
 you delete the namespace itself (the namespace in which they were present).
 
+#### Upgrading a release fails due to missing ServiceAccount
+
+When upgrading a release, some configuration changes result in this error:
+
+```
+Error creating: pods "releasename-kong-pre-upgrade-migrations-" is forbidden: error looking up service account releasename-kong: serviceaccount "releasename-kong" not found
+```
+
+Enabling the ingress controller or PodSecurityPolicy requires that the Kong
+chart also create a ServiceAccount. When upgrading from a configuration that
+previously had neither of these features enabled, the pre-upgrade-migrations
+Job attempts to use this ServiceAccount before it is created. It is [not
+possible to easily handle this case automatically](https://github.com/Kong/charts/pull/31).
+
+Users encountering this issue should temporarily modify their
+[pre-upgrade-migrations template](https://github.com/Kong/charts/blob/master/charts/kong/templates/migrations-pre-upgrade.yaml),
+adding the following at the bottom:
+
+```
+{{ if or .Values.podSecurityPolicy.enabled (and .Values.ingressController.enabled .Values.ingressController.serviceAccount.create) -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kong.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+{{- end -}}
+```
+
+Upgrading with this in place will create a temporary service account before
+creating the actual service account. After this initial upgrade, users must
+revert to the original pre-upgrade migrations template, as leaving the
+temporary ServiceAccount template in place will [cause permissions issues on
+subsequent upgrades](https://github.com/Kong/charts/issues/30).

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -466,6 +466,13 @@ value is your SMTP password.
 
 ## Changelog
 
+### UNRELEASED
+
+#### Improvements
+
+* Handle initial migrations using an auto-deleted hook. This prevents old
+  migrations jobs from interfering with upgrades.
+
 ### 1.1.1
 
 #### Fixed

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -253,6 +253,8 @@ section of `values.yaml` file:
 | image.tag                          | Version of the ingress controller                                                     | 0.7.0                                                                        |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
+| serviceAccount.create              | Create Service Account for ingress controller                                         | true
+| serviceAccount.name                | Use existing Service Account, specifiy its name                                       | ""
 | installCRDs                        | Create CRDs. Regardless of value of this, Helm v3+ will install the CRDs if those are not present already. Use `--skip-crds` with `helm install` if you want to skip CRD creation. | true |
 | env                                | Specify Kong Ingress Controller configuration via environment variables               |                                                                              |
 | ingressClass                       | The ingress-class value for controller                                                | kong                                                                         |
@@ -497,7 +499,7 @@ value is your SMTP password.
 
 ### 1.0.2
 
-- Helm 3 support: CRDs are declared in crds directory. Backward compatible support for helm 2. 
+- Helm 3 support: CRDs are declared in crds directory. Backward compatible support for helm 2.
 
 ### 1.0.1
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -464,7 +464,7 @@ the template that it itself is using form the above sections.
 
 {{- $completeEnv := mergeOverwrite $autoEnv $userEnv -}}
 
-{{- range keys $completeEnv }}
+{{- range keys $completeEnv | sortAlpha }}
 {{- $val := pluck . $completeEnv | first -}}
 {{- $valueType := printf "%T" $val -}}
 {{ if eq $valueType "map[string]interface {}" }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -439,6 +439,8 @@ the template that it itself is using form the above sections.
   {{- $_ := set $autoEnv "KONG_PG_PORT" .Values.postgresql.service.port -}}
   {{- $pgPassword := include "secretkeyref" (dict "name" (include "kong.postgresql.fullname" .) "key" "postgresql-password") -}}
   {{- $_ := set $autoEnv "KONG_PG_PASSWORD" $pgPassword -}}
+{{- else if eq .Values.env.database "postgres" }}
+  {{- $_ := set $autoEnv "KONG_PG_PORT" "5432" }}
 {{- end }}
 
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
@@ -492,5 +494,5 @@ the template that it itself is using form the above sections.
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:
   {{- include "kong.no_daemon_env" . | nindent 2 }}
-  command: [ "/bin/sh", "-c", "until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo 'waiting for db'; sleep 1; done" ]
+  command: [ "/bin/sh", "-c", "set -u; until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo \"waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}\"; sleep 1; done" ]
 {{- end -}}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -47,17 +47,3 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
 {{- end }}
-
-{{ if or .Values.podSecurityPolicy.enabled (and .Values.ingressController.enabled .Values.ingressController.serviceAccount.create) -}}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "kong.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-{{- end -}}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
+  annotations:
+    helm.sh/hook: "post-install"
+    helm.sh/hook-delete-policy: "hook-succeeded"
 spec:
   template:
     metadata:


### PR DESCRIPTION
**What this PR does / why we need it:**

Control the lifecycle of init-migrations jobs with a hook. The job is created after resources are created (namely, after Postgres is created if its subchart is enabled), runs, and is deleted if it succeeds. Install flow should proceed normally after. The job is no longer created during upgrades.

**Which issue this PR fixes**

I thought there was an issue filed for this somewhere, but could not find it. It may have been lost in the depths of the helm/charts repo. See previous discussion in https://github.com/Kong/charts/pull/29#pullrequestreview-351858753

Not deleting the job automatically and creating it for upgrades also allows it to conflict with previous versions of itself, resulting in a very unintuitive error and requiring that users know they need to delete it manually.