### PR TITLE
[kong] Refactor listener templates

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -203,6 +203,12 @@ Kong can be configured via two methods:
 
 ### Kong parameters
 
+The various `SVC.*` parameters below are common to the various Kong services
+(the admin API, proxy, Kong Manger, the Developer Portal, and the Developer
+Portal API) and define their listener configuration, K8S Service properties,
+and K8S Ingress properties. Defaults are listed only if consistent across the
+individual services: see values.yaml for their individual default values.
+
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
@@ -210,54 +216,32 @@ Kong can be configured via two methods:
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count                                                                   | `1`                 |
-| admin.enabled                      | Create admin Service                                                                  | `false`             |
-| admin.http.enabled                 | Enables http on the admin API                                                         | `false`             |
-| admin.http.servicePort             | Service port to use for http                                                          | 8001                |
-| admin.http.containerPort           | Container port to use for http                                                        | 8001                |
-| admin.http.nodePort                | Node port to use for http                                                             |                     |
-| admin.http.hostPort                | Host port to use for http                                                             |                     |
-| admin.http.parameters              | Array of additional listen parameters                                                 | `[]`                |
-| admin.tls.enabled                  | Enables TLS on the admin API                                                          | true                |
-| admin.tls.containerPort            | Container port to use for TLS                                                         | 8443                |
-| admin.tls.servicePort              | Service port to use for TLS                                                           | 8443                |
-| admin.tls.nodePort                 | Node port to use for TLS                                                              |                     |
-| admin.tls.hostPort                 | Host port to use for TLS                                                              |                     |
-| admin.tls.overrideServiceTargetPort| Override service port to use for TLS without touching Kong containerPort              |                     |
-| admin.tls.parameters               | Array of additional listen parameters                                                 | `[]`                |
-| admin.type                         | k8s service type, Options: NodePort, ClusterIP, LoadBalancer                          | `NodePort`          |
-| admin.loadBalancerIP               | Will reuse an existing ingress static IP for the admin service                        | `null`              |
-| admin.loadBalancerSourceRanges     | Limit admin access to CIDRs if set and service type is `LoadBalancer`                 | `[]`                |
-| admin.ingress.enabled              | Enable ingress resource creation (works with proxy.type=ClusterIP)                    | `false`             |
-| admin.ingress.tls                  | Name of secret resource, containing TLS secret                                        |                     |
-| admin.ingress.hosts                | List of ingress hosts.                                                                | `[]`                |
-| admin.ingress.path                 | Ingress path.                                                                         | `/`                 |
-| admin.ingress.annotations          | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
-| proxy.enabled                      | Create proxy Service                                                                  | `true`              |
-| proxy.http.enabled                 | Enables http on the proxy                                                             | true                |
-| proxy.http.servicePort             | Service port to use for http                                                          | 80                  |
-| proxy.http.containerPort           | Container port to use for http                                                        | 8000                |
-| proxy.http.nodePort                | Node port to use for http                                                             |                     |
-| proxy.http.hostPort                | Host port to use for http                                                             |                     |
-| proxy.http.parameters              | Array of additional listen parameters                                                 | `{}`                |
-| proxy.tls.enabled                  | Enables TLS on the proxy                                                              | true                |
-| proxy.tls.containerPort            | Container port to use for TLS                                                         | 8443                |
-| proxy.tls.servicePort              | Service port to use for TLS                                                           | 8443                |
-| proxy.tls.nodePort                 | Node port to use for TLS                                                              |                     |
-| proxy.tls.hostPort                 | Host port to use for TLS                                                              |                     |
-| proxy.tls.overrideServiceTargetPort| Override service port to use for TLS without touching Kong containerPort              |                     |
-| proxy.tls.parameters               | Array of additional listen parameters                                                 | `{}`                |
-| proxy.type                         | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          | `LoadBalancer`      |
-| proxy.clusterIP                    | k8s service clusterIP                                                                 |                     |
-| proxy.loadBalancerSourceRanges     | Limit proxy access to CIDRs if set and service type is `LoadBalancer`                 | `[]`                |
-| proxy.loadBalancerIP               | To reuse an existing ingress static IP for the admin service                          |                     |
-| proxy.externalIPs                  | IPs for which nodes in the cluster will also accept traffic for the proxy             | `[]`                |
-| proxy.externalTrafficPolicy        | k8s service's externalTrafficPolicy. Options: Cluster, Local                          |                     |
-| proxy.ingress.enabled              | Enable ingress resource creation (works with proxy.type=ClusterIP)                    | `false`             |
-| proxy.ingress.tls                  | Name of secret resource, containing TLS secret                                        |                     |
-| proxy.ingress.hosts                | List of ingress hosts.                                                                | `[]`                |
-| proxy.ingress.path                 | Ingress path.                                                                         | `/`                 |
-| proxy.ingress.annotations          | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
-| proxy.annotations                  | Service annotations                                                                   | `{}`                |
+| SVC.enabled                        | Create Service resource for SVC (admin, proxy, manager, etc.)                         |                     |
+| SVC.http.enabled                   | Enables http on the service                                                           |                     |
+| SVC.http.servicePort               | Service port to use for http                                                          |                     |
+| SVC.http.containerPort             | Container port to use for http                                                        |                     |
+| SVC.http.nodePort                  | Node port to use for http                                                             |                     |
+| SVC.http.hostPort                  | Host port to use for http                                                             |                     |
+| SVC.http.parameters                | Array of additional listen parameters                                                 | `[]`                |
+| SVC.tls.enabled                    | Enables TLS on the service                                                            |                     |
+| SVC.tls.containerPort              | Container port to use for TLS                                                         |                     |
+| SVC.tls.servicePort                | Service port to use for TLS                                                           |                     |
+| SVC.tls.nodePort                   | Node port to use for TLS                                                              |                     |
+| SVC.tls.hostPort                   | Host port to use for TLS                                                              |                     |
+| SVC.tls.overrideServiceTargetPort  | Override service port to use for TLS without touching Kong containerPort              |                     |
+| SVC.tls.parameters                 | Array of additional listen parameters                                                 | `["http2"]`         |
+| SVC.type                           | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          |                     |
+| SVC.clusterIP                      | k8s service clusterIP                                                                 |                     |
+| SVC.loadBalancerSourceRanges       | Limit service access to CIDRs if set and service type is `LoadBalancer`               | `[]`                |
+| SVC.loadBalancerIP                 | Reuse an existing ingress static IP for the service                                   |                     |
+| SVC.externalIPs                    | IPs for which nodes in the cluster will also accept traffic for the servic            | `[]`                |
+| SVC.externalTrafficPolicy          | k8s service's externalTrafficPolicy. Options: Cluster, Local                          |                     |
+| SVC.ingress.enabled                | Enable ingress resource creation (works with SVC.type=ClusterIP)                      | `false`             |
+| SVC.ingress.tls                    | Name of secret resource, containing TLS secret                                        |                     |
+| SVC.ingress.hosts                  | List of ingress hosts.                                                                | `[]`                |
+| SVC.ingress.path                   | Ingress path.                                                                         | `/`                 |
+| SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
+| SVC.annotations                    | Service annotations                                                                   | `{}`                |
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | runMigrations                      | Run Kong migrations job                                                               | `true`              |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -210,12 +210,20 @@ Kong can be configured via two methods:
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count                                                                   | `1`                 |
-| admin.enabled                      | Create Admin Service                                                                  | `false`             |
-| admin.useTLS                       | Secure Admin traffic                                                                  | `true`              |
-| admin.servicePort                  | TCP port on which the Kong admin service is exposed                                   | `8444`              |
-| admin.containerPort                | TCP port on which Kong app listens for admin traffic                                  | `8444`              |
-| admin.nodePort                     | Node port when service type is `NodePort`                                             |                     |
-| admin.hostPort                     | Host port to use for admin traffic                                                    |                     |
+| admin.enabled                      | Create admin Service                                                                  | `false`             |
+| admin.http.enabled                 | Enables http on the admin API                                                         | `false`             |
+| admin.http.servicePort             | Service port to use for http                                                          | 8001                |
+| admin.http.containerPort           | Container port to use for http                                                        | 8001                |
+| admin.http.nodePort                | Node port to use for http                                                             |                     |
+| admin.http.hostPort                | Host port to use for http                                                             |                     |
+| admin.http.parameters              | Array of additional listen parameters                                                 | `[]`                |
+| admin.tls.enabled                  | Enables TLS on the admin API                                                          | true                |
+| admin.tls.containerPort            | Container port to use for TLS                                                         | 8443                |
+| admin.tls.servicePort              | Service port to use for TLS                                                           | 8443                |
+| admin.tls.nodePort                 | Node port to use for TLS                                                              |                     |
+| admin.tls.hostPort                 | Host port to use for TLS                                                              |                     |
+| admin.tls.overrideServiceTargetPort| Override service port to use for TLS without touching Kong containerPort              |                     |
+| admin.tls.parameters               | Array of additional listen parameters                                                 | `[]`                |
 | admin.type                         | k8s service type, Options: NodePort, ClusterIP, LoadBalancer                          | `NodePort`          |
 | admin.loadBalancerIP               | Will reuse an existing ingress static IP for the admin service                        | `null`              |
 | admin.loadBalancerSourceRanges     | Limit admin access to CIDRs if set and service type is `LoadBalancer`                 | `[]`                |
