### PR TITLE
fix(nodePort) chart respects LoadBalancer NodePort

### DIFF
--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -30,7 +30,7 @@ spec:
   - name: kong-proxy
     port: {{ .Values.proxy.http.servicePort }}
     targetPort: {{ .Values.proxy.http.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.http.nodePort))) }}
+  {{- if (and (or (eq .Values.proxy.type "LoadBalancer") (eq .Values.proxy.type "NodePort")) (not (empty .Values.proxy.http.nodePort))) }}
     nodePort: {{ .Values.proxy.http.nodePort }}
   {{- end }}
     protocol: TCP
@@ -39,7 +39,7 @@ spec:
   - name: kong-proxy-tls
     port: {{ .Values.proxy.tls.servicePort }}
     targetPort: {{ .Values.proxy.tls.overrideServiceTargetPort | default .Values.proxy.tls.containerPort }}
-  {{- if (and (eq .Values.proxy.type "NodePort") (not (empty .Values.proxy.tls.nodePort))) }}
+  {{- if (and (or (eq .Values.proxy.type "LoadBalancer") (eq .Values.proxy.type "NodePort")) (not (empty .Values.proxy.tls.nodePort))) }}
     nodePort: {{ .Values.proxy.tls.nodePort }}
   {{- end }}
     protocol: TCP


### PR DESCRIPTION
# What

This PR introduces ability to specify a custom `nodePort` in values
passed to `helm`. Before, the chart would only respect the `nodePort`
value if `proxy.type` was set to `NodePort`. Now it also respects
`nodePort` for default `proxy.type` of `LoadBalancer`.

# Testing

Deployed and verified working with https://bit.ly/echo-service