### PR TITLE
[kong] add read-only root filesystem option

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -338,7 +338,7 @@ For a complete list of all configuration values you can set in the
 | podDisruptionBudget.maxUnavailable | Represents the minimum number of Pods that can be unavailable (integer or percentage) | `50%`               |
 | podDisruptionBudget.minAvailable   | Represents the number of Pods that must be available (integer or percentage)          |                     |
 | podSecurityPolicy.enabled          | Enable podSecurityPolicy for Kong                                                     | `false`             |
-| podSecurityPolicy.readOnlyRootFilesystem | Enable readOnlyRootFilesystem in PodSecurityPolicy                              | `true`              |
+| podSecurityPolicy.spec             | Collection of [PodSecurityPolicy settings](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#what-is-a-pod-security-policy) | |
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | ""                  |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | false               |
 | serviceMonitor.interval            | Scrapping interval                                                                    | 10s                 |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -338,6 +338,7 @@ For a complete list of all configuration values you can set in the
 | podDisruptionBudget.maxUnavailable | Represents the minimum number of Pods that can be unavailable (integer or percentage) | `50%`               |
 | podDisruptionBudget.minAvailable   | Represents the number of Pods that must be available (integer or percentage)          |                     |
 | podSecurityPolicy.enabled          | Enable podSecurityPolicy for Kong                                                     | `false`             |
+| podSecurityPolicy.readOnlyRootFilesystem | Enable readOnlyRootFilesystem in PodSecurityPolicy                              | `true`              |
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | ""                  |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | false               |
 | serviceMonitor.interval            | Scrapping interval                                                                    | 10s                 |

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -52,7 +52,7 @@ clear it.
 `podSecurityPolicy.enabled: true` is set in values.yaml. This improves
 security, but is incompatible with Kong Enterprise versions prior to 1.5. If
 you use an older version and enable PodSecurityPolicy, you must set
-`podSecurityPolicy.readOnlyRootFilesystem: false`.
+`podSecurityPolicy.spec.readOnlyRootFilesystem: false`.
 
 Kong open-source and Kong for Kubernetes Enterprise are compatible with a
 read-only root filesystem on all versions.

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -13,6 +13,7 @@ install/status/upgrade`.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [1.5.0](#150)
 - [1.4.0](#140)
 - [1.3.0](#130)
 
@@ -42,6 +43,19 @@ text ending with `field is immutable`. This is typically due to a bug with the
 functionality](https://github.com/Kong/charts/blob/master/charts/kong/FAQs.md#running-helm-upgrade-fails-because-of-old-init-migrations-job).
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+## 1.5.0
+
+### PodSecurityPolicy defaults to read-only root filesystem
+
+1.5.0 defaults to using a read-only root container filesystem if
+`podSecurityPolicy.enabled: true` is set in values.yaml. This improves
+security, but is incompatible with Kong Enterprise versions prior to 1.5. If
+you use an older version and enable PodSecurityPolicy, you must set
+`podSecurityPolicy.readOnlyRootFilesystem: false`.
+
+Kong open-source and Kong for Kubernetes Enterprise are compatible with a
+read-only root filesystem on all versions.
 
 ## 1.4.0
 

--- a/charts/kong/templates/psp.yaml
+++ b/charts/kong/templates/psp.yaml
@@ -25,6 +25,7 @@ spec:
   hostNetwork: false
   hostIPC: false
   hostPID: false
+  readOnlyRootFilesystem: {{ .Values.podSecurityPolicy.readOnlyRootFilesystem }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/kong/templates/psp.yaml
+++ b/charts/kong/templates/psp.yaml
@@ -6,26 +6,7 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
-  privileged: false
-  fsGroup:
-    rule: RunAsAny
-  runAsUser:
-    rule: RunAsAny
-  runAsGroup:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-    - 'configMap'
-    - 'secret'
-    - 'emptyDir'
-  allowPrivilegeEscalation: false
-  hostNetwork: false
-  hostIPC: false
-  hostPID: false
-  readOnlyRootFilesystem: {{ .Values.podSecurityPolicy.readOnlyRootFilesystem }}
+{{ .Values.podSecurityPolicy.spec | toYaml | indent 2 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -403,6 +403,9 @@ podDisruptionBudget:
 
 podSecurityPolicy:
   enabled: false
+  # Make the root filesystem read-only. This is not compatible with Kong Enterprise <1.5.
+  # If you use Kong Enterprise <1.5, this must be set to false.
+  readOnlyRootFilesystem: true
 
 
 priorityClassName: ""

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -403,9 +403,29 @@ podDisruptionBudget:
 
 podSecurityPolicy:
   enabled: false
-  # Make the root filesystem read-only. This is not compatible with Kong Enterprise <1.5.
-  # If you use Kong Enterprise <1.5, this must be set to false.
-  readOnlyRootFilesystem: true
+  spec:
+    privileged: false
+    fsGroup:
+      rule: RunAsAny
+    runAsUser:
+      rule: RunAsAny
+    runAsGroup:
+      rule: RunAsAny
+    seLinux:
+      rule: RunAsAny
+    supplementalGroups:
+      rule: RunAsAny
+    volumes:
+      - 'configMap'
+      - 'secret'
+      - 'emptyDir'
+    allowPrivilegeEscalation: false
+    hostNetwork: false
+    hostIPC: false
+    hostPID: false
+    # Make the root filesystem read-only. This is not compatible with Kong Enterprise <1.5.
+    # If you use Kong Enterprise <1.5, this must be set to false.
+    readOnlyRootFilesystem: true
 
 
 priorityClassName: ""


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds an option to control enforcing read-only root filesystem in the PodSecurityPolicy.

#### Special notes for your reviewer:
Prior work in https://github.com/helm/charts/pull/19663
* The issue where Enterprise wrote to root regardless of its prefix will be addressed in 1.5 (see FTI-1163 for internal discussion). Manual testing of upgrades and fresh installs of 1.5 preview builds confirmed that the issue is clear.
* The second issue with the container image no longer appears to be present. I was not able to reproduce it with either core 1.5, core 2.0, or Enterprise 1.5.
* The Postgres sub-chart does not play well with PSP automation, and requires creating a PSP independent of the chart (Bitnami does not provide a stock policy). It cannot reuse the ServiceAccount we create for Kong, as it both requires a writeable root filesystem and access to PVCs.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