@@ -224,17 +232,20 @@ Kong can be configured via two methods:
 | admin.ingress.hosts                | List of ingress hosts.                                                                | `[]`                |
 | admin.ingress.path                 | Ingress path.                                                                         | `/`                 |
 | admin.ingress.annotations          | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
+| proxy.enabled                      | Create proxy Service                                                                  | `true`              |
 | proxy.http.enabled                 | Enables http on the proxy                                                             | true                |
 | proxy.http.servicePort             | Service port to use for http                                                          | 80                  |
 | proxy.http.containerPort           | Container port to use for http                                                        | 8000                |
-| proxy.http.nodePort                | Node port to use for http                                                             | 32080               |
+| proxy.http.nodePort                | Node port to use for http                                                             |                     |
 | proxy.http.hostPort                | Host port to use for http                                                             |                     |
+| proxy.http.parameters              | Array of additional listen parameters                                                 | `{}`                |
 | proxy.tls.enabled                  | Enables TLS on the proxy                                                              | true                |
 | proxy.tls.containerPort            | Container port to use for TLS                                                         | 8443                |
 | proxy.tls.servicePort              | Service port to use for TLS                                                           | 8443                |
-| proxy.tls.nodePort                 | Node port to use for TLS                                                              | 32443               |
+| proxy.tls.nodePort                 | Node port to use for TLS                                                              |                     |
 | proxy.tls.hostPort                 | Host port to use for TLS                                                              |                     |
 | proxy.tls.overrideServiceTargetPort| Override service port to use for TLS without touching Kong containerPort              |                     |
