### PR TITLE
[kong] persistent volumes and local plugins

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -274,7 +274,7 @@ Kong can be configured via two methods:
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count                                                                   | `1`                 |
-| plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
+| plugins                            | Install custom plugins into Kong via ConfigMaps, Secrets or from file system          | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
@@ -402,6 +402,7 @@ For a complete list of all configuration values you can set in the
 | podSecurityPolicy.spec             | Collection of [PodSecurityPolicy settings](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#what-is-a-pod-security-policy) | |
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | `""`                |
 | secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
+| persistentVolumes                  | Mount existing PVC as a volume in Kong container to inject extra files e.g. custom plugins. | `[]`                |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | `false`             |
 | serviceMonitor.interval            | Scraping interval                                                                     | `30s`               |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -253,6 +253,11 @@ The name of the service used for the ingress controller's validation webhook
   secret:
     secretName: {{ . }}
 {{- end }}
+{{- range .Values.persistentVolumes }}
+- name: {{ .claimName }}
+  persistentVolumeClaim:
+    claimName: {{ .claimName }}
+{{- end }}
 {{- end -}}
 
 {{- define "kong.volumeMounts" -}}
@@ -292,6 +297,11 @@ The name of the service used for the ingress controller's validation webhook
   readOnly: true
 {{- end }}
 {{- end }}
+{{- range .Values.persistentVolumes }}
+- name: {{ .claimName }}
+  mountPath: {{ .mountPath }}
+  readOnly: true
+{{- end }}
 {{- end -}}
 
 {{- define "kong.plugins" -}}
@@ -300,8 +310,11 @@ The name of the service used for the ingress controller's validation webhook
 {{- $myList = append $myList .pluginName -}}
 {{- end -}}
 {{- range .Values.plugins.secrets -}}
-  {{ $myList = append $myList .pluginName -}}
-{{- end }}
+{{- $myList = append $myList .pluginName -}}
+{{- end -}}
+{{- range .Values.plugins.local -}}
+{{- $myList = append $myList .pluginName -}}
+{{- end -}}
 {{- $myList | join "," -}}
 {{- end -}}
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -198,6 +198,12 @@ proxy:
 # Subdirectories (which are optional) require separate ConfigMaps/Secrets.
 # "path" indicates their directory under the main plugin directory: the example
 # below will mount the contents of kong-plugin-rewriter-migrations at "/opt/kong/rewriter/migrations".
+# Additionally, it is possible to load plugins injected earlier (e.g. by persistent volume)
+# to file-system of Kong container. The `local` property allows to take advantage of this
+# feature. This may be useful for plugins written in Go programming language,
+# which are too large to store them in ConfigMap or Secret.
+# Rembember to set `go_plugins_dir` and/or `lua_package_path` configuration properties
+# in `env` section to make loaded plugins available to Kong.
 plugins: {}
   # configMaps:
   # - pluginName: rewriter
@@ -208,6 +214,8 @@ plugins: {}
   # secrets:
   # - pluginName: rewriter
   #   name: kong-plugin-rewriter
+  # local:
+  # - pluginName: rewriter
 # Inject specified secrets as a volume in Kong Container at path /etc/secrets/{secret-name}/
 # This can be used to override default SSL certificates.
 # Be aware that the secret name will be used verbatim, and that certain types
@@ -217,6 +225,13 @@ plugins: {}
 # - kong-proxy-tls
 # - kong-admin-tls
 secretVolumes: []
+# Mount existing PVC as a volume in Kong Container. Can be used for injecting
+# plugins, complex nginx configuration snippets, etc.
+# Example configuration
+# persistentVolumes
+# - claimName: kong-plugins
+#   mountPath: /plugins
+persistentVolumes: []
 
 # Enable/disable migration jobs, and set annotations for them
 migrations:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/master/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Add support for:
* mounting existing PVC as volumes in Kong Container
* loading plugins located on Kong container (e.g. on mounted PVC)

The motivation for this functionality was the need
to load plugins written in Golang, which are too large
to be stored in ConfigMap or Secret.
It can also be used for other purposes, e.g. injecting
complex nginx configuration snippets.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
