### PR TITLE
[kong] Release Kong 1.3.1 to master

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.3.1
+
+### Fixed
+
+* Added missing newline to NOTES.txt template.
+  ([#66](https://github.com/Kong/charts/pull/66)
+
+### Documentation
+
+* Instruct users to create secrets for both the kong-enterprise-k8s and
+  kong-enterprise-edition Docker registries.
+  ([#65](https://github.com/Kong/charts/pull/65)
+* Updated maintainer information.
+
 ## 1.3.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -4,11 +4,11 @@ engine: gotpl
 home: https://konghq.com/
 icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
 maintainers:
-- name: shashiranjan84
-  email: shashi@konghq.com
 - name: hbagdi
   email: harry@konghq.com
+- name: rainest
+  email: traines@konghq.com
 name: kong
 sources:
-version: 1.3.0
+version: 1.3.1
 appVersion: 2.0.0

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -398,22 +398,30 @@ Kong is going to be deployed.
 #### Kong Enterprise Docker registry access
 
 Next, we need to setup Docker credentials in order to allow Kubernetes
-nodes to pull down Kong Enterprise Docker image, which is hosted as a private
-repository.
+nodes to pull down Kong Enterprise Docker images, which are hosted in a private
+registry.
 
-As part of your sign up for Kong Enterprise, you should have received
-credentials for these as well.
+You should received credentials to log into https://bintray.com/kong after
+purchasing Kong Enterprise. After logging in, you can retrieve your API key
+from \<your username\> \> Edit Profile \> API Key. Use this to create registry
+secrets:
 
 ```bash
-$ kubectl create secret docker-registry kong-enterprise-docker \
+$ kubectl create secret docker-registry kong-enterprise-k8s-docker \
     --docker-server=kong-docker-kong-enterprise-k8s.bintray.io \
-    --docker-username=<your-username> \
-    --docker-password=<your-password>
-secret/kong-enterprise-docker created
+    --docker-username=<your-bintray-username@kong> \
+    --docker-password=<your-bintray-api-key>
+secret/kong-enterprise-k8s-docker created
+
+$ kubectl create secret docker-registry kong-enterprise-edition-docker \
+    --docker-server=kong-docker-kong-enterprise-edition-docker.bintray.io \
+    --docker-username=<your-bintray-username@kong> \
+    --docker-password=<your-bintray-api-key>
+secret/kong-enterprise-edition-docker created
 ```
 
-Set the secret name in `values.yaml` in the `image.pullSecrets` section.
-Again, Please ensure the above secret is created in the same namespace in which
+Set the secret names in `values.yaml` in the `image.pullSecrets` section.
+Again, please ensure the above secret is created in the same namespace in which
 Kong is going to be deployed.
 
 ### Service location hints

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -6,7 +6,7 @@ PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fu
 {{- else if contains "NodePort" .Values.proxy.type -}}
 HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
 PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
-{{- end -}}
+{{ end -}}
 export PROXY_IP=${HOST}:${PORT}
 curl $PROXY_IP
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases Kong 1.3.1 to master.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
