### PR TITLE
[kong] optionally expose prometheus metrics

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -224,6 +224,10 @@ Kong can be configured via two methods:
 | admin.ingress.hosts                | List of ingress hosts.                                                                | `[]`                |
 | admin.ingress.path                 | Ingress path.                                                                         | `/`                 |
 | admin.ingress.annotations          | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
+| metrics.containerPort              | Container port to serve metrics endpoint on                                           | 9542                |
+| metrics.service.enabled            | Enable service for metrics port                                                       | false               |
+| metrics.service.port               | Service listen port                                                                   | 9542                |
+| metrics.service.type               | Service type                                                                          | ClusterIP           |
 | proxy.http.enabled                 | Enables http on the proxy                                                             | true                |
 | proxy.http.servicePort             | Service port to use for http                                                          | 80                  |
 | proxy.http.containerPort           | Container port to use for http                                                        | 8000                |

--- a/charts/kong/templates/config-custom-server-blocks.yaml
+++ b/charts/kong/templates/config-custom-server-blocks.yaml
@@ -9,7 +9,7 @@ data:
     # Prometheus metrics and health-checking server
     server {
         server_name kong_prometheus_exporter;
-        listen 0.0.0.0:9542; # can be any other port as well
+        listen 0.0.0.0:{{ .Values.metrics.containerPort }};
         access_log off;
         location /status {
             default_type text/plain;

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
           protocol: TCP
         {{- end }}
         - name: metrics
-          containerPort: 9542
+          containerPort: {{ .Values.metrics.containerPort }}
           protocol: TCP
         {{- if .Values.ingressController.admissionWebhook.enabled }}
         - name: webhook

--- a/charts/kong/templates/service-kong-metrics.yaml
+++ b/charts/kong/templates/service-kong-metrics.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.service.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: {{ .Values.metrics.service.port }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+spec:
+  ports:
+  - name: {{ template "kong.fullname" . }}-metrics
+    port: {{ .Values.metrics.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.metrics.containerPort }}
+  selector:
+    {{- include "kong.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.metrics.service.type }}
+{{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -371,6 +371,14 @@ serviceMonitor:
   # labels:
   #   foo: bar
 
+# Toggle Kubernetes service to expose Prometheus metrics
+metrics:
+  containerPort: 9542
+  service:
+    enabled: false
+    port: 9542
+    type: "ClusterIP"
+
 # -----------------------------------------------------------------------------
 # Kong Enterprise parameters
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows the `metrics` endpoint to be optionally exposed as a Kubernetes service.

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
