### PR TITLE
Use internal address for admin API when appropriate

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -60,7 +60,10 @@ Generic tool for creating KONG_PROXY_LISTEN, KONG_ADMIN_LISTEN, etc.
   {{- $unifiedListen := list -}}
 
   {{- if .http.enabled -}}
-    {{- $httpListen := (include "kong.singleListen" .http) -}}
+    {{- $listenConfig := dict -}}
+    {{- $listenConfig := merge $listenConfig .http -}}
+    {{- $_ := set $listenConfig "address" (default "0.0.0.0" .address) -}}
+    {{- $httpListen := (include "kong.singleListen" $listenConfig) -}}
     {{- $unifiedListen = append $unifiedListen $httpListen -}}
   {{- end -}}
 
@@ -72,11 +75,12 @@ Generic tool for creating KONG_PROXY_LISTEN, KONG_ADMIN_LISTEN, etc.
     https://github.com/helm/helm/issues/4987 indicates it should be. Instead,
     this creates a new object and new parameters list built from the original.
     */}}
-    {{- $tls := dict -}}
+    {{- $listenConfig := dict -}}
+    {{- $listenConfig := merge $listenConfig .tls -}}
     {{- $parameters := append .tls.parameters "ssl" -}}
-    {{- $_ := set $tls "containerPort" .tls.containerPort -}}
-    {{- $_ := set $tls "parameters" $parameters -}}
-    {{- $tlsListen := (include "kong.singleListen" $tls) -}}
+    {{- $_ := set $listenConfig "parameters" $parameters -}}
+    {{- $_ := set $listenConfig "address" (default "0.0.0.0" .address) -}}
+    {{- $tlsListen := (include "kong.singleListen" $listenConfig) -}}
     {{- $unifiedListen = append $unifiedListen $tlsListen -}}
   {{- end -}}
 
@@ -93,7 +97,10 @@ Create KONG_STREAM_LISTEN string
 {{- define "kong.streamListen" -}}
   {{- $unifiedListen := list -}}
   {{- range .stream -}}
-    {{- $unifiedListen = append $unifiedListen (include "kong.singleListen" . ) -}}
+    {{- $listenConfig := dict -}}
+    {{- $listenConfig := merge $listenConfig . -}}
+    {{- $_ := set $listenConfig "address" "0.0.0.0" -}}
+    {{- $unifiedListen = append $unifiedListen (include "kong.singleListen" $listenConfig ) -}}
   {{- end -}}
 
   {{- $listenString := ($unifiedListen | join ", ") -}}
@@ -108,7 +115,7 @@ Create a single listen (IP+port+parameter combo)
 */}}
 {{- define "kong.singleListen" -}}
   {{- $listen := list -}}
-  {{- $listen = append $listen (printf "0.0.0.0:%d" (int64 .containerPort)) -}}
+  {{- $listen = append $listen (printf "%s:%d" .address (int64 .containerPort)) -}}
   {{- range $param := .parameters | default (list) | uniq }}
     {{- $listen = append $listen $param -}}
   {{- end -}}
@@ -393,14 +400,23 @@ the template that it itself is using form the above sections.
 TODO: remove legacy admin listen behavior at a future date
 */}}
 
-{{- if .Values.admin.containerPort -}} {{/* Legacy admin listener */}}
-  {{- if .Values.admin.useTLS -}}
-    {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "0.0.0.0:%d ssl" (int64 .Values.admin.containerPort)) -}}
-  {{- else -}}
-    {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "0.0.0.0:%d" (int64 .Values.admin.containerPort)) -}}
+{{- with .Values.admin -}}
+  {{- $address := "0.0.0.0" -}}
+  {{- if (not .enabled) -}}
+    {{- $address = "127.0.0.1" -}}
   {{- end -}}
-{{- else -}} {{/* Modern admin listener */}}
-  {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (include "kong.listen" .Values.admin) -}}
+  {{- if .containerPort -}} {{/* Legacy admin listener */}}
+    {{- if .useTLS -}}
+      {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "%s:%d ssl" $address (int64 .containerPort)) -}}
+    {{- else -}}
+      {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "%s:%d" $address (int64 .containerPort)) -}}
+    {{- end -}}
+  {{- else -}} {{/* Modern admin listener */}}
+    {{- $listenConfig := dict -}}
+    {{- $listenConfig := merge $listenConfig . -}}
+    {{- $_ := set $listenConfig "address" $address -}}
+    {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (include "kong.listen" $listenConfig) -}}
+  {{- end -}}
 {{- end -}}
 
 {{- if .Values.admin.ingress.enabled }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           {{- toYaml .Values.lifecycle | nindent 10 }}
         ports:
         {{/* TODO: remove legacy admin port template */}}
-        {{- if .Values.admin.containerPort }}
+        {{- if (and .Values.admin.containerPort .Values.admin.enabled) }}
         - name: admin
           containerPort: {{ .Values.admin.containerPort }}
           {{- if .Values.admin.hostPort }}
@@ -77,7 +77,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.admin.http.enabled }}
+        {{- if (and .Values.admin.http.enabled .Values.admin.enabled) }}
         - name: admin
           containerPort: {{ .Values.admin.http.containerPort }}
           {{- if .Values.admin.http.hostPort }}
