### PR TITLE
[kong] bump Kong version to 2.0.2

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -35,7 +35,7 @@ image:
   repository: kong
   # repository: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
   # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: "2.0"
+  tag: 2.0.2
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Since 2.0.2 was released [earlier today](https://github.com/Kong/kong/commit/e82f5300b0618e2583b48ea56a8d15b1860e77f4), figure we may as well bump this to the latest patch release before the new chart version.