### PR TITLE
[kong] switch to bitnami's chart repo for postgresql

### DIFF
--- a/charts/kong/requirements.lock
+++ b/charts/kong/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 8.1.2
-digest: sha256:c4bf54db60c2c5953ba7b79ce4814f8b8225d04e932868bcfab23b93c05b0f7f
-generated: "2019-12-31T13:58:27.104134475-08:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.6.8
+digest: sha256:8a3bbab2075144edbd954b95b2c779a61dcc55ec6a858f24b01b1e0031b72c19
+generated: "2020-03-20T13:08:19.76868615-07:00"

--- a/charts/kong/requirements.yaml
+++ b/charts/kong/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
-  version: ~8.1.0
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 8.6.8
+  repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled

--- a/ct-master.yaml
+++ b/ct-master.yaml
@@ -2,6 +2,7 @@
 remote: origin
 chart-dirs:
   - charts
-chart-repos: []
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 200
 check-version-increment: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,6 +2,7 @@
 remote: origin
 chart-dirs:
   - charts
-chart-repos: []
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 200
 check-version-increment: false


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/master/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Change postgresql chart repository as the older one is deprecated now.

#### Special notes for your reviewer:

Question: can this cause an upgrade problem? 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
