### PR TITLE
[repo] add contributing guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,6 @@ when it is merged.
 
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
-- [ ] PR is based off the current tip of the `next` branch
+- [ ] PR is based off the current tip of the `next` branch and targets `next`, not `master`
 - [ ] New or modified sections of values.yaml are documented in the README.md
 - [ ] Title of the PR and commit headers start with chart name (e.g. `[kong]`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+<!--
+Thank you for contributing to Kong/charts. Please read through our contribution
+guidelines to understand our review process: https://github.com/Kong/charts/blob/master/CONTRIBUTING.md
+
+When updates to your PR are requested, please add new commits and do not squash the
+history. This will make it easier to identify new changes. The PR will be squashed
+when it is merged.
+-->
+
+#### What this PR does / why we need it:
+
+#### Which issue this PR fixes
+*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
+  - fixes #
+
+#### Special notes for your reviewer:
+
+#### Checklist
+[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
+- [ ] PR is based off the current tip of the `next` branch
+- [ ] New or modified sections of values.yaml are documented in the README.md
+- [ ] Title of the PR and commit headers start with chart name (e.g. `[kong]`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ Before submitting a pull request, please run through the following steps:
 - Rebase your branch off the current tip of the `next` branch.
 - Run `helm lint` and correct any issues it finds.
 - If your change adds new user-facing (exposed in values.yaml) features or
-  changes existing features, update README.md accordingly.
+  changes existing features, update README.md accordingly. Documentation should
+  adhere to the [Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/).
 
 All contributors must sign our Community License Agreement. If you have not yet
 signed it, we will add a comment asking you to do so.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,9 @@
 # Contributing to Kong Helm charts
 
 Feel free to contribute fixes or minor features, we love to receive pull
-requests! If you are planning to develop a larger feature, please come talk to
-us first. We can be found in the [#kong
-channel](https://kubernetes.slack.com/archives/CDCA87FRD) on the Kubernetes
-community Slack instance or the [Kubernetes
-forum](https://discuss.konghq.com/c/kubernetes/19) on Kong Nation.
+requests! If you are planning to develop a larger feature, please submit a
+GitHub issue describing your proposal first, to discuss it with the chart
+maintainers.
 
 ## Submitting a pull request
 The Kong charts repository accepts contributions via GitHub pull requests to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,69 @@
-Welcome to the Kong/charts repo! We're currently in the process of writing a more detailed CONTRIBUTING guide.
+# Contributing to Kong Helm charts
 
-In lieu of a complete guide, please base your pull requests off the `next` branch and do not increment your chart's version number as part of your changes. The repo maintainers will bundle changes together periodically and bump the version when merging changes from `next` into `master`.
+Feel free to contribute fixes or minor features, we love to receive pull
+requests! If you are planning to develop a larger feature, please come talk to
+us first. We can be found in the [#kong
+channel](https://kubernetes.slack.com/archives/CDCA87FRD) on the Kubernetes
+community Slack instance or the [Kubernetes
+forum](https://discuss.konghq.com/c/kubernetes/19) on Kong Nation.
+
+## Submitting a pull request
+The Kong charts repository accepts contributions via GitHub pull requests to
+the `next` branch.
+
+### Preparing a pull request
+
+Before submitting a pull request, please run through the following steps:
+- Rebase your branch off the current tip of the `next` branch.
+- Run `helm lint` and correct any issues it finds.
+- If your change adds new user-facing (exposed in values.yaml) features or
+  changes existing features, update README.md accordingly.
+
+All contributors must sign our Community License Agreement. If you have not yet
+signed it, we will add a comment asking you to do so.
+
+### Review process
+
+Changes to Kong charts undergo automatic and manual review. When you create a
+pull request, CI will run automated tests against a standard set of values.yaml
+configurations. If any fail, you will receive an email alert with details of
+the failure.
+
+If changes are requested or tests find an issue with your changes, please
+add separate fix commits on top of your initial pull request. Do not squash
+changes; the maintainers will squash as needed when merging the pull request.
+
+### Accepted pull requests
+
+Accepted pull requests are merged into the `next` branch and are not typically
+released immediately. The chart maintainers periodically bundle all changes in
+`next` together and merge them into `master` with a version bump to create a
+release.
+
+## Commit message format
+
+To maintain a healthy Git history, we ask of you that you write your commit
+messages as follows:
+
+- The commit header is in present tense.
+- The header indicates its chart, e.g. `[kong] made a cool change`.
+- The header and body are separated by a blank line.
+- The header should not be longer than 50 characters.
+- The body of your message should not contain lines longer than 72 characters.
+
+### Header
+
+Your commit header/subject should contain a succinct description of the change.
+It should be written so that:
+
+- It uses the present, imperative tense: "fix typo", and not "fixed" or "fixes"
+- It is **not** capitalized: "fix typo", and not "Fix typo"
+- It does **not** include a period. :smile:
+
+### Body
+
+The body of your commit message should contain a detailed description of your
+changes. Ideally, if the change is significant, you should explain its
+motivation, the chosen implementation, and justify it.
+
+Lines in the commit messages should not exceed 72 characters.


### PR DESCRIPTION
Add contributing guides outlining the pull request process and
requirements.

Add a condensed set of guidelines in a pull request template.