### PR TITLE
[kong] add support for stream listens

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -272,12 +272,6 @@ individual services: see values.yaml for their individual default values.
 | SVC.tls.hostPort                   | Host port to use for TLS                                                              |                     |
 | SVC.tls.overrideServiceTargetPort  | Override service port to use for TLS without touching Kong containerPort              |                     |
 | SVC.tls.parameters                 | Array of additional listen parameters                                                 | `["http2"]`         |
-| proxy.stream.name                  | Name for a stream listen                                                              |                     |
-| proxy.stream.containerPort         | Container port to use for a stream listen                                             |                     |
-| proxy.stream.servicePort           | Service port to use for a stream listen                                               |                     |
-| proxy.stream.nodePort              | Node port to use for a stream listen                                                  |                     |
-| proxy.stream.hostPort              | Host port to use for a stream listen                                                  |                     |
-| proxy.stream.parameters            | Array of additional listen parameters                                                 | `["http2"]`         |
 | SVC.type                           | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          |                     |
 | SVC.clusterIP                      | k8s service clusterIP                                                                 |                     |
 | SVC.loadBalancerSourceRanges       | Limit service access to CIDRs if set and service type is `LoadBalancer`               | `[]`                |
@@ -290,6 +284,19 @@ individual services: see values.yaml for their individual default values.
 | SVC.ingress.path                   | Ingress path.                                                                         | `/`                 |
 | SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
 | SVC.annotations                    | Service annotations                                                                   | `{}`                |
+
+#### Stream listens
+
+The proxy configuration additionally supports creating stream listens. These
+are configured using an array of objects under `proxy.stream`:
+
+| Parameter                          | Description                                                                           | Default             |
+| ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| containerPort                      | Container port to use for a stream listen                                             |                     |
+| servicePort                        | Service port to use for a stream listen                                               |                     |
+| nodePort                           | Node port to use for a stream listen                                                  |                     |
+| hostPort                           | Host port to use for a stream listen                                                  |                     |
+| parameters                         | Array of additional listen parameters                                                 | `[]`                |
 
 ### Ingress Controller Parameters
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -272,6 +272,12 @@ individual services: see values.yaml for their individual default values.
 | SVC.tls.hostPort                   | Host port to use for TLS                                                              |                     |
 | SVC.tls.overrideServiceTargetPort  | Override service port to use for TLS without touching Kong containerPort              |                     |
 | SVC.tls.parameters                 | Array of additional listen parameters                                                 | `["http2"]`         |
+| proxy.stream.name                  | Name for a stream listen                                                              |                     |
+| proxy.stream.containerPort         | Container port to use for a stream listen                                             |                     |
+| proxy.stream.servicePort           | Service port to use for a stream listen                                               |                     |
+| proxy.stream.nodePort              | Node port to use for a stream listen                                                  |                     |
+| proxy.stream.hostPort              | Host port to use for a stream listen                                                  |                     |
+| proxy.stream.parameters            | Array of additional listen parameters                                                 | `["http2"]`         |
 | SVC.type                           | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          |                     |
 | SVC.clusterIP                      | k8s service clusterIP                                                                 |                     |
 | SVC.loadBalancerSourceRanges       | Limit service access to CIDRs if set and service type is `LoadBalancer`               | `[]`                |

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -25,6 +25,15 @@ proxy:
     annotations: {}
     path: /
   useTLS: true
+# - add stream listens
+  stream:
+  - containerPort: 9000
+    servicePort: 9000
+    parameters: []
+  - containerPort: 9001
+    servicePort: 9001
+    parameters:
+    - ssl
 
 # - PDB is enabled
 podDisruptionBudget:

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -26,12 +26,3 @@ dblessConfig:
             message: "dbless-config"
 proxy:
   type: NodePort
-# - add stream listens
-  stream:
-  - containerPort: 9000
-    servicePort: 9000
-    parameters: []
-  - containerPort: 9001
-    servicePort: 9001
-    parameters:
-    - ssl

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -1,4 +1,4 @@
-# CI test for testing dbless deployment without ingress controllers and stream listens
+# CI test for testing dbless deployment without ingress controllers
 # - disable ingress controller
 ingressController:
   enabled: false

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -1,4 +1,4 @@
-# CI test for testing dbless deployment without ingress controllers
+# CI test for testing dbless deployment without ingress controllers and stream listens
 # - disable ingress controller
 ingressController:
   enabled: false
@@ -26,3 +26,12 @@ dblessConfig:
             message: "dbless-config"
 proxy:
   type: NodePort
+# - add stream listens
+  stream:
+  - containerPort: 9000
+    servicePort: 9000
+    parameters: []
+  - containerPort: 9001
+    servicePort: 9001
+    parameters:
+    - ssl

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -1,4 +1,4 @@
-# CI test for testing dbless deployment without ingress controllers using legacy admin listen
+# CI test for testing dbless deployment without ingress controllers using legacy admin listen and stream listens
 # TODO: remove legacy admin listen behavior at a future date
 # - disable ingress controller
 ingressController:
