### PR TITLE
[kong] update registry secret documentation

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -398,22 +398,30 @@ Kong is going to be deployed.
 #### Kong Enterprise Docker registry access
 
 Next, we need to setup Docker credentials in order to allow Kubernetes
-nodes to pull down Kong Enterprise Docker image, which is hosted as a private
-repository.
+nodes to pull down Kong Enterprise Docker images, which are hosted in a private
+registry.
 
-As part of your sign up for Kong Enterprise, you should have received
-credentials for these as well.
+You should received credentials to log into https://bintray.com/kong after
+purchasing Kong Enterprise. After logging in, you can retrieve your API key
+from \<your username\> \> Edit Profile \> API Key. Use this to create registry
+secrets:
 
 ```bash
-$ kubectl create secret docker-registry kong-enterprise-docker \
+$ kubectl create secret docker-registry kong-enterprise-k8s-docker \
     --docker-server=kong-docker-kong-enterprise-k8s.bintray.io \
-    --docker-username=<your-username> \
-    --docker-password=<your-password>
-secret/kong-enterprise-docker created
+    --docker-username=<your-username@kong> \
+    --docker-password=<your-bintray-api-key>
+secret/kong-enterprise-k8s-docker created
+
+$ kubectl create secret docker-registry kong-enterprise-edition-docker \
+    --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
+    --docker-username=<your-username@kong> \
+    --docker-password=<your-bintray-api-key>
+secret/kong-enterprise-edition-docker created
 ```
 
-Set the secret name in `values.yaml` in the `image.pullSecrets` section.
-Again, Please ensure the above secret is created in the same namespace in which
+Set the secret names in `values.yaml` in the `image.pullSecrets` section.
+Again, please ensure the above secret is created in the same namespace in which
 Kong is going to be deployed.
 
 ### Service location hints

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -409,13 +409,13 @@ secrets:
 ```bash
 $ kubectl create secret docker-registry kong-enterprise-k8s-docker \
     --docker-server=kong-docker-kong-enterprise-k8s.bintray.io \
-    --docker-username=<your-username@kong> \
+    --docker-username=<your-bintray-username@kong> \
     --docker-password=<your-bintray-api-key>
 secret/kong-enterprise-k8s-docker created
 
 $ kubectl create secret docker-registry kong-enterprise-edition-docker \
     --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
-    --docker-username=<your-username@kong> \
+    --docker-username=<your-bintray-username@kong> \
     --docker-password=<your-bintray-api-key>
 secret/kong-enterprise-edition-docker created
 ```


### PR DESCRIPTION
#### What this PR does / why we need it:
* Update the registry secret documentation to add secrets for both kong-enterprise-k8s and kong-enterprise-edition-docker registries. We do include both in values.yaml comments, but it's easy to miss that they're in separate registries (and need separate secrets) rather than different images in the same registry.
* Update examples to clarify the credential type and format.
* Indicate more clearly that users should use their Bintray API key, which may be different from their Bintray password.

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