+| proxy.tls.parameters               | Array of additional listen parameters                                                 | `{}`                |
 | proxy.type                         | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          | `LoadBalancer`      |
 | proxy.clusterIP                    | k8s service clusterIP                                                                 |                     |
 | proxy.loadBalancerSourceRanges     | Limit proxy access to CIDRs if set and service type is `LoadBalancer`                 | `[]`                |
@@ -322,7 +333,7 @@ and upper-cased before setting the environment variable.
 Furthermore, all `kong.env` parameters can also accept a mapping instead of a
 value to ensure the parameters can be set through configmaps and secrets.
 
-An example :
+An example:
 
 ```yaml
 kong:
@@ -340,22 +351,6 @@ For complete list of Kong configurations please check the
 [Kong configuration docs](https://docs.konghq.com/latest/configuration).
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
-
-##### Admin/Proxy listener override
-
-If you specify `env.admin_listen` or `env.proxy_listen`, this chart will use
-the value provided by you as opposed to constructing a listen variable
-from fields like `proxy.http.containerPort` and `proxy.http.enabled`.
-This allows you to be more prescriptive when defining listen directives.
-
-**Note:** Overriding `env.proxy_listen` and `env.admin_listen` will
-potentially cause `admin.containerPort`, `proxy.http.containerPort` and
-`proxy.tls.containerPort` to become out of sync,
-and therefore must be updated accordingly.
-
-For example, updating to `env.proxy_listen: 0.0.0.0:4444, 0.0.0.0:4443 ssl`
-will need `proxy.http.containerPort: 4444` and `proxy.tls.containerPort: 4443`
-to be set in order for the service definition to work properly.
 
 ## Kong Enterprise Parameters
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -30,6 +30,7 @@ $ helm install kong/kong
   - [Configuration method](#configuration-method)
 - [Configuration](#configuration)
   - [Kong Parameters](#kong-parameters)
+    - [Kong Service Parameters](#kong-service-parameters)
   - [Ingress Controller Parameters](#ingress-controller-parameters)
   - [General Parameters](#general-parameters)
   - [The `env` section](#the-env-section)
@@ -203,12 +204,6 @@ Kong can be configured via two methods:
 
 ### Kong parameters
 
-The various `SVC.*` parameters below are common to the various Kong services
-(the admin API, proxy, Kong Manger, the Developer Portal, and the Developer
-Portal API) and define their listener configuration, K8S Service properties,
-and K8S Ingress properties. Defaults are listed only if consistent across the
-individual services: see values.yaml for their individual default values.
-
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
@@ -216,6 +211,33 @@ individual services: see values.yaml for their individual default values.
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count                                                                   | `1`                 |
+| plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
+| env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
+| runMigrations                      | Run Kong migrations job                                                               | `true`              |
+| waitImage.repository               | Image used to wait for database to become ready                                       | `busybox`           |
+| waitImage.tag                      | Tag for image used to wait for database to become ready                               | `latest`            |
+| waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |
+| postgresql.enabled                 | Spin up a new postgres instance for Kong                                              | `false`             |
+| dblessConfig.configMap             | Name of an existing ConfigMap containing the `kong.yml` file. This must have the key `kong.yml`.| `` |
+| dblessConfig.config                | Yaml configuration file for the dbless (declarative) configuration of Kong | see in `values.yaml`    |
+
+#### Kong Service Parameters
+
+The various `SVC.*` parameters below are common to the various Kong services
+(the admin API, proxy, Kong Manger, the Developer Portal, and the Developer
+Portal API) and define their listener configuration, K8S Service properties,
+and K8S Ingress properties. Defaults are listed only if consistent across the
+individual services: see values.yaml for their individual default values.
+
+`SVC` below can be substituted with each of:
+* `proxy`
+* `admin`
+* `manager`
+* `portal`
+* `portalapi`
+
+| Parameter                          | Description                                                                           | Default             |
+| ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | SVC.enabled                        | Create Service resource for SVC (admin, proxy, manager, etc.)                         |                     |
 | SVC.http.enabled                   | Enables http on the service                                                           |                     |
 | SVC.http.servicePort               | Service port to use for http                                                          |                     |
@@ -242,15 +264,6 @@ individual services: see values.yaml for their individual default values.
 | SVC.ingress.path                   | Ingress path.                                                                         | `/`                 |
 | SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
 | SVC.annotations                    | Service annotations                                                                   | `{}`                |
-| plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
-| env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
-| runMigrations                      | Run Kong migrations job                                                               | `true`              |
-| waitImage.repository               | Image used to wait for database to become ready                                       | `busybox`           |
-| waitImage.tag                      | Tag for image used to wait for database to become ready                               | `latest`            |
-| waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |
-| postgresql.enabled                 | Spin up a new postgres instance for Kong                                              | `false`             |
-| dblessConfig.configMap             | Name of an existing ConfigMap containing the `kong.yml` file. This must have the key `kong.yml`.| `` |
-| dblessConfig.config                | Yaml configuration file for the dbless (declarative) configuration of Kong | see in `values.yaml`    |
 
 ### Ingress Controller Parameters
 

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -1,0 +1,36 @@
+# CI test for testing dbless deployment without ingress controllers using legacy admin listen
+# TODO: remove legacy admin listen behavior at a future date
+# - disable ingress controller
+ingressController:
+  enabled: false
+# - use legacy admin listen config
+admin:
+  enabled: true
+  useTLS: true
+  servicePort: 8444
+  containerPort: 8444
+
+# - disable DB for kong
+env:
+  database: "off"
+postgresql:
+  enabled: false
+# - supply DBless config for kong
+dblessConfig:
+  # Or the configuration is passed in full-text below
+  config:
+    _format_version: "1.1"
+    services:
+      - name: test-svc
+        url: http://example.com
+        routes:
+        - name: test
+          paths:
+          - /test
+        plugins:
+        - name: request-termination
+          config:
+            status_code: 200
+            message: "dbless-config"
+proxy:
+  type: NodePort

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -10,13 +10,13 @@ PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fu
 export PROXY_IP=${HOST}:${PORT}
 curl $PROXY_IP
 
-Once installed, please follow along the getting started guide to start using Kong:
-https://bit.ly/k4k8s-get-started
+Once installed, please follow along the getting started guide to start using
+Kong: https://bit.ly/k4k8s-get-started
 
 {{ if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}} {{/* Legacy Portal auth handling */}}
 /!\ WARNING: You are currently using legacy Portal authentication configuration
-in values.yaml (https://github.com/Kong/charts/blob/kong-1.2.0/charts/kong/values.yaml#L384-L392).
-Support for this will be removed in a future release.
+in values.yaml. Support for this will be removed in a future release:
+https://github.com/Kong/charts/blob/kong-1.2.0/charts/kong/values.yaml#L384-L392
 
 You should move these settings to "portal_session_conf" (using a secretKeyRef)
 and "portal_auth" under your "env" block.
@@ -24,8 +24,8 @@ and "portal_auth" under your "env" block.
 
 {{ if .Values.admin.containerPort -}} {{/* Legacy admin API listen */}}
 /!\ WARNING: You are currently using legacy admin API configuration in
-values.yaml (https://github.com/Kong/charts/blob/kong-1.3.0/charts/kong/values.yaml#L58-L66).
-Support for this will be removed in a future release.
+values.yaml.  Support for this will be removed in a future release:
+https://github.com/Kong/charts/blob/kong-1.3.0/charts/kong/values.yaml#L58-L66
 
 You should rework your admin listen configuration to match the current format
 (https://github.com/Kong/charts/blob/master/charts/kong/values.yaml).

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -14,14 +14,19 @@ Once installed, please follow along the getting started guide to start using Kon
 https://bit.ly/k4k8s-get-started
 
 {{ if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}} {{/* Legacy Portal auth handling */}}
-/!\ WARNING: You are currently using legacy Portal authentication configuration in values.yaml (https://github.com/Kong/charts/blob/kong-1.2.0/charts/kong/values.yaml#L384-L392). Support for this will be removed in a future release.
+/!\ WARNING: You are currently using legacy Portal authentication configuration
+in values.yaml (https://github.com/Kong/charts/blob/kong-1.2.0/charts/kong/values.yaml#L384-L392).
+Support for this will be removed in a future release.
 
-You should move these settings to "portal_session_conf" (using a secretKeyRef) and "portal_auth" under your "env" block.
-{{- end -}}
+You should move these settings to "portal_session_conf" (using a secretKeyRef)
+and "portal_auth" under your "env" block.
+{{- end }}
 
 {{ if .Values.admin.containerPort -}} {{/* Legacy admin API listen */}}
-/!\ WARNING: You are currently using legacy admin API configuration in values.yaml (https://github.com/Kong/charts/blob/kong-1.3.0/charts/kong/values.yaml#L58-L66). Support for this will be removed in a future release.
+/!\ WARNING: You are currently using legacy admin API configuration in
+values.yaml (https://github.com/Kong/charts/blob/kong-1.3.0/charts/kong/values.yaml#L58-L66).
+Support for this will be removed in a future release.
 
-You should rework your admin listen configuration to match the current format (https://github.com/Kong/charts/blob/master/charts/kong/values.yaml).
+You should rework your admin listen configuration to match the current format
+(https://github.com/Kong/charts/blob/master/charts/kong/values.yaml).
 {{- end -}}
-

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -19,3 +19,9 @@ https://bit.ly/k4k8s-get-started
 You should move these settings to "portal_session_conf" (using a secretKeyRef) and "portal_auth" under your "env" block.
 {{- end -}}
 
+{{ if .Values.admin.containerPort -}} {{/* Legacy admin API listen */}}
+/!\ WARNING: You are currently using legacy admin API configuration in values.yaml (https://github.com/Kong/charts/blob/kong-1.3.0/charts/kong/values.yaml#L58-L66). Support for this will be removed in a future release.
+
+You should rework your admin listen configuration to match the current format (https://github.com/Kong/charts/blob/master/charts/kong/values.yaml).
+{{- end -}}
+

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -54,6 +54,7 @@ Create the name of the service account to use
 
 {{/*
 Create KONG_SERVICE_LISTEN strings
+Generic tool for creating KONG_PROXY_LISTEN, KONG_ADMIN_LISTEN, etc.
 */}}
 {{- define "kong.listen" -}}
   {{- $httpListen := list -}}
@@ -102,7 +103,7 @@ https://localhost:{{ .Values.admin.tls.containerPort }}
     {{- else if .Values.admin.http.enabled -}}
 http://localhost:{{ .Values.admin.http.containerPort }}
     {{- else -}}
-http://localhost:9999 # You have an ingress controller enabled, but no admin listens!
+http://localhost:9999 # You have no admin listens! The controller will not work unless you set .Values.admin.http.enabled=true or .Values.admin.tls.enabled=true!
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -365,7 +366,7 @@ TODO: remove legacy admin listen behavior at a future date
 
 {{- if .Values.enterprise.enabled }}
   {{- $_ := set $autoEnv "KONG_ADMIN_GUI_LISTEN" (include "kong.listen" .Values.manager) -}}
-  {{- if and (.Values.manager.ingress.enabled) (.Values.enterprise.enabled) }}
+  {{- if .Values.manager.ingress.enabled }}
     {{- $_ := set $autoEnv "KONG_ADMIN_GUI_URL" (include "kong.ingress.serviceUrl" .Values.manager.ingress) -}}
   {{- end -}}
 
@@ -375,10 +376,10 @@ TODO: remove legacy admin listen behavior at a future date
 
   {{- if .Values.enterprise.portal.enabled }}
     {{- $_ := set $autoEnv "KONG_PORTAL" "on" -}}
-        {{- $_ := set $autoEnv "KONG_PORTAL_GUI_LISTEN" (include "kong.listen" .Values.portal) -}}
+      {{- $_ := set $autoEnv "KONG_PORTAL_GUI_LISTEN" (include "kong.listen" .Values.portal) -}}
     {{- $_ := set $autoEnv "KONG_PORTAL_API_LISTEN" (include "kong.listen" .Values.portalapi) -}}
 
-    {{- if and (.Values.portal.ingress.enabled) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
+    {{- if .Values.portal.ingress.enabled }}
       {{- $_ := set $autoEnv "KONG_PORTAL_GUI_HOST" .Values.portal.ingress.hostname -}}
       {{- if .Values.portal.ingress.tls }}
         {{- $_ := set $autoEnv "KONG_PORTAL_GUI_PROTOCOL" "https" -}}
@@ -387,7 +388,7 @@ TODO: remove legacy admin listen behavior at a future date
       {{- end }}
     {{- end }}
 
-    {{- if and (.Values.portalapi.ingress.enabled) (.Values.enterprise.enabled) (.Values.enterprise.portal.enabled) }}
+    {{- if .Values.portalapi.ingress.enabled }}
       {{- $_ := set $autoEnv "KONG_PORTAL_API_URL" (include "kong.ingress.serviceUrl" .Values.portalapi.ingress) -}}
     {{- end }}
 

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -63,12 +63,31 @@ spec:
             exec:
               command: [ "/bin/sh", "-c", "kong quit" ]
         ports:
+        {{/* TODO: remove legacy admin port template */}}
+        {{- if .Values.admin.containerPort }}
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           {{- if .Values.admin.hostPort }}
           hostPort: {{ .Values.admin.hostPort }}
           {{- end}}
           protocol: TCP
+        {{- end }}
+        {{- if .Values.admin.http.enabled }}
+        - name: admin
+          containerPort: {{ .Values.admin.http.containerPort }}
+          {{- if .Values.admin.http.hostPort }}
+          hostPort: {{ .Values.admin.http.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
+        {{- if .Values.admin.tls.enabled }}
+        - name: admin-tls
+          containerPort: {{ .Values.admin.tls.containerPort }}
+          {{- if .Values.admin.tls.hostPort }}
+          hostPort: {{ .Values.admin.tls.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
         {{- if .Values.proxy.http.enabled }}
         - name: proxy
           containerPort: {{ .Values.proxy.http.containerPort }}

--- a/charts/kong/templates/ingress-admin.yaml
+++ b/charts/kong/templates/ingress-admin.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.admin.ingress.enabled -}}
+{{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := .Values.admin.servicePort -}}
 {{- $path := .Values.admin.ingress.path -}}
@@ -29,4 +30,36 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- else -}} {{/* Modern admin handler */}}
+{{- $serviceName := include "kong.fullname" . -}}
+{{- $servicePort := include "kong.ingress.servicePort" .Values.admin -}}
+{{- $path := .Values.admin.ingress.path -}}
+{{- $tls := .Values.admin.ingress.tls -}}
+{{- $hostname := .Values.admin.ingress.hostname -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "kong.fullname" . }}-admin
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+  annotations:
+    {{- range $key, $value := .Values.admin.ingress.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  - host: {{ $hostname }}
+    http:
+      paths:
+        - path: {{ $path }}
+          backend:
+            serviceName: {{ $serviceName }}-admin
+            servicePort: {{ $servicePort }}
+  {{- if $tls }}
+  tls:
+  - hosts:
+    - {{ $hostname }}
+    secretName: {{ $tls }}
+  {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.admin.enabled -}}
+{{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,4 +33,54 @@ spec:
     protocol: TCP
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- else -}} {{/* Modern admin handler */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-admin
+  annotations:
+    {{- range $key, $value := .Values.admin.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.admin.type }}
+  {{- if eq .Values.admin.type "LoadBalancer" }}
+  {{- if .Values.admin.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.admin.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.admin.loadBalancerSourceRanges }}
+  - {{ $cidr }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  externalIPs:
+  {{- range $ip := .Values.admin.externalIPs }}
+  - {{ $ip }}
+  {{- end }}
+  ports:
+  {{- if .Values.admin.http.enabled }}
+  - name: kong-admin
+    port: {{ .Values.admin.http.servicePort }}
+    targetPort: {{ .Values.admin.http.containerPort }}
+  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.http.nodePort))) }}
+    nodePort: {{ .Values.admin.http.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  {{- if or .Values.admin.tls.enabled }}
+  - name: kong-admin-tls
+    port: {{ .Values.admin.tls.servicePort }}
+    targetPort: {{ .Values.admin.tls.containerPort }}
+  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.tls.nodePort))) }}
+    nodePort: {{ .Values.admin.tls.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  selector:
+    {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.admin.enabled -}}
 {{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
+{{- if .Values.admin.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,7 +33,9 @@ spec:
     protocol: TCP
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- else -}} {{/* Modern admin handler */}}
+{{- if and .Values.admin.enabled (or .Values.admin.http.enabled .Values.admin.tls.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/kong/templates/service-kong-manager.yaml
+++ b/charts/kong/templates/service-kong-manager.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enterprise.enabled }}
+{{- if and .Values.manager.enabled (or .Values.manager.http.enabled .Values.manager.tls.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -47,4 +48,5 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-portal-api.yaml
+++ b/charts/kong/templates/service-kong-portal-api.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enterprise.enabled }}
+{{- if and .Values.portalapi.enabled (or .Values.portalapi.http.enabled .Values.portalapi.tls.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -47,4 +48,5 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-portal.yaml
+++ b/charts/kong/templates/service-kong-portal.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enterprise.enabled }}
+{{- if and .Values.portal.enabled (or .Values.portal.http.enabled .Values.portal.tls.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -47,4 +48,5 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.proxy.enabled (or .Values.proxy.http.enabled .Values.proxy.tls.enabled) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -52,3 +53,4 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -45,12 +45,13 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-# Specify Kong admin service and listener configuration
+# Specify Kong admin API service and listener configuration
 admin:
-  # Enable creating a Service for the admin API
+  # Enable creating a Kubernetes service for the admin API
   # Disabling this is recommended for most ingress controller configurations
   # Enterprise users that wish to use Kong Manager with the controller should enable this
   enabled: false
+  type: NodePort
   # If you want to specify annotations for the admin service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
@@ -81,9 +82,6 @@ admin:
     parameters:
     - http2
 
-  type: NodePort
-  # Set a nodePort which is available
-  # nodePort: 32444
   # Kong admin ingress settings. Useful if you want to expose the Admin
   # API of Kong outside the k8s cluster.
   ingress:
@@ -100,8 +98,9 @@ admin:
 
 # Specify Kong proxy service and listener configuration
 proxy:
-  # Enable creating a Service for the proxy
+  # Enable creating a Kubernetes service for the proxy
   enabled: true
+  type: LoadBalancer
   # If you want to specify annotations for the proxy service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
@@ -130,8 +129,6 @@ proxy:
     # Additional listen parameters, e.g. "reuseport", "backlog=16384"
     parameters:
     - http2
-
-  type: LoadBalancer
 
   # Kong proxy ingress settings.
   # Note: You need this only if you are using another Ingress Controller
@@ -448,8 +445,9 @@ enterprise:
       smtp_password_secret: you-must-create-an-smtp-password
 
 manager:
-  # Enable creating a Service for Kong Manager
+  # Enable creating a Kubernetes service for Kong Manager
   enabled: true
+  type: NodePort
   # If you want to specify annotations for the Manager service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
@@ -476,8 +474,6 @@ manager:
     parameters:
     - http2
 
-  type: NodePort
-
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
@@ -493,8 +489,9 @@ manager:
   externalIPs: []
 
 portal:
-  # Enable creating a Service for the Developer Portal
+  # Enable creating a Kubernetes service for the Developer Portal
   enabled: true
+  type: NodePort
   # If you want to specify annotations for the Portal service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
@@ -521,8 +518,6 @@ portal:
     parameters:
     - http2
 
-  type: NodePort
-
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
@@ -538,8 +533,9 @@ portal:
   externalIPs: []
 
 portalapi:
-  # Enable creating a Service for the Developer Portal API
+  # Enable creating a Kubernetes service for the Developer Portal API
   enabled: true
+  type: NodePort
   # If you want to specify annotations for the Portal API service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
@@ -565,8 +561,6 @@ portalapi:
     # Additional listen parameters, e.g. "reuseport", "backlog=16384"
     parameters:
     - http2
-
-  type: NodePort
 
   ingress:
     # Enable/disable exposure using ingress.

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -45,22 +45,42 @@ image:
   # pullSecrets:
   #   - myRegistrKeySecretName
 
-# Specify Kong admin service configuration
-# Note: It is recommended to not use the Admin API to configure Kong
-# when using Kong as an Ingress Controller.
+# Specify Kong admin service and listener configuration
 admin:
+  # Enable creating a Service for the admin API
+  # Disabling this is recommended for most ingress controller configurations
+  # Enterprise users that wish to use Kong Manager with the controller should enable this
   enabled: false
   # If you want to specify annotations for the admin service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # HTTPS traffic on the admin port
-  # if set to false also set readinessProbe and livenessProbe httpGet scheme's to 'HTTP'
-  useTLS: true
-  servicePort: 8444
-  containerPort: 8444
-  # Kong admin service type
+  http:
+    # Enable plaintext HTTP listen for the admin API
+    # Disabling this and using a TLS listen only is recommended for most configuration
+    enabled: false
+    servicePort: 8001
+    containerPort: 8001
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32080
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters: {}
+
+  tls:
+    # Enable HTTPS listen for the admin API
+    enabled: true
+    servicePort: 8444
+    containerPort: 8444
+    # Set a target port for the TLS port in the admin API service, useful when using TLS
+    # termination on an ELB.
+    # overrideServiceTargetPort: 8000
+    # Set a nodePort which is available if service type is NodePort
+    # nodePort: 32443
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters:
+    - http2
+
   type: NodePort
   # Set a nodePort which is available
   # nodePort: 32444
@@ -78,22 +98,27 @@ admin:
     # Ingress path.
     path: /
 
-# Specify Kong proxy service configuration
+# Specify Kong proxy service and listener configuration
 proxy:
+  # Enable creating a Service for the proxy
+  enabled: true
   # If you want to specify annotations for the proxy service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # HTTP plain-text traffic
   http:
+    # Enable plaintext HTTP listen for the proxy
     enabled: true
     servicePort: 80
     containerPort: 8000
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters: {}
 
   tls:
+    # Enable HTTPS listen for the proxy
     enabled: true
     servicePort: 443
     containerPort: 8443
@@ -102,6 +127,9 @@ proxy:
     # overrideServiceTargetPort: 8000
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters:
+    - http2
 
   type: LoadBalancer
 
@@ -420,25 +448,33 @@ enterprise:
       smtp_password_secret: you-must-create-an-smtp-password
 
 manager:
+  # Enable creating a Service for Kong Manager
+  enabled: true
   # If you want to specify annotations for the Manager service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # HTTP plain-text traffic
   http:
+    # Enable plaintext HTTP listen for Kong Manager
     enabled: true
     servicePort: 8002
     containerPort: 8002
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters: {}
 
   tls:
+    # Enable HTTPS listen for Kong Manager
     enabled: true
     servicePort: 8445
     containerPort: 8445
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters:
+    - http2
 
   type: NodePort
 
@@ -458,25 +494,33 @@ manager:
   externalIPs: []
 
 portal:
+  # Enable creating a Service for the Developer Portal
+  enabled: true
   # If you want to specify annotations for the Portal service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # HTTP plain-text traffic
   http:
+    # Enable plaintext HTTP listen for the Developer Portal
     enabled: true
     servicePort: 8003
     containerPort: 8003
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters: {}
 
   tls:
+    # Enable HTTPS listen for the Developer Portal
     enabled: true
     servicePort: 8446
     containerPort: 8446
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters:
+    - http2
 
   type: NodePort
 
@@ -496,25 +540,33 @@ portal:
   externalIPs: []
 
 portalapi:
+  # Enable creating a Service for the Developer Portal API
+  enabled: true
   # If you want to specify annotations for the Portal API service, uncomment the following
   # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
-  # HTTP plain-text traffic
   http:
+    # Enable plaintext HTTP listen for the Developer Portal API
     enabled: true
     servicePort: 8004
     containerPort: 8004
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters: {}
 
   tls:
+    # Enable HTTPS listen for the Developer Portal API
     enabled: true
     servicePort: 8447
     containerPort: 8447
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443
+    # Additional listen parameters, e.g. "reuseport", "backlog=16384"
+    parameters:
+    - http2
 
   type: NodePort
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -478,7 +478,6 @@ manager:
 
   type: NodePort
 
-  # Kong proxy ingress settings.
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
@@ -524,7 +523,6 @@ portal:
 
   type: NodePort
 
-  # Kong proxy ingress settings.
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
@@ -570,7 +568,6 @@ portalapi:
 
   type: NodePort
 
-  # Kong proxy ingress settings.
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -65,7 +65,7 @@ admin:
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
     # Additional listen parameters, e.g. "reuseport", "backlog=16384"
-    parameters: {}
+    parameters: []
 
   tls:
     # Enable HTTPS listen for the admin API
@@ -115,7 +115,7 @@ proxy:
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
     # Additional listen parameters, e.g. "reuseport", "backlog=16384"
-    parameters: {}
+    parameters: []
 
   tls:
     # Enable HTTPS listen for the proxy
@@ -463,7 +463,7 @@ manager:
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
     # Additional listen parameters, e.g. "reuseport", "backlog=16384"
-    parameters: {}
+    parameters: []
 
   tls:
     # Enable HTTPS listen for Kong Manager
@@ -509,7 +509,7 @@ portal:
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
     # Additional listen parameters, e.g. "reuseport", "backlog=16384"
-    parameters: {}
+    parameters: []
 
   tls:
     # Enable HTTPS listen for the Developer Portal
@@ -555,7 +555,7 @@ portalapi:
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
     # Additional listen parameters, e.g. "reuseport", "backlog=16384"
-    parameters: {}
+    parameters: []
 
   tls:
     # Enable HTTPS listen for the Developer Portal API


### PR DESCRIPTION
#### What this PR does / why we need it:
Consolidates listeners templates into a single generic template. This DRYs helper template code, makes the listener/service configuration consistent, and paves the way towards consolidating Service/Ingress templates in the future.

* Use the same listener/service configuration format in values.yaml for all Kong services. This mainly affects the admin API, which previously had a unique format. That format is still supported, but is deprecated. Users are warned to update it in NOTES.txt output if the old format is detected.
* Use the same template for generating all `KONG_<SERVICE>_LISTEN` variables.
* Add support for additional listener parameters (see previous discussion in #47).
* Combine documentation for various service values.yaml parameters.
* Add CI values.yaml for legacy admin API configuration.
* Move generation of the ingress controller `--kong-url` argument into a new `kong.adminLocalURL` helper.

#### Special notes for your reviewer:
PR contains un-squashed commits to show dev history, but should be squashed before merger, as most of the details are irrelevant after review. If merging, please use the commit message from https://github.com/Kong/charts/commit/6451e7f8ab28112f648d42ce7f7b49c581946aaf with one additional bullet point:

```
 * Add a "kong.adminLocalURL" helper to generate the local URL for the
   admin API, for use with the ingress controller.
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
