### PR TITLE
Fix NOTES indentation

### DIFF
--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: harry@konghq.com
 name: kong
 sources:
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.4

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -1,13 +1,11 @@
-To connect to Kong, please execute the following command
-
-
-{{- if contains "LoadBalancer" .Values.proxy.type }}
-  HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].port}')
-{{- else if contains "NodePort" .Values.proxy.type -}}
-  HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
-  PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
-{{- end -}}
+To connect to Kong, please execute the following commands:
+{{ if contains "LoadBalancer" .Values.proxy.type }}
+HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].port}')
+{{ else if contains "NodePort" .Values.proxy.type }}
+HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+{{ end -}}
 export PROXY_IP=${HOST}:${PORT}
 curl $PROXY_IP
 


### PR DESCRIPTION
Previously, the installation notes (NOTES.txt) had inconsistent indentation making it hard to read sometimes. This commit fixes that.

I also chose to remove the proceeding whitespaces so that the commands are easier to select with the mouse in order to copy-paste them.

**Before:**
![Before](https://user-images.githubusercontent.com/7773090/74147799-45a14b00-4c04-11ea-9e6c-278de408a971.png)
**After**
![After](https://user-images.githubusercontent.com/7773090/74147798-44701e00-4c04-11ea-8537-af2c412b8ebd.png)
