### PR TITLE
[kong] add 1.4 upgrade info for Postgres subchart

### DIFF
--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -45,6 +45,33 @@ clear it.
 
 ## 1.4.0
 
+### Changes to default Postgres permissions
+
+The [Postgres sub-chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+used by this chart has modified the way their chart handles file permissions.
+This is not an issue for new installations, but prevents Postgres from starting
+if its PVC was created with an older version. If affected, your Postgres pod
+logs will show:
+
+```
+postgresql 19:16:04.03 INFO  ==> ** Starting PostgreSQL **
+2020-03-27 19:16:04.053 GMT [1] FATAL:  data directory "/bitnami/postgresql/data" has group or world access
+2020-03-27 19:16:04.053 GMT [1] DETAIL:  Permissions should be u=rwx (0700).
+```
+
+You can restore the old permission handling behavior by adding two settings to
+the `postgresql` block in values.yaml:
+
+```yaml
+postgresql:
+  enabled: true
+  postgresqlDataDir: /bitnami/postgresql/data
+  volumePermissions:
+    enabled: true
+```
+
+For background, see https://github.com/helm/charts/issues/13651
+
 ### `strip_path` now defaults to `false` for controller-managed routes
 
 1.4.0 defaults to version 0.8 of the ingress controller, which changes the


### PR DESCRIPTION
#### What this PR does / why we need it:
Changes to the Bitnami Postgres chart result in compatibility issues with PVCs created by older versions of the subchart. This PR adds documentation to UPGRADE.md and bumps the minor version to 1.4.2.

#### Special notes for your reviewer:
This PR is direct to master. It must be merged into next after merging into master.

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
