### PR TITLE
Release Kong 1.3.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.3.1
+
+### Fixed
+
+* Added missing newline to NOTES.txt template.
+  ([#66](https://github.com/Kong/charts/pull/66)
+
+### Documentation
+
+* Instruct users to create secrets for both the kong-enterprise-k8s and
+  kong-enterprise-edition Docker registries.
+  ([#65](https://github.com/Kong/charts/pull/65)
+* Updated maintainer information.
+
 ## 1.3.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -4,11 +4,11 @@ engine: gotpl
 home: https://konghq.com/
 icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
 maintainers:
-- name: shashiranjan84
-  email: shashi@konghq.com
 - name: hbagdi
   email: harry@konghq.com
+- name: rainest
+  email: traines@konghq.com
 name: kong
 sources:
-version: 1.3.0
+version: 1.3.1
 appVersion: 2.0.0


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases version 1.3.1 of the Kong chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
