### PR TITLE
[kong] Allow the proxy container's lifecycle hooks to be overridden

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -389,6 +389,7 @@ For a complete list of all configuration values you can set in the
 | updateStrategy                     | update strategy for deployment                                                        | `{}`                |
 | readinessProbe                     | Kong readiness probe                                                                  |                     |
 | livenessProbe                      | Kong liveness probe                                                                   |                     |
+| lifecycle                          | Proxy container lifecycle hooks                                                       | see `values.yaml`   |
 | affinity                           | Node/pod affinities                                                                   |                     |
 | nodeSelector                       | Node labels for pod assignment                                                        | `{}`                |
 | deploymentAnnotations              | Annotations to add to deployment                                                      |  see `values.yaml`  |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -63,9 +63,7 @@ spec:
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
         lifecycle:
-          preStop:
-            exec:
-              command: [ "/bin/sh", "-c", "kong quit" ]
+          {{- toYaml .Values.lifecycle | nindent 10 }}
         ports:
         {{/* TODO: remove legacy admin port template */}}
         {{- if .Values.admin.containerPort }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -397,6 +397,13 @@ livenessProbe:
   successThreshold: 1
   failureThreshold: 3
 
+# Proxy container lifecycle hooks
+# Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+lifecycle:
+  preStop:
+    exec:
+      command: ["/bin/sh", "-c", "/bin/sleep 15 && kong quit"]
+
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 # affinity: {}


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/master/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Allows the proxy container's lifecycle hooks to be overridden. In order to prevent dropped requests during the shutdown process, it can help to sleep first before signaling the shutdown to the container process. This gives `kube-proxy` and other ingress controllers time to remove the IP of the terminating pod from their iptables rules or load balancing configurations. There was a KubeCon NA talk that demonstrated this: [video](https://youtu.be/0o5C12kzEDI?t=329) + [slides](https://static.sched.com/hosted_files/kccncna19/f7/The%20Gotchas%20of%20Zero-Downtime%20Traffic.pdf)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes # N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
