### PR TITLE
[kong] target proxy with ServiceMonitor selector

### DIFF
--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -8,6 +8,7 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
   labels:
+    enable-metrics: "true"
     {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
   type: {{ .Values.proxy.type }}

--- a/charts/kong/templates/servicemonitor.yaml
+++ b/charts/kong/templates/servicemonitor.yaml
@@ -24,5 +24,6 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
+      enable-metrics: "true"
       {{- include "kong.metaLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
This commit limits the ServiceMonitor, so it only targets the proxy
Service resource instead of both the proxy and the admin Service.

#### What this PR does / why we need it:

When we set `serviceMonitor.enabled` to `true`, a `ServiceMonitor` resource is created, which targets both the admin `Service` and the proxy `Service`. The metrics are identical, which means they're doubled in in Prometheus. This change makes it so the `ServiceMonitor` only targets the proxy `Service`.

#### Special notes for your reviewer:

I didn't know which label we'd think would be appropriate, and since naming is hard, I opted to throw a strawman label into this PR, so we could discuss what we want here.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
