### PR TITLE
[kong] add configurable migration job annotations

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -234,6 +234,7 @@ Kong can be configured via two methods:
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | runMigrations                      | Run Kong migrations job                                                               | `true`              |
+| migrationAnnotations               | Annotations for migration jobs                                                        | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |
 | waitImage.repository               | Image used to wait for database to become ready                                       | `busybox`           |
 | waitImage.tag                      | Tag for image used to wait for database to become ready                               | `latest`            |
 | waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -11,6 +11,9 @@ metadata:
   annotations:
     helm.sh/hook: "post-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
+    {{- range $key, $value := .Values.migrationAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -11,6 +11,9 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
+    {{- range $key, $value := .Values.migrationAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
+  annotations:
+    {{- range $key, $value := .Values.migrationAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -185,6 +185,12 @@ secretVolumes: []
 
 # Set runMigrations to run Kong migrations
 runMigrations: true
+# Additional annotations to apply to migrations jobs
+# By default, these disable service mesh sidecar injection for Istio and Kuma,
+# as the sidecar containers do not terminate and prevent the jobs from completing
+migrationAnnotations:
+  sidecar.istio.io/inject: false
+  kuma.io/sidecar-injection: "disabled"
 
 # Kong's configuration for DB-less mode
 # Note: Use this section only if you are deploying Kong in DB-less mode


### PR DESCRIPTION
#### What this PR does / why we need it:
Add a migrationAnnotations setting to values.yaml with default annotations disabling the Istio and Kuma sidecars. Annotations are added to migration jobs.

#### Which issue this PR fixes
Fixes #19 

#### Special notes for your reviewer:
All jobs receive the same set of annotations. For the original use case this seems desirable, and I couldn't immediately think of a reason to split them. It's easy enough to do so, but adds more config clutter and duplication, so absent a clear need I made them identical.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
