### PR TITLE
[kong] release chart version 1.4.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.1
+
+### Documentation
+
+* Fixed an issue with the 1.4.1 upgrade steps.
+
 ## 1.4.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.4.0
+version: 1.4.1
 appVersion: 2.0

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -65,7 +65,7 @@ To preserve your existing route handling, you should add this annotation to
 your ingress resources:
 
 ```
-konghq.com/strip-path: true
+konghq.com/strip-path: "true"
 ```
 
 This is a new annotation that is equivalent to the `route.strip_path` setting


### PR DESCRIPTION
#### What this PR does / why we need it:
Fix a documentation issue and bump the Kong chart version to 1.4.1.

#### Special notes for your reviewer:
This PR is direct to master, and needs to be merged to next after.

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
