### PR TITLE
autoscaling variable typo fix in hpa.yaml

### DIFF
--- a/charts/kong/templates/hpa.yaml
+++ b/charts/kong/templates/hpa.yaml
@@ -13,7 +13,7 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   {{- if not (.Capabilities.APIVersions.Has "autoscaling/v2beta2") }}
-  targetCPUUtilizationPercentage: {{ .Values.autscaling.targetCPUUtilizationPercentage | default 80 }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage | default 80 }}
   {{- else }}
   metrics:
     {{- toYaml .Values.autoscaling.metrics | nindent 4 }}


### PR DESCRIPTION
This PR will fix the following error when HPA is enabled:
`Error: render error in "kong/templates/hpa.yaml": template: kong/templates/hpa.yaml:16:44: executing "kong/templates/hpa.yaml" at <.Values.autscaling.targetCPUUtilizationPercentage>: nil pointer evaluating interface {}.targetCPUUtilizationPercentage`