### PR TITLE
[kong] rework migration job configuration

### DIFF
--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -84,7 +84,8 @@ is immutable
 This occurs if a `RELEASE-NAME-kong-init-migrations` Job is left over from a
 previous `helm install` or `helm upgrade`. Deleting it with
 `kubectl delete job RELEASE-NAME-kong-init-migrations` will allow the upgrade
-to proceed.
+to proceed. Setting `migrations.init: false` will prevent the job from spawning
+and creating this issue for future upgrades.
 
 This job is not removed automatically [due to limitations in
 Helm](https://github.com/Kong/charts/pull/36).

--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -84,8 +84,4 @@ is immutable
 This occurs if a `RELEASE-NAME-kong-init-migrations` Job is left over from a
 previous `helm install` or `helm upgrade`. Deleting it with
 `kubectl delete job RELEASE-NAME-kong-init-migrations` will allow the upgrade
-to proceed. Setting `migrations.init: false` will prevent the job from spawning
-and creating this issue for future upgrades.
-
-This job is not removed automatically [due to limitations in
-Helm](https://github.com/Kong/charts/pull/36).
+to proceed. Chart versions greater than 1.5.0 delete the job automatically.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -33,6 +33,7 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
   - [Database](#database)
   - [Runtime package](#runtime-package)
   - [Configuration method](#configuration-method)
+  - [Separate admin and proxy nodes](#separate-admin-and-proxy-nodes)
 - [Configuration](#configuration)
   - [Kong Parameters](#kong-parameters)
     - [Kong Service Parameters](#kong-service-parameters)
@@ -95,6 +96,9 @@ $ helm install kong/kong
 # Helm 3
 $ helm install kong/kong --generate-name --set ingressController.installCRDs=false
 ```
+
+After installing, set `migrations.init: false` in values.yaml to prevent the
+initial migrations from spawning during upgrades.
 
 ## Uninstall
 
@@ -201,6 +205,45 @@ The package to run can be changed via `image.repository` and `image.tag`
 parameters. If you would like to run the Enterprise package, please read
 the [Kong Enterprise Parameters](#kong-enterprise-parameters) section.
 
+### Separate admin and proxy nodes
+
+Users may wish to split their Kong deployment into multiple instances that only
+run some of Kong's services, e.g. where some nodes only run the proxy and other
+only run the admin API, or where some nodes only run Developer Portal services.
+At present, these require separate Helm releases (i.e. you run `helm install`
+once for every instance type you wish to create).
+
+To disable Kong services on an instance, you should set `SVC.enabled`,
+`SVC.http.enabled`, `SVC.tls.enabled`, and `SVC.ingress.enabled` all to
+`false`, where `SVC` is `proxy`, `admin`, `manager`, `portal`, or `portalapi`.
+
+The standard chart upgrade automation process assumes that there is only a
+single Kong release in the Kong cluster, and runs both `migrations up` and
+`migrations finish` jobs. To handle clusters split across multipl releases, you
+should:
+1. Upgrade one of the releases with `helm upgrade RELEASENAME -f values.yaml
+   --set migrations.preUpgrade=true --set migrations.postUpgrade=false`.
+2. Upgrade all but one of the remaining releases with `helm upgrade RELEASENAME
+   -f values.yaml --set migrations.preUpgrade=false --set
+   migrations.postUpgrade=false`.
+3. Upgrade the final release with `helm upgrade RELEASENAME -f values.yaml
+   --set migrations.preUpgrade=false --set migrations.postUpgrade=true`.
+
+This ensures that all instances are using the new Kong package before running
+`kong migrations finish`.
+
+Users should note that Helm supports supplying multiple values.yaml files,
+allowing you to separate shared configuration from instance-specific
+configuration. For example, you may have a shared values.yaml that contains
+environment variables and other common settings, and then several
+instance-specific values.yamls that contain service configuration only. You can
+then create releases with:
+
+```
+helm install proxy-only -f shared-values.yaml -f only-proxy.yaml kong/kong
+helm install admin-only -f shared-values.yaml -f only-admin.yaml kong/kong
+```
+
 ### Configuration method
 
 Kong can be configured via two methods:
@@ -233,7 +276,10 @@ Kong can be configured via two methods:
 | replicaCount                       | Kong instance count                                                                   | `1`                 |
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
-| runMigrations                      | Run Kong migrations job                                                               | `true`              |
+| migrations.init                    | Run "kong migrations bootstrap" jobs                                                  | `true`              |
+| migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
+| migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
+| migrations.annotations             | Annotations for migration jobs                                                        | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |
 | waitImage.repository               | Image used to wait for database to become ready                                       | `busybox`           |
 | waitImage.tag                      | Tag for image used to wait for database to become ready                               | `latest`            |
 | waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -216,8 +216,8 @@ To disable Kong services on an instance, you should set `SVC.enabled`,
 
 The standard chart upgrade automation process assumes that there is only a
 single Kong release in the Kong cluster, and runs both `migrations up` and
-`migrations finish` jobs. To handle clusters split across multipl releases, you
-should:
+`migrations finish` jobs. To handle clusters split across multiple releases,
+you should:
 1. Upgrade one of the releases with `helm upgrade RELEASENAME -f values.yaml
    --set migrations.preUpgrade=true --set migrations.postUpgrade=false`.
 2. Upgrade all but one of the remaining releases with `helm upgrade RELEASENAME

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -97,9 +97,6 @@ $ helm install kong/kong
 $ helm install kong/kong --generate-name --set ingressController.installCRDs=false
 ```
 
-After installing, set `migrations.init: false` in values.yaml to prevent the
-initial migrations from spawning during upgrades.
-
 ## Uninstall
 
 To uninstall/delete a Helm release `my-release`:
@@ -210,8 +207,8 @@ the [Kong Enterprise Parameters](#kong-enterprise-parameters) section.
 Users may wish to split their Kong deployment into multiple instances that only
 run some of Kong's services, e.g. where some nodes only run the proxy and other
 only run the admin API, or where some nodes only run Developer Portal services.
-At present, these require separate Helm releases (i.e. you run `helm install`
-once for every instance type you wish to create).
+These require separate Helm releases (i.e. you run `helm install` once for
+every instance type you wish to create).
 
 To disable Kong services on an instance, you should set `SVC.enabled`,
 `SVC.http.enabled`, `SVC.tls.enabled`, and `SVC.ingress.enabled` all to
@@ -276,7 +273,6 @@ Kong can be configured via two methods:
 | replicaCount                       | Kong instance count                                                                   | `1`                 |
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
-| migrations.init                    | Run "kong migrations bootstrap" jobs                                                  | `true`              |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
 | migrations.annotations             | Annotations for migration jobs                                                        | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -59,9 +59,6 @@ individual upgrade migrations:
 migrations:
   preUpgrade: true
   postUpgrade: true
-  annotations:
-    sidecar.istio.io/inject: false
-    kuma.io/sidecar-injection: "disabled"
 ```
 
 Initial migration jobs are now only run during `helm install` and are deleted

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -19,9 +19,6 @@ install/status/upgrade`.
 
 ## Upgrade considerations for all versions
 
-Before upgrading, users should set `migrations.init: false` in values.yaml.
-This prevents the `field is immutable` error mentioned below.
-
 The chart automates the
 [upgrade migration process](https://github.com/Kong/kong/blob/master/UPGRADE.md).
 When running `helm upgrade`, the chart spawns an initial job to run `kong
@@ -46,11 +43,9 @@ the issue stems from changes in Kubernetes resources or changes in Kong.
 
 Users may encounter an error when upgrading which displays a large block of
 text ending with `field is immutable`. This is typically due to a bug with the
-`init-migrations` job, which is [difficult to solve using current Helm
-functionality](https://github.com/Kong/charts/blob/master/charts/kong/FAQs.md#running-helm-upgrade-fails-because-of-old-init-migrations-job).
+`init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
-clear it. Set `migrations.init: false` in values.yaml to avoid this in future
-upgrades.
+clear it.
 
 ## 1.5.0
 
@@ -58,11 +53,10 @@ upgrades.
 
 Previously, all migration jobs were enabled/disabled through a single
 `runMigrations` setting. 1.5.0 splits these into toggles for each of the
-individual migrations:
+individual upgrade migrations:
 
 ```
 migrations:
-  init: true
   preUpgrade: true
   postUpgrade: true
   annotations:
@@ -70,11 +64,14 @@ migrations:
     kuma.io/sidecar-injection: "disabled"
 ```
 
+Initial migration jobs are now only run during `helm install` and are deleted
+automatically when users first run `helm upgrade`.
+
 Users should replace `runMigrations` with the above block from the latest
 values.yaml.
 
 The new format addresses several needs:
-* The initial migrations job can be disabled after the initial install,
+* The initial migrations job are only created during the initial install,
   preventing [conflicts on upgrades](https://github.com/Kong/charts/blob/master/charts/kong/FAQs.md#running-helm-upgrade-fails-because-of-old-init-migrations-job).
 * The upgrade migrations jobs can be disabled as need for managing
   [multi-release clusters](https://github.com/Kong/charts/blob/master/charts/kong/README.md#separate-admin-and-proxy-nodes).
@@ -82,7 +79,7 @@ The new format addresses several needs:
   e.g. nodes that only run the proxy and nodes that only run the admin API.
 * Migration jobs now allow specifying annotations, and provide a default set
   of annotations that disable some service mesh sidecars. Because sidecar
-  containers do not terminate, they prevent the jobs from terminating.
+  containers do not terminate, they [prevent the jobs from terminating](https://github.com/kubernetes/kubernetes/issues/25908).
 
 ## 1.4.0
 

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -79,7 +79,7 @@ The new format addresses several needs:
   e.g. nodes that only run the proxy and nodes that only run the admin API.
 * Migration jobs now allow specifying annotations, and provide a default set
   of annotations that disable some service mesh sidecars. Because sidecar
-  containers do not terminate, they [prevent the jobs from terminating](https://github.com/kubernetes/kubernetes/issues/25908).
+  containers do not terminate, they [prevent the jobs from completing](https://github.com/kubernetes/kubernetes/issues/25908).
 
 ## 1.4.0
 

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -1,10 +1,8 @@
 To connect to Kong, please execute the following commands:
-
 {{ if contains "LoadBalancer" .Values.proxy.type }}
 HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].port}')
-{{- else if contains "NodePort" .Values.proxy.type -}}
-HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
+{{ else if contains "NodePort" .Values.proxy.type }}HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath='{.items[0].status.addresses[0].address}')
 PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "kong.fullname" . }}-proxy -o jsonpath='{.spec.ports[0].nodePort}')
 {{ end -}}
 export PROXY_IP=${HOST}:${PORT}

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -15,18 +15,21 @@ Kong: https://bit.ly/k4k8s-get-started
 
 {{ if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}} {{/* Legacy Portal auth handling */}}
 /!\ WARNING: You are currently using legacy Portal authentication configuration
-in values.yaml. Support for this will be removed in a future release:
-https://github.com/Kong/charts/blob/kong-1.2.0/charts/kong/values.yaml#L384-L392
-
-You should move these settings to "portal_session_conf" (using a secretKeyRef)
-and "portal_auth" under your "env" block.
+in values.yaml. Support for this will be removed in a future release. Please
+see the upgrade guide for instructions to update your configuration:
+https://github.com/Kong/charts/blob/master/charts/kong/UPGRADE.md#removal-of-dedicated-portal-authentication-configuration-parameters
 {{- end }}
 
 {{ if .Values.admin.containerPort -}} {{/* Legacy admin API listen */}}
 /!\ WARNING: You are currently using legacy admin API configuration in
-values.yaml.  Support for this will be removed in a future release:
-https://github.com/Kong/charts/blob/kong-1.3.0/charts/kong/values.yaml#L58-L66
+values.yaml. Support for this will be removed in a future release. Please see
+the upgrade guide for instructions to update your configuration:
+https://github.com/Kong/charts/blob/master/charts/kong/UPGRADE.md#changes-to-kong-service-configuration
+{{- end }}
 
-You should rework your admin listen configuration to match the current format
-(https://github.com/Kong/charts/blob/master/charts/kong/values.yaml).
-{{- end -}}
+{{ if .Values.runMigrations -}} {{/* Legacy migration toggle */}}
+/!\ WARNING: You are currently using the legacy runMigrations setting in
+values.yaml. Support for this will be removed in a future release. Please see
+the upgrade guide for instructions to update your configuration:
+https://github.com/Kong/charts/blob/master/charts/kong/UPGRADE.md#changes-to-migration job-configuration
+{{- end }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.runMigrations) (not (eq .Values.env.database "off"))) }}
+{{- if (and (or (.Values.runMigrations) (.Values.migrations.postUpgrade)) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1
@@ -11,6 +11,9 @@ metadata:
   annotations:
     helm.sh/hook: "post-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
+    {{- range $key, $value := .Values.migrationAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -11,9 +11,6 @@ metadata:
   annotations:
     helm.sh/hook: "post-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
-    {{- range $key, $value := .Values.migrationAnnotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
 spec:
   template:
     metadata:
@@ -21,6 +18,10 @@ spec:
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
         app.kubernetes.io/component: post-upgrade-migrations
+      annotations:
+        {{- range $key, $value := .Values.migrations.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- if .Values.podSecurityPolicy.enabled }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.runMigrations) (not (eq .Values.env.database "off"))) }}
+{{- if (and (or (.Values.runMigrations) (.Values.migrations.preUpgrade)) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1
@@ -11,6 +11,9 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
+    {{- range $key, $value := .Values.migrationAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -11,9 +11,6 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
-    {{- range $key, $value := .Values.migrationAnnotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
 spec:
   template:
     metadata:
@@ -21,6 +18,10 @@ spec:
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
         app.kubernetes.io/component: pre-upgrade-migrations
+      annotations:
+        {{- range $key, $value := .Values.migrations.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- if .Values.podSecurityPolicy.enabled }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -1,4 +1,9 @@
-{{- if (and (or (.Values.runMigrations) (.Values.migrations.init)) (not (eq .Values.env.database "off"))) }}
+{{- if .Release.IsInstall -}}
+{{/* .migrations.init isn't normally exposed in values.yaml. In testing,
+however, adding it with value "false" didn't actually disable this job. Not
+clear why, but not a major concern: this job should always be created if it
+meets the .Release.IsInstall condition for a DB-backed instance. */}}
+{{- if (and (or (.Values.runMigrations) (.Values.migrations.init | default true)) (not (eq .Values.env.database "off"))) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -6,10 +11,6 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
-  annotations:
-    {{- range $key, $value := .Values.migrationAnnotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
 spec:
   template:
     metadata:
@@ -17,6 +18,10 @@ spec:
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
         app.kubernetes.io/component: init-migrations
+      annotations:
+        {{- range $key, $value := .Values.migrations.annotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     spec:
       {{- if .Values.podSecurityPolicy.enabled }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
@@ -45,4 +50,5 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
+{{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -1,4 +1,4 @@
-{{- if (and (.Values.runMigrations) (not (eq .Values.env.database "off"))) }}
+{{- if (and (or (.Values.runMigrations) (.Values.migrations.init)) (not (eq .Values.env.database "off"))) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
+  annotations:
+    {{- range $key, $value := .Values.migrationAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -185,12 +185,9 @@ secretVolumes: []
 
 # Enable/disable migration jobs, and set annotations for them
 migrations:
-  # Enable initial migrations/"kong migrations bootstrap"
-  # This should be set to false after the initial install
-  init: true
-  # Enable pre-upgrade migrations/"kong migrations up"
+  # Enable pre-upgrade migrations (run "kong migrations up")
   preUpgrade: true
-  # Enable post-upgrade migrations/"kong migrations finish"
+  # Enable post-upgrade migrations (run "kong migrations finish")
   postUpgrade: true
   # Annotations to apply to migrations jobs
   # By default, these disable service mesh sidecar injection for Istio and Kuma,

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -183,8 +183,21 @@ plugins: {}
 # - kong-admin-tls
 secretVolumes: []
 
-# Set runMigrations to run Kong migrations
-runMigrations: true
+# Enable/disable migration jobs, and set annotations for them
+migrations:
+  # Enable initial migrations/"kong migrations bootstrap"
+  # This should be set to false after the initial install
+  init: true
+  # Enable pre-upgrade migrations/"kong migrations up"
+  preUpgrade: true
+  # Enable post-upgrade migrations/"kong migrations finish"
+  postUpgrade: true
+  # Annotations to apply to migrations jobs
+  # By default, these disable service mesh sidecar injection for Istio and Kuma,
+  # as the sidecar containers do not terminate and prevent the jobs from completing
+  annotations:
+    sidecar.istio.io/inject: false
+    kuma.io/sidecar-injection: "disabled"
 
 # Kong's configuration for DB-less mode
 # Note: Use this section only if you are deploying Kong in DB-less mode


### PR DESCRIPTION
#### What this PR does / why we need it:
* Create a new `migrations` section in values.yaml.
* Add configurable annotations to migration jobs, with default annotations to disable Istio and Kuma sidecars.
* Splits `runMigrations` into per-migration toggles under `migrations`.
* Points NOTES.txt deprecation warnings to the relevant UPGRADE.md section rather than explaining the issue in place.
* Add documentation for split deployments and init conflict issue.

This addresses several different issues:
* Migration annotations address an issue with sidecar containers blocking job completion (#19).
* Avoiding the init job conflict (#43)
* Allowing users to disable pre/post-upgrade migrations is needed for deployments that split different role nodes across multiple releases.

#### Which issue this PR fixes
Fixes #19
Fixes #43 

#### Special notes for your reviewer:
This supersedes https://github.com/Kong/charts/pull/101

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
