### PR TITLE
[kong] add support for annotations on Deployment

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -307,6 +307,7 @@ For a complete list of all configuration values you can set in the
 | livenessProbe                      | Kong liveness probe                                                                   |                     |
 | affinity                           | Node/pod affinities                                                                   |                     |
 | nodeSelector                       | Node labels for pod assignment                                                        | `{}`                |
+| deploymentAnnotations              | Annotations to add to deployment                                                      |  see `values.yaml`  |
 | podAnnotations                     | Annotations to add to each pod                                                        | `{}`                |
 | resources                          | Pod resource requests & limits                                                        | `{}`                |
 | tolerations                        | List of node taints to tolerate                                                       | `[]`                |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: app
+  annotations:
+    {{- if .Values.deploymentAnnotations }}
+{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -356,6 +356,11 @@ podAnnotations: {}
 # Kong pod count
 replicaCount: 1
 
+# Annotations to be added to Kong deployment
+deploymentAnnotations:
+  kuma.io/gateway: enabled
+  traffic.sidecar.istio.io/includeInboundPorts: ""
+
 # Enable autoscaling using HorizontalPodAutoscaler
 autoscaling:
   enabled: false


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/master/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Adds support for adding custom annotations on the Deployment resource of Kong's chart.

#### Which issue this PR fixes

Closes #71 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
