### PR TITLE
[kong] add annotations for service account

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -299,7 +299,8 @@ section of `values.yaml` file:
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
 | installCRDs                        | Create CRDs. **FOR HELM3, MAKE SURE THIS VALUE IS SET TO `false`.**                   | true                                                                         |
 | serviceAccount.create              | Create Service Account for ingress controller                                         | true
-| serviceAccount.name                | Use existing Service Account, specifiy its name                                       | ""
+| serviceAccount.name                | Use existing Service Account, specify its name                                        | ""
+| serviceAccount.annotations         | Annotations for Service Account                                                       | {}
 | installCRDs                        | Create CRDs. Regardless of value of this, Helm v3+ will install the CRDs if those are not present already. Use `--skip-crds` with `helm install` if you want to skip CRD creation. | true |
 | env                                | Specify Kong Ingress Controller configuration via environment variables               |                                                                              |
 | ingressClass                       | The ingress-class value for controller                                                | kong                                                                         |

--- a/charts/kong/ci/test1-values.yaml
+++ b/charts/kong/ci/test1-values.yaml
@@ -1,4 +1,4 @@
-# This tests the following unrealted aspects of Ingress Controller
+# This tests the following unrelated aspects of Ingress Controller
 # - HPA enabled
 autoscaling:
   enabled: true
@@ -13,6 +13,10 @@ ingressController:
 # - environment variables can be injected into ingress controller container
   env:
     kong_admin_header: "foo:bar"
+# - annotations can be injected for service account
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
 # - podSecurityPolicies are enabled
 podSecurityPolicy:
   enabled: true

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -1,4 +1,4 @@
-# This tests the following unrealted aspects of Ingress Controller
+# This tests the following unrelated aspects of Ingress Controller
 # - ingressController deploys with a database
 ingressController:
   enabled: true

--- a/charts/kong/templates/controller-service-account.yaml
+++ b/charts/kong/templates/controller-service-account.yaml
@@ -3,11 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kong.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   annotations:
   {{- if .Values.ingressController.serviceAccount.annotations }}
 {{ toYaml .Values.ingressController.serviceAccount.annotations | indent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 {{- end -}}

--- a/charts/kong/templates/controller-service-account.yaml
+++ b/charts/kong/templates/controller-service-account.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kong.serviceAccountName" . }}
+  annotations:
+  {{- if .Values.ingressController.serviceAccount.annotations }}
+{{ toYaml .Values.ingressController.serviceAccount.annotations | indent 4 }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -238,6 +238,8 @@ ingressController:
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     name:
+    # The annotations for service account
+    annotations: {}
 
   installCRDs: true
 


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/master/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
In order to use AWS EKS IAM Roles for Service Accounts feature, one must annotate the service account to specify what IAM role admin wants to grant to that service account.

```yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
```

#### Which issue this PR fixes
  - fixes # https://github.com/Kong/charts/issues/98

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