@@ -34,3 +34,12 @@ dblessConfig:
             message: "dbless-config"
 proxy:
   type: NodePort
+# - add stream listens
+  stream:
+  - containerPort: 9000
+    servicePort: 9000
+    parameters: []
+  - containerPort: 9001
+    servicePort: 9001
+    parameters:
+    - ssl

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -57,26 +57,27 @@ Create KONG_SERVICE_LISTEN strings
 Generic tool for creating KONG_PROXY_LISTEN, KONG_ADMIN_LISTEN, etc.
 */}}
 {{- define "kong.listen" -}}
-  {{- $httpListen := list -}}
-  {{- $tlsListen := list -}}
   {{- $unifiedListen := list -}}
 
   {{- if .http.enabled -}}
-    {{- $httpListen = append $httpListen (printf "0.0.0.0:%d" (int64 .http.containerPort)) -}}
-    {{- range $param := .http.parameters }}
-      {{- $httpListen = append $httpListen $param -}}
-    {{- end -}}
-
-    {{- $unifiedListen = append $unifiedListen ($httpListen | join " ") -}}
+    {{- $httpListen := (include "kong.singleListen" .http) -}}
+    {{- $unifiedListen = append $unifiedListen $httpListen -}}
   {{- end -}}
 
   {{- if .tls.enabled -}}
-    {{- $tlsListen = append $tlsListen (printf "0.0.0.0:%d ssl" (int64 .tls.containerPort)) -}}
-    {{- range $param := .tls.parameters }}
-      {{- $tlsListen = append $tlsListen $param -}}
-    {{- end -}}
-
-    {{- $unifiedListen = append $unifiedListen ($tlsListen | join " ") -}}
+    {{/*
+    This is a bit of a hack to support always including "ssl" in the parameter
+    list for TLS listens. It's not possible to set a variable to an object from
+    .Values and then modify one of the objects values locally, although
+    https://github.com/helm/helm/issues/4987 indicates it should be. Instead,
+    this creates a new object and new parameters list built from the original.
+    */}}
+    {{- $tls := dict -}}
+    {{- $parameters := append .tls.parameters "ssl" -}}
+    {{- $_ := set $tls "containerPort" .tls.containerPort -}}
+    {{- $_ := set $tls "parameters" $parameters -}}
+    {{- $tlsListen := (include "kong.singleListen" $tls) -}}
+    {{- $unifiedListen = append $unifiedListen $tlsListen -}}
   {{- end -}}
 
   {{- $listenString := ($unifiedListen | join ", ") -}}
@@ -86,6 +87,33 @@ Generic tool for creating KONG_PROXY_LISTEN, KONG_ADMIN_LISTEN, etc.
   {{- $listenString -}}
 {{- end -}}
 
