### PR TITLE
[kong] specify tag info for enterprise images

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -33,9 +33,14 @@ env:
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  # repository: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
-  # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
   tag: "2.0"
+  # kong-enterprise-k8s image (Kong OSS + Enterprise plugins)
+  # repository: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
+  # tag: "2.0.2.0-alpine"
+  # kong-enterprise image
+  # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
+  # tag: "1.3.0.2-alpine"
+
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/master/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Specifies tags for the enterprise images so that users don't have to look them up.

#### Special notes for your reviewer:
None
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
