### PR TITLE
[kong] add the ability to include adhoc pod labels

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -393,6 +393,7 @@ For a complete list of all configuration values you can set in the
 | nodeSelector                       | Node labels for pod assignment                                                        | `{}`                |
 | deploymentAnnotations              | Annotations to add to deployment                                                      |  see `values.yaml`  |
 | podAnnotations                     | Annotations to add to each pod                                                        | `{}`                |
+| podLabels                          | Labels to add to each pod                                                             | `{}`                |
 | resources                          | Pod resource requests & limits                                                        | `{}`                |
 | tolerations                        | List of node taints to tolerate                                                       | `[]`                |
 | podDisruptionBudget.enabled        | Enable PodDisruptionBudget for Kong                                                   | `false`             |

--- a/charts/kong/ci/test1-values.yaml
+++ b/charts/kong/ci/test1-values.yaml
@@ -17,6 +17,10 @@ ingressController:
   serviceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
+# - pod labels can be added to the deployment template
+podLabels:
+  app: kong
+  environment: test
 # - podSecurityPolicies are enabled
 podSecurityPolicy:
   enabled: true

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
         app.kubernetes.io/component: app
+        {{- if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -412,6 +412,9 @@ nodeSelector: {}
 # Annotation to be added to Kong pods
 podAnnotations: {}
 
+# Labels to be added to Kong pods
+podLabels: {}
+
 # Kong pod count
 replicaCount: 1
 

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,5 +4,5 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
-helm-extra-args: --timeout 200s
+helm-extra-args: --timeout 200
 check-version-increment: false

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,5 +4,5 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
-helm-extra-args: --timeout 200
+helm-extra-args: --timeout 200s
 check-version-increment: false


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds the ability to include adhoc pod labels.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [X] New or modified sections of values.yaml are documented in the README.md
- [X] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