+{{/*
+Create KONG_STREAM_LISTEN string
+*/}}
+{{- define "kong.streamListen" -}}
+  {{- $unifiedListen := list -}}
+  {{- range .stream -}}
+    {{- $unifiedListen = append $unifiedListen (include "kong.singleListen" . ) -}}
+  {{- end -}}
+
+  {{- $listenString := ($unifiedListen | join ", ") -}}
+  {{- if eq (len $listenString) 0 -}}
+    {{- $listenString = "off" -}}
+  {{- end -}}
+  {{- $listenString -}}
+{{- end -}}
+
+{{/*
+Create a single listen (IP+port+parameter combo)
+*/}}
+{{- define "kong.singleListen" -}}
+  {{- $listen := list -}}
+  {{- $listen = append $listen (printf "0.0.0.0:%d" (int64 .containerPort)) -}}
+  {{- range $param := .parameters }}
+    {{- $listen = append $listen $param -}}
+  {{- end -}}
+  {{- $listen | join " " -}}
+{{- end -}}
 
 {{/*
 Return the local admin API URL, preferring HTTPS if available
@@ -368,6 +396,8 @@ TODO: remove legacy admin listen behavior at a future date
 {{- end -}}
 
 {{- $_ := set $autoEnv "KONG_PROXY_LISTEN" (include "kong.listen" .Values.proxy) -}}
+
+{{- $_ := set $autoEnv "KONG_STREAM_LISTEN" (include "kong.streamListen" .Values.proxy) -}}
 
 {{- if .Values.enterprise.enabled }}
   {{- $_ := set $autoEnv "KONG_ADMIN_GUI_LISTEN" (include "kong.listen" .Values.manager) -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -109,7 +109,7 @@ Create a single listen (IP+port+parameter combo)
 {{- define "kong.singleListen" -}}
   {{- $listen := list -}}
   {{- $listen = append $listen (printf "0.0.0.0:%d" (int64 .containerPort)) -}}
-  {{- range $param := .parameters }}
+  {{- range $param := .parameters | uniq }}
     {{- $listen = append $listen $param -}}
   {{- end -}}
   {{- $listen | join " " -}}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -108,6 +108,14 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
+        {{- range .Values.proxy.stream }}
+        - name: {{ .name }}
+          containerPort: {{ .containerPort }}
+          {{- if .hostPort }}
+          hostPort: {{ .hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
         - name: metrics
           containerPort: 9542
           protocol: TCP

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
           protocol: TCP
         {{- end }}
         {{- range .Values.proxy.stream }}
-        - name: {{ .name }}
+        - name: stream-{{ .containerPort }}
           containerPort: {{ .containerPort }}
           {{- if .hostPort }}
           hostPort: {{ .hostPort }}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -45,6 +45,16 @@ spec:
   {{- end }}
     protocol: TCP
   {{- end }}
+  {{- $root := .Values }}
+  {{- range .Values.proxy.stream }}
+  - name: {{ .name }}
+    port: {{ .servicePort }}
+    targetPort: {{ .containerPort }}
+    {{- if (and (or (eq $root.proxy.type "LoadBalancer") (eq $root.proxy.type "NodePort")) (not (empty .nodePort))) }}
+    nodePort: {{ .nodePort }}
+    {{- end }}
+    protocol: TCP
+  {{- end }}
   {{- if .Values.proxy.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.proxy.externalTrafficPolicy }}
   {{- end }}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -47,7 +47,7 @@ spec:
   {{- end }}
   {{- $root := .Values }}
   {{- range .Values.proxy.stream }}
-  - name: {{ .name }}
+  - name: stream-{{ .containerPort }}
     port: {{ .servicePort }}
     targetPort: {{ .containerPort }}
     {{- if (and (or (eq $root.proxy.type "LoadBalancer") (eq $root.proxy.type "NodePort")) (not (empty .nodePort))) }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -130,6 +130,20 @@ proxy:
     parameters:
     - http2
 
+  # Define stream (TCP) listen
+  # To enable, remove "{}", uncomment the section below, and select your desired
+  # ports and parameters.
+  stream: {}
+    # - name: example-stream
+    #   containerPort: 9000
+    #   servicePort: 9000
+    #   # Optionally set a static nodePort if the service type is NodePort
+    #   # nodePort: 32080
+    #   # Additional listen parameters, e.g. "ssl", "reuseport", "backlog=16384"
+    #   # "ssl" is not supported on versions <2.0, but is not required for
+    #   # SNI-based listens. It is used to reject any non-TLS connections.
+    #   parameters: []
+
   # Kong proxy ingress settings.
   # Note: You need this only if you are using another Ingress Controller
   # to expose Kong outside the k8s cluster.

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -132,16 +132,18 @@ proxy:
 
   # Define stream (TCP) listen
   # To enable, remove "{}", uncomment the section below, and select your desired
-  # ports and parameters.
+  # ports and parameters. Listens are dynamically named after their servicePort,
+  # e.g. "stream-9000" for the below.
   stream: {}
-    # - name: example-stream
-    #   containerPort: 9000
+    #   # Set the container (internal) and service (external) ports for this listen.
+    #   # These values should normally be the same. If your environment requires they
+    #   # differ, note that Kong will match routes based on the containerPort only.
+    # - containerPort: 9000
     #   servicePort: 9000
     #   # Optionally set a static nodePort if the service type is NodePort
     #   # nodePort: 32080
     #   # Additional listen parameters, e.g. "ssl", "reuseport", "backlog=16384"
-    #   # "ssl" is not supported on versions <2.0, but is not required for
-    #   # SNI-based listens. It is used to reject any non-TLS connections.
+    #   # "ssl" is required for SNI-based routes. It is not supported on versions <2.0
     #   parameters: []
 
   # Kong proxy ingress settings.


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for stream listens as an additional listen type on the proxy.

#### Special notes for your reviewer:
I'm still running into issues with the balancer when attempting to configure these:

```
2020/04/03 20:45:38 [error] 37#0: *37954 lua entry thread aborted: runtime error: /usr/local/share/lua/5.1/kong/runloop/balancer.lua:569: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
coroutine 0:
	[C]: in function 'ipairs'
	/usr/local/share/lua/5.1/kong/runloop/balancer.lua:569: in function 'get_all_upstreams'
	/usr/local/share/lua/5.1/kong/runloop/balancer.lua:612: in function 'get_upstream_by_name'
	/usr/local/share/lua/5.1/kong/runloop/balancer.lua:638: in function 'get_balancer'
	/usr/local/share/lua/5.1/kong/runloop/balancer.lua:919: in function 'execute'
	/usr/local/share/lua/5.1/kong/runloop/handler.lua:930: in function 'balancer_execute'
	/usr/local/share/lua/5.1/kong/runloop/handler.lua:1097: in function 'after'
	/usr/local/share/lua/5.1/kong/init.lua:622: in function 'preread'
	preread_by_lua(nginx-kong-stream.conf:66):2: in main chunk while prereading client data, client: 10.138.15.225, server: 0.0.0.0:9001
```
I'd run into them previously with TCPIngress testing and got them again when configuring manual test config for this. That definitely warrants investigation, but I don't think it's anything to do with the PR: the PR code is only setting up the listens and making them accessible, and that does work.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
