### PR TITLE
[kong] add additionalMatchLabels to ServiceMonitor

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -404,8 +404,9 @@ For a complete list of all configuration values you can set in the
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | false               |
 | serviceMonitor.interval            | Scrapping interval                                                                    | 10s                 |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |
-| secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
 | serviceMonitor.labels              | ServiceMonito Labels                                                                  | {}                  |
+| serviceMonitor.additionalMatchLabels | Add matchLabels selector to ServiceMonitor and corresponding label to proxy Service | `{}`                |
+| secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
 
 #### The `env` section
 

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- end }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalMatchLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalMatchLabels | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.proxy.type }}
   {{- if eq .Values.proxy.type "LoadBalancer" }}

--- a/charts/kong/templates/servicemonitor.yaml
+++ b/charts/kong/templates/servicemonitor.yaml
@@ -25,4 +25,7 @@ spec:
   selector:
     matchLabels:
       {{- include "kong.metaLabels" . | nindent 6 }}
+    {{- if .Values.serviceMonitor.additionalMatchLabels }}
+      {{- toYaml .Values.serviceMonitor.additionalMatchLabels | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -482,6 +482,8 @@ serviceMonitor:
   # namespace: monitoring
   # labels:
   #   foo: bar
+  # additionalMatchLabels:
+  #   foo: bar
 
 # -----------------------------------------------------------------------------
 # Kong Enterprise parameters


### PR DESCRIPTION
#### What this PR does / why we need it:

When we set `serviceMonitor.enabled` to true, a `ServiceMonitor`
resource is created, which targets both the admin `Service` and the
proxy `Service`. The metrics are identical, which means they're doubled
in in Prometheus.

This change makes it so it's possible to configure a label on the proxy
`Service`, which is used in the `matchLabels` selector on the
`ServiceMonitor`.

The reason this is optional is because setting it by default would break
reverse-compatibility for folks who may already be alerting on metrics
coming from the admin `Service`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
