### PR TITLE
crd install hook

### DIFF
--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kongconsumers.configuration.konghq.com
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: configuration.konghq.com
   version: v1
@@ -36,6 +38,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kongcredentials.configuration.konghq.com
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: configuration.konghq.com
   version: v1
@@ -71,6 +75,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kongplugins.configuration.konghq.com
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: configuration.konghq.com
   version: v1
@@ -132,6 +138,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kongingresses.configuration.konghq.com
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: configuration.konghq.com
   version: v1


### PR DESCRIPTION
Make the crds `crd-install` hook. 
This will hopefully go the next step in providing helm 2 and helm 3 support seamlessly. The crd-install hook is ignored (AFAIK) in helm 3 so the crds wont be installed a second time in helm 3. 

(If this works as designed, not sure we need the same warning as presented in: https://github.com/Kong/charts/pull/34)