### PR TITLE
Remove dedicated Portal auth configuration from values.yaml

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -471,9 +471,9 @@ secret/kong-session-config created
 The exact plugin settings may vary in your environment. The `secret` should
 always be changed for both configurations.
 
-After creating your secret, set its name in values.yaml, in the
-`.enterprise.rbac.session_conf_secret` and optionally in
-`env.portal_session_conf` using a secretKeyRef.
+After creating your secret, set its name in values.yaml in
+`.enterprise.rbac.session_conf_secret`. If you create a Portal configuration,
+add it at `env.portal_session_conf` using a secretKeyRef.
 
 ### Email/SMTP
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -452,9 +452,13 @@ accessible outside the Pod.
 
 Login sessions for Kong Manager and the Developer Portal make use of
 [the Kong Sessions plugin](https://docs.konghq.com/enterprise/latest/kong-manager/authentication/sessions).
-Their configuration must be stored in Secrets, as it contains an HMAC key.
-If using either RBAC or the Portal, create a Secret with `admin_gui_session_conf`
-and `portal_session_conf` keys.
+When configured via values.yaml, their configuration must be stored in Secrets,
+as it contains an HMAC key.
+
+Kong Manager's session configuration must be configured via values.yaml,
+whereas this is optional for the Developer Portal on versions 0.36+. Providing
+Portal session configuration in values.yaml provides the default session
+configuration, which can be overriden on a per-workspace basis.
 
 ```
 $ cat admin_gui_session_conf
@@ -468,8 +472,8 @@ The exact plugin settings may vary in your environment. The `secret` should
 always be changed for both configurations.
 
 After creating your secret, set its name in values.yaml, in the
-`.enterprise.rbac.session_conf_secret` and
-`.enterprise.portal.session_conf_secret` keys.
+`.enterprise.rbac.session_conf_secret` and optionally in
+`env.portal_session_conf` using a secretKeyRef.
 
 ### Email/SMTP
 

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -16,8 +16,6 @@ https://bit.ly/k4k8s-get-started
 {{ if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}} {{/* Legacy Portal auth handling */}}
 /!\ WARNING: You are currently using legacy Portal authentication configuration in values.yaml (https://github.com/Kong/charts/blob/kong-1.2.0/charts/kong/values.yaml#L384-L392). Support for this will be removed in a future release.
 
-You should typically remove these settings entirely, as both are configured per-workspace, and the values here only provide defaults. If you wish to configure them, you should set them under the Values.env block.
-
-Enterprise 0.35 users MUST add portal_session_conf to their Values.env using a secretKeyRef, as 0.35 does not support per-workspace session configuration.
+You should move these settings to "portal_session_conf" (using a secretKeyRef) and "portal_auth" under your "env" block.
 {{- end -}}
 

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -1,16 +1,23 @@
-To connect to Kong, please execute the following command
+To connect to Kong, please execute the following commands:
 
-
-{{- if contains "LoadBalancer" .Values.proxy.type }}
-  HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].port}')
+{{ if contains "LoadBalancer" .Values.proxy.type }}
+HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].port}')
 {{- else if contains "NodePort" .Values.proxy.type -}}
-  HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
-  PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
+HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
 {{- end -}}
 export PROXY_IP=${HOST}:${PORT}
 curl $PROXY_IP
 
 Once installed, please follow along the getting started guide to start using Kong:
 https://bit.ly/k4k8s-get-started
+
+{{ if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}} {{/* Legacy Portal auth handling */}}
+/!\ WARNING: You are currently using legacy Portal authentication configuration in values.yaml (https://github.com/Kong/charts/blob/kong-1.2.0/charts/kong/values.yaml#L384-L392). Support for this will be removed in a future release.
+
+You should typically remove these settings entirely, as both are configured per-workspace, and the values here only provide defaults. If you wish to configure them, you should set them under the Values.env block.
+
+Enterprise 0.35 users MUST add portal_session_conf to their Values.env using a secretKeyRef, as 0.35 does not support per-workspace session configuration.
+{{- end -}}
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -410,7 +410,7 @@ the template that it itself is using form the above sections.
 
   {{- if .Values.enterprise.portal.enabled }}
     {{- $_ := set $autoEnv "KONG_PORTAL" "on" -}}
-    {{- if .Values.enterprise.portal.portal_auth }}
+    {{- if .Values.enterprise.portal.portal_auth }} {{/* TODO: deprecated, remove in a future version */}}
       {{- $_ := set $autoEnv "KONG_PORTAL_AUTH" .Values.enterprise.portal.portal_auth -}}
       {{- $portalSession := include "secretkeyref" (dict "name" .Values.enterprise.portal.session_conf_secret "key" "portal_session_conf") -}}
       {{- $_ := set $autoEnv "KONG_PORTAL_SESSION_CONF" $portalSession -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -384,21 +384,10 @@ enterprise:
   # This secret must contain a single 'license' key, containing your base64-encoded license data
   # The license secret is required for all Kong Enterprise deployments
   license_secret: you-must-create-a-kong-license-secret
-  # Session configuration secret
-  # The session conf secret is required if using RBAC or the Portal
   vitals:
     enabled: true
   portal:
     enabled: false
-    # portal_auth here sets the default authentication mechanism for the Portal
-    # FIXME This can be changed per-workspace, but must currently default to
-    # basic-auth to work around limitations with session configuration
-    portal_auth: basic-auth
-    # If the Portal is enabled and any workspace's Portal uses authentication,
-    # this Secret must contain an portal_session_conf key
-    # The key value must be a secret configuration, following the example at
-    # https://docs.konghq.com/enterprise/latest/developer-portal/configuration/authentication/sessions
-    session_conf_secret: you-must-create-a-portal-session-conf-secret
   rbac:
     enabled: false
     admin_gui_auth: basic-auth


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove the dedicated Portal auth/session configuration. These are not necessary for most versions, as Kong Enterprise will start fine without them and allows users to set them via a workspace's Portal configuration in Manager.

This change continues support for the existing configuration to maintain compatibility with existing user values.yamls. It places a warning in NOTES.txt to inform users that the configuration is deprecated and should be moved under `env` if they wish to keep it in place.

#### Which issue this PR fixes
Fix #52

#### Special notes for your reviewer:
Unlike other versions, 0.35 does *not* support configuring sessions via Manager: the kong.conf `portal_session_conf` is the only way to set Portal session configuration, and is used by all workspaces. Setting this in `env` or continuing to use the deprecated configuration works for 0.35.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
