### PR TITLE
[kong] add settings to specify images with a single string

### DIFF
--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -1,0 +1,15 @@
+# install chart with default values
+# use single image strings instead of repository/tag
+
+image:
+  single: kong:2.0
+proxy:
+  type: NodePort
+
+env:
+  anonymous_reports: "off"
+ingressController:
+  env:
+    anonymous_reports: "false"
+  image:
+    single: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.8.1

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -348,7 +348,7 @@ The name of the service used for the ingress controller's validation webhook
         apiVersion: v1
         fieldPath: metadata.namespace
 {{- include "kong.ingressController.env" .  | indent 2 }}
-{{- if .Values.image.single }}
+{{- if .Values.ingressController.image.single }}
   image: "{{ .Values.ingressController.image.single }}"
 {{- else }}
   image: "{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -314,8 +314,8 @@ The name of the service used for the ingress controller's validation webhook
 
 {{- define "kong.wait-for-db" -}}
 - name: wait-for-db
-{{- if .Values.image.single }}
-  image: "{{ .Values.image.single }}"
+{{- if .Values.image.unifiedRepoTag }}
+  image: "{{ .Values.image.unifiedRepoTag }}"
 {{- else }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 {{- end }}
@@ -348,8 +348,8 @@ The name of the service used for the ingress controller's validation webhook
         apiVersion: v1
         fieldPath: metadata.namespace
 {{- include "kong.ingressController.env" .  | indent 2 }}
-{{- if .Values.ingressController.image.single }}
-  image: "{{ .Values.ingressController.image.single }}"
+{{- if .Values.ingressController.image.unifiedRepoTag }}
+  image: "{{ .Values.ingressController.image.unifiedRepoTag }}"
 {{- else }}
   image: "{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"
 {{- end }}
@@ -578,8 +578,8 @@ Environment variables are sorted alphabetically
 
 {{- define "kong.wait-for-postgres" -}}
 - name: wait-for-postgres
-{{- if .Values.waitImage.single }}
-  image: "{{ .Values.waitImage.single }}"
+{{- if .Values.waitImage.unifiedRepoTag }}
+  image: "{{ .Values.waitImage.unifiedRepoTag }}"
 {{- else }}
   image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
 {{- end }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -314,7 +314,11 @@ The name of the service used for the ingress controller's validation webhook
 
 {{- define "kong.wait-for-db" -}}
 - name: wait-for-db
+{{- if .Values.image.single }}
+  image: "{{ .Values.image.single }}"
+{{- else }}
   image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+{{- end }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   env:
   {{- include "kong.env" . | nindent 2 }}
@@ -344,7 +348,11 @@ The name of the service used for the ingress controller's validation webhook
         apiVersion: v1
         fieldPath: metadata.namespace
 {{- include "kong.ingressController.env" .  | indent 2 }}
+{{- if .Values.image.single }}
+  image: "{{ .Values.ingressController.image.single }}"
+{{- else }}
   image: "{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"
+{{- end }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   readinessProbe:
 {{ toYaml .Values.ingressController.readinessProbe | indent 4 }}
@@ -570,7 +578,11 @@ Environment variables are sorted alphabetically
 
 {{- define "kong.wait-for-postgres" -}}
 - name: wait-for-postgres
+{{- if .Values.waitImage.single }}
+  image: "{{ .Values.ingressController.image.single }}"
+{{- else }}
   image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+{{- end }}
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:
   {{- include "kong.no_daemon_env" . | nindent 2 }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -579,7 +579,7 @@ Environment variables are sorted alphabetically
 {{- define "kong.wait-for-postgres" -}}
 - name: wait-for-postgres
 {{- if .Values.waitImage.single }}
-  image: "{{ .Values.ingressController.image.single }}"
+  image: "{{ .Values.waitImage.single }}"
 {{- else }}
   image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
 {{- end }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -61,8 +61,8 @@ spec:
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
       - name: "proxy"
-        {{- if .Values.image.single }}
-        image: "{{ .Values.image.single }}"
+        {{- if .Values.image.unifiedRepoTag }}
+        image: "{{ .Values.image.unifiedRepoTag }}"
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- end }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -61,7 +61,11 @@ spec:
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
       - name: "proxy"
+        {{- if .Values.image.single }}
+        image: "{{ .Values.image.single }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -38,8 +38,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations
-        {{- if .Values.image.single }}
-        image: "{{ .Values.image.single }}"
+        {{- if .Values.image.unifiedRepoTag }}
+        image: "{{ .Values.image.unifiedRepoTag }}"
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- end }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -38,7 +38,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations
+        {{- if .Values.image.single }}
+        image: "{{ .Values.image.single }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -38,7 +38,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations
+        {{- if .Values.image.single }}
+        image: "{{ .Values.image.single }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -38,8 +38,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations
-        {{- if .Values.image.single }}
-        image: "{{ .Values.image.single }}"
+        {{- if .Values.image.unifiedRepoTag }}
+        image: "{{ .Values.image.unifiedRepoTag }}"
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -38,8 +38,8 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations
-        {{- if .Values.image.single }}
-        image: "{{ .Values.image.single }}"
+        {{- if .Values.image.unifiedRepoTag }}
+        image: "{{ .Values.image.unifiedRepoTag }}"
         {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -38,7 +38,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations
+        {{- if .Values.image.single }}
+        image: "{{ .Values.image.single }}"
+        {{- else }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for specifying the Kong and Kong Ingress Controller images via a single string.

#### Special notes for your reviewer:
This is necessary to satisfy offline operator constraints. We need a way to override images anyway to specify the versions on RHCC, so may as well kill two birds with one PR.

See https://github.com/Kong/kong-operator/blob/fork/operatorhub/watches.yaml#L7-L9 and https://github.com/Kong/kong-operator/blob/fork/operatorhub/olm/0.2.6/kong.v0.2.6.clusterserviceversion.yaml#L142-L145 for draft usage.

These are intentionally omitted from documentation, as they are not intended for general usage, only by the operator.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
