### PR TITLE
[kong] correct serviceMonitor.interval docs

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -400,12 +400,13 @@ For a complete list of all configuration values you can set in the
 | podDisruptionBudget.minAvailable   | Represents the number of Pods that must be available (integer or percentage)          |                     |
 | podSecurityPolicy.enabled          | Enable podSecurityPolicy for Kong                                                     | `false`             |
 | podSecurityPolicy.spec             | Collection of [PodSecurityPolicy settings](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#what-is-a-pod-security-policy) | |
-| priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | ""                  |
-| serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | false               |
-| serviceMonitor.interval            | Scraping interval                                                                     | 30s                 |
-| serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |
+| priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | `""`                |
 | secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
+| serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | `false`             |
+| serviceMonitor.interval            | Scraping interval                                                                     | `30s`               |
+| serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |
 | serviceMonitor.labels              | ServiceMonitor labels                                                                 | `{}`                |
+
 #### The `env` section
 
 The `env` section can be used to configured all properties of Kong.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -402,11 +402,10 @@ For a complete list of all configuration values you can set in the
 | podSecurityPolicy.spec             | Collection of [PodSecurityPolicy settings](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#what-is-a-pod-security-policy) | |
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | ""                  |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | false               |
-| serviceMonitor.interval            | Scrapping interval                                                                    | 10s                 |
+| serviceMonitor.interval            | Scraping interval                                                                     | 30s                 |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |
 | secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
-| serviceMonitor.labels              | ServiceMonito Labels                                                                  | {}                  |
-
+| serviceMonitor.labels              | ServiceMonitor labels                                                                 | `{}`                |
 #### The `env` section
 
 The `env` section can be used to configured all properties of Kong.


### PR DESCRIPTION
#### What this PR does / why we need it:

The scraping interval is not set in the `values.yaml` file of the Helm
chart. As such, the [default scraping][1] interval is used. This is
[actually 30s][2] and not 10s.

[1]:
https://github.com/coreos/prometheus-operator/blob/7ebf899f9768ead08ac7af6d59688d642cb8ef9c/pkg/prometheus/promcfg.go#L627-L629
[2]:
https://github.com/coreos/prometheus-operator/blob/7ebf899f9768ead08ac7af6d59688d642cb8ef9c/pkg/prometheus/promcfg.go#L175-L189

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
