### PR TITLE
Fix broken newline chomp in Kong NOTES.txt

### DIFF
--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -6,7 +6,7 @@ PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fu
 {{- else if contains "NodePort" .Values.proxy.type -}}
 HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
 PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
-{{- end -}}
+{{ end -}}
 export PROXY_IP=${HOST}:${PORT}
 curl $PROXY_IP
 


### PR DESCRIPTION
#### What this PR does / why we need it:
I missed part of the fix in #38 earlier :woman_facepalming: 

The original template chomped the newline before `export PROXY_IP=${HOST}:${PORT}`, causing it to render as `PORT=$(kubectl get svc --namespace default skulking-moose-kong-proxy -o jsonpath='{.spec.ports[0].nodePort}')export PROXY_IP=${HOST}:${PORT}`, which doesn't work very well.

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
