### PR TITLE
[kong] release 1.4.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 1.4.0
+
+### Improvements
+
+* Service and listen configuration now use a unified configuration format.
+  Listen configuration now supports specifying parameters. Kubernetes service
+  creation can now be enabled or disabled for all Kong services. Users should
+  review the [1.4.0 upgrade
+  guide](https://github.com/Kong/charts/blob/next/charts/kong/UPGRADE.md#changes-to-kong-service-configuration)
+  for details on how to update their values.yaml.
+  ([#72](https://github.com/Kong/charts/pull/72))
+* Updated the default controller version to 0.8. This adds new
+  KongClusterPlugin and TCPIngress CRDs and RBAC permissions for them. Users
+  should also note that `strip_path` now defaults to disabled, which will
+  likely break existing configuration. See [the controller
+  changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/master/CHANGELOG.md#080---20200325)
+  and [upgrade-guide](https://github.com/Kong/charts/blob/next/charts/kong/UPGRADE.md#strip_path-now-defaults-to-false-for-controller-managed-routes)
+  for full details.
+  ([#77](https://github.com/Kong/charts/pull/77))
+* Added support for user-supplied ingress controller CLI arguments.
+  ([#79](https://github.com/Kong/charts/pull/79))
+* Added support for annotating the chart's deployment.
+  ([#81](https://github.com/Kong/charts/pull/81))
+* Switched to the Bitnami Postgres chart, as the chart in Helm's repository has
+  [moved
+  there](https://github.com/helm/charts/tree/master/stable/postgresql#this-helm-chart-is-deprecated).
+  ([#82](https://github.com/Kong/charts/pull/82))
+
+### Fixed
+
+* Corrected the app version in Chart.yaml.
+  ([#86](https://github.com/Kong/charts/pull/86))
+
+### Documentation
+
+* Fixed incorrect default value for `installCRDs`.
+  ([#78](https://github.com/Kong/charts/pull/78))
+* Added detailed upgrade guide covering breaking changes and deprecations.
+  ([#74](https://github.com/Kong/charts/pull/74))
+* Improved installation steps for Helm 2 and Helm 3.
+  ([#83](https://github.com/Kong/charts/pull/83))
+  ([#84](https://github.com/Kong/charts/pull/84))
+* Remove outdated `ingressController.replicaCount` setting.
+  ([#87](https://github.com/Kong/charts/pull/87))
+
 ## 1.3.1
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.3.1
+version: 1.4.0
 appVersion: 2.0

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -45,6 +45,33 @@ clear it.
 
 ## 1.4.0
 
+### `strip_path` now defaults to `false` for controller-managed routes
+
+1.4.0 defaults to version 0.8 of the ingress controller, which changes the
+default value of the `strip_path` route setting from `true` to `false`. To
+understand how this works in practice, compare the upstream path for these
+requests when `strip_path` is toggled:
+
+| Ingress path | `strip_path` | Request path | Upstream path |
+|--------------|--------------|--------------|---------------|
+| /foo/bar     | true         | /foo/bar/baz | /baz          |
+| /foo/bar     | false        | /foo/bar/baz | /foo/bar/baz  |
+
+This change brings the controller in line with the Kubernetes Ingress
+specification, which expects that controllers will not modify the request
+before passing it upstream unless explicitly configured to do so.
+
+To preserve your existing route handling, you should add this annotation to
+your ingress resources:
+
+```
+konghq.com/strip-path: true
+```
+
+This is a new annotation that is equivalent to the `route.strip_path` setting
+in KongIngress resources. Note that if you have already set this to `false`,
+you should leave it as-is and not add an annotation to the ingress.
+
 ### Changes to Kong service configuration 
 
 1.4.0 reworks the templates and configuration used to generate Kong


### PR DESCRIPTION
#### What this PR does / why we need it:
Update changelog and chart version for v1.4.0 of the Kong chart. Add UPGRADE.md section for `strip_path` changes.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
