### PR TITLE
Remove resuseport from proxy listen

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -58,13 +58,13 @@ Create the KONG_PROXY_LISTEN value string
 {{- define "kong.kongProxyListenValue" -}}
 
 {{- if and .Values.proxy.http.enabled .Values.proxy.tls.enabled -}}
-   0.0.0.0:{{ .Values.proxy.http.containerPort }} reuseport,0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl http2 reuseport
+   0.0.0.0:{{ .Values.proxy.http.containerPort }},0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl http2
 {{- else -}}
 {{- if .Values.proxy.http.enabled -}}
-   0.0.0.0:{{ .Values.proxy.http.containerPort }} reuseport
+   0.0.0.0:{{ .Values.proxy.http.containerPort }}
 {{- end -}}
 {{- if .Values.proxy.tls.enabled -}}
-   0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl http2 reuseport
+   0.0.0.0:{{ .Values.proxy.tls.containerPort }} ssl http2
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

I should have been more diligent when checking legacy support in #47. Turns out there's a lot of stuff still common in the wild (everything <1.3.0) that still doesn't support `resuseport` in listens.

The good news is that `next` is working as intended to catch this sort of thing before release!

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)