@@ -85,7 +85,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.admin.tls.enabled }}
+        {{- if (and .Values.admin.tls.enabled .Values.admin.enabled) }}
         - name: admin-tls
           containerPort: {{ .Values.admin.tls.containerPort }}
           {{- if .Values.admin.tls.hostPort }}
@@ -93,7 +93,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.proxy.http.enabled }}
+        {{- if (and .Values.proxy.http.enabled .Values.proxy.enabled) }}
         - name: proxy
           containerPort: {{ .Values.proxy.http.containerPort }}
           {{- if .Values.proxy.http.hostPort }}
@@ -101,7 +101,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.proxy.tls.enabled }}
+        {{- if (and .Values.proxy.tls.enabled .Values.proxy.enabled)}}
         - name: proxy-tls
           containerPort: {{ .Values.proxy.tls.containerPort }}
           {{- if .Values.proxy.tls.hostPort }}
@@ -117,7 +117,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.status.http.enabled }}
+        {{- if (and .Values.status.http.enabled .Values.status.enabled)}}
         - name: status
           containerPort: {{ .Values.status.http.containerPort }}
           {{- if .Values.status.http.hostPort }}
@@ -125,7 +125,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.status.tls.enabled }}
+        {{- if (and .Values.status.tls.enabled .Values.status.enabled) }}
         - name: status-tls
           containerPort: {{ .Values.status.tls.containerPort }}
           {{- if .Values.status.tls.hostPort }}
@@ -142,7 +142,7 @@ spec:
           protocol: TCP
         {{- end }}
         {{- if .Values.enterprise.enabled }}
-        {{- if .Values.manager.http.enabled }}
+        {{- if (and .Values.manager.http.enabled .Values.manager.enabled) }}
         - name: manager
           containerPort: {{ .Values.manager.http.containerPort }}
           {{- if .Values.manager.http.hostPort }}
@@ -150,7 +150,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.manager.tls.enabled }}
+        {{- if (and .Values.manager.tls.enabled .Values.manager.enabled) }}
         - name: manager-tls
           containerPort: {{ .Values.manager.tls.containerPort }}
           {{- if .Values.manager.tls.hostPort }}
@@ -158,7 +158,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.portal.http.enabled }}
+        {{- if (and .Values.portal.http.enabled .Values.portal.enabled) }}
         - name: portal
           containerPort: {{ .Values.portal.http.containerPort }}
           {{- if .Values.portal.http.hostPort }}
@@ -166,7 +166,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.portal.tls.enabled }}
+        {{- if (and .Values.portal.tls.enabled .Values.portal.enabled) }}
         - name: portal-tls
           containerPort: {{ .Values.portal.tls.containerPort }}
           {{- if .Values.portal.tls.hostPort }}
@@ -174,7 +174,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.portalapi.http.enabled }}
+        {{- if (and .Values.portalapi.http.enabled .Values.portalapi.enabled) }}
         - name: portalapi
           containerPort: {{ .Values.portalapi.http.containerPort }}
           {{- if .Values.portalapi.http.hostPort }}
@@ -182,7 +182,7 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
-        {{- if .Values.portalapi.tls.enabled }}
+        {{- if (and .Values.portalapi.tls.enabled .Values.portalapi.enabled) }}
         - name: portalapi-tls
           containerPort: {{ .Values.portalapi.tls.containerPort }}
           {{- if .Values.portalapi.tls.hostPort }}


### PR DESCRIPTION
#### What this PR does / why we need it:
If the admin service is disabled, but the admin listens are enabled (i.e. the configuration we expect for controller-managed instances), use `127.0.0.1` for the admin listen address to prevent access from outside the pod.

Additionally:
* If a service's service is disabled, but its listens are enabled, do not render port information for that service in the Kong container template.
* Listens now support specifying the address in general in the template, but currently only the admin API makes use of this, as I'm not aware of any situation where it's useful for the other services--although they support the same service disabled/listens enabled configuration, we shouldn't encounter that in the wild, and they don't have the same security concerns as the admin API.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
