### PR TITLE
[kong] migrate controller to envvar-based configuration

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -149,6 +149,7 @@ The name of the service used for the ingress controller's validation webhook
 */}}
 
 {{- $autoEnv := dict -}}
+{{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" "true" -}}
 {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" (printf "%s/%s-proxy" .Release.Namespace (include "kong.fullname" .)) -}}
 {{- $_ := set $autoEnv "CONTROLLER_INGRESS_CLASS" .Values.ingressController.ingressClass -}}
 {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -277,7 +277,6 @@ The name of the service used for the ingress controller's validation webhook
   # the kong URL points to the kong admin api server
   {{- if (or .Values.admin.useTLS .Values.admin.tls.enabled) }} {{/* TODO: remove legacy admin handling */}}
   - --kong-url={{ template "kong.adminLocalURL" . }}
-  - --admin-tls-skip-verify
   {{- else }}
   - --kong-url={{ template "kong.adminLocalURL" . }}
   {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -219,7 +219,18 @@ ingressController:
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables
-  env: {}
+  env:
+    # The controller disables TLS verification by default because Kong
+    # generates self-signed certificates by default. Set this to false once you
+    # have installed CA-signed certificates.
+    kong_admin_tls_skip_verify: true
+    # If using Kong Enterprise with RBAC enabled, uncomment the section below
+    # and specify the secret/key containing your admin token.
+    # kong_admin_token:
+    #   valueFrom:
+    #     secretKeyRef:
+    #        name: CHANGEME-admin-token-secret
+    #        key: CHANGEME-admin-token-key
 
   admissionWebhook:
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
* Migrate controller `env` block generation to the dict-based system used by the Kong container.
* Move static controller arguments to equivalent environment variables.
* Place `kong_admin_tls_skip_verify` default and example `kong_admin_token` in values.yaml.

#### Special notes for your reviewer:
* `POD_NAMESPACE` and `POD_NAME` remain outside the new system (they're still part of the `kong.controller-container` template). Users cannot override them (user variables all receive the `CONTROLLER_` prefix) and we'd need an additional (albeit simple) template to handle fieldRefs, so I think it's reasonable to omit them.
* Although `kong_admin_tls_skip_verify` is now a user-set variable with a default in values.yaml, it also has a default inside the template. This is to account for users with an existing values.yaml that specifies `env: {}`.

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
