### PR TITLE
[kong] add support for controller-only deployments

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -310,7 +310,6 @@ directory.
 
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| enabled                            | Enable or disable deploying Kong                                                      | `true`              |
 | image.repository                   | Kong image                                                                            | `kong`              |
 | image.tag                          | Kong image version                                                                    | `2.0`               |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
@@ -422,6 +421,7 @@ For a complete list of all configuration values you can set in the
 
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |
 | autoscaling.minReplicas            | Set minimum number of replicas                                                        | `2`                 |
 | autoscaling.maxReplicas            | Set maximum number of replicas                                                        | `5`                 |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -35,6 +35,8 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
   - [Configuration method](#configuration-method)
   - [Separate admin and proxy nodes](#separate-admin-and-proxy-nodes)
   - [Standalone controller nodes](#standalone-controller-nodes)
+  - [CRDs only](#crds-only)
+  - [Example configurations](#example-configurations)
 - [Configuration](#configuration)
   - [Kong Parameters](#kong-parameters)
     - [Kong Service Parameters](#kong-service-parameters)
@@ -267,9 +269,9 @@ helm install admin-only -f shared-values.yaml -f only-admin.yaml kong/kong
 ### Standalone controller nodes
 
 The chart can deploy releases that contain the controller only, with no Kong
-container, by setting `enabled: false` in values.yaml. There are several
-controller settings that must be populated manually in this scenario and
-several settings that are useful when using multiple controllers:
+container, by setting `deployment.kong.enabled: false` in values.yaml. There
+are several controller settings that must be populated manually in this
+scenario and several settings that are useful when using multiple controllers:
 
 * `ingressController.env.kong_admin_url` must be set to the Kong Admin API URL.
   If the Admin API is exposed by a service in the cluster, this should look
@@ -286,7 +288,7 @@ several settings that are useful when using multiple controllers:
 Standalone controllers require a database-backed Kong instance, as DB-less mode
 requires that a single controller generate a complete Kong configuration.
 
-### Configuration method
+### CRDs only
 
 For Helm 2 installations, CRDs are managed as part of a release, and are
 deleted if the release is. This can cause issues for clusters with multiple

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -34,8 +34,7 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
   - [Runtime package](#runtime-package)
   - [Configuration method](#configuration-method)
   - [Separate admin and proxy nodes](#separate-admin-and-proxy-nodes)
-  - [CRDs only](#crds-only)
-  - [Example configurations](#example-configurations)
+  - [Standalone controller nodes](#standalone-controller-nodes)
 - [Configuration](#configuration)
   - [Kong Parameters](#kong-parameters)
     - [Kong Service Parameters](#kong-service-parameters)
@@ -265,7 +264,29 @@ helm install proxy-only -f shared-values.yaml -f only-proxy.yaml kong/kong
 helm install admin-only -f shared-values.yaml -f only-admin.yaml kong/kong
 ```
 
-### CRDs only
+### Standalone controller nodes
+
+The chart can deploy releases that contain the controller only, with no Kong
+container, by setting `enabled: false` in values.yaml. There are several
+controller settings that must be populated manually in this scenario and
+several settings that are useful when using multiple controllers:
+
+* `ingressController.env.kong_admin_url` must be set to the Kong Admin API URL.
+  If the Admin API is exposed by a service in the cluster, this should look
+  something like `https://my-release-kong-admin.kong-namespace.svc:8444`
+* `ingressController.env.publish_service` must be set to the Kong proxy
+  service, e.g. `namespace/my-release-kong-proxy`.
+* `ingressController.ingressClass` should be set to a different value for each
+  instance of the controller.
+* `ingressController.env.admin_filter_tag` should be set to a different value
+  for each instance of the controller.
+* If using Kong Enterprise, `ingressController.env.kong_workspace` can
+  optionally create configuration in a workspace other than `default`.
+
+Standalone controllers require a database-backed Kong instance, as DB-less mode
+requires that a single controller generate a complete Kong configuration.
+
+### Configuration method
 
 For Helm 2 installations, CRDs are managed as part of a release, and are
 deleted if the release is. This can cause issues for clusters with multiple
@@ -289,6 +310,7 @@ directory.
 
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| enabled                            | Enable or disable deploying Kong                                                      | `true`              |
 | image.repository                   | Kong image                                                                            | `kong`              |
 | image.tag                          | Kong image version                                                                    | `2.0`               |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -238,7 +238,7 @@ The name of the service used for the ingress controller's validation webhook
     secretName: {{ .name }}
 {{- end }}
 {{- end }}
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 - name: custom-nginx-template-volume
   configMap:
     name: {{ template "kong.fullname" . }}-default-custom-server-blocks

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -238,9 +238,11 @@ The name of the service used for the ingress controller's validation webhook
     secretName: {{ .name }}
 {{- end }}
 {{- end }}
+{{- if .Values.enabled }}
 - name: custom-nginx-template-volume
   configMap:
     name: {{ template "kong.fullname" . }}-default-custom-server-blocks
+{{- end }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 - name: kong-custom-dbless-config-volume
   configMap:

--- a/charts/kong/templates/config-custom-server-blocks.yaml
+++ b/charts/kong/templates/config-custom-server-blocks.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,3 +29,4 @@ data:
             stub_status;
         }
     }
+{{- end }}

--- a/charts/kong/templates/config-custom-server-blocks.yaml
+++ b/charts/kong/templates/config-custom-server-blocks.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 {{- if not .Values.dblessConfig.configMap }}
 apiVersion: v1

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 {{- if not .Values.dblessConfig.configMap }}
 apiVersion: v1
@@ -9,5 +10,6 @@ metadata:
 data:
   kong.yml: |
 {{ .Values.dblessConfig.config | toYaml | indent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/custom-resource-definitions.yaml
+++ b/charts/kong/templates/custom-resource-definitions.yaml
@@ -1,4 +1,4 @@
-{{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (not (or .Values.enabled .Values.ingressController.enabled))) -}}
+{{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (and (not (or .Values.enabled .Values.ingressController.enabled )) .Values.ingressController.installCRDs)) -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{ $.Files.Get $path }}
 ---

--- a/charts/kong/templates/custom-resource-definitions.yaml
+++ b/charts/kong/templates/custom-resource-definitions.yaml
@@ -1,4 +1,4 @@
-{{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (and (not (or .Values.enabled .Values.ingressController.enabled )) .Values.ingressController.installCRDs)) -}}
+{{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (and (not (or .Values.deployment.kong.enabled .Values.ingressController.enabled )) .Values.ingressController.installCRDs)) -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{ $.Files.Get $path }}
 ---

--- a/charts/kong/templates/custom-resource-definitions.yaml
+++ b/charts/kong/templates/custom-resource-definitions.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingressController.enabled .Values.ingressController.installCRDs -}}
+{{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (not (or .Values.enabled .Values.ingressController.enabled))) -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{ $.Files.Get $path }}
 ---

--- a/charts/kong/templates/custom-resource-definitions.yaml
+++ b/charts/kong/templates/custom-resource-definitions.yaml
@@ -1,3 +1,8 @@
+{{/*
+This handles two cases where we should render this template. These map to the two top-level or clauses:
+- This is a controller-managed Helm 2 install. The controller is enabled and installCRDs is enabled.
+- This is a CRD-only install. Neither the controller nor Kong are enabled (the "not or") and installCRDs is enabled.
+*/}}
 {{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (and (not (or .Values.deployment.kong.enabled .Values.ingressController.enabled )) .Values.ingressController.installCRDs)) -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{ $.Files.Get $path }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -53,13 +53,16 @@ spec:
       {{- end }}
       {{- end }}
       {{- if not (eq .Values.env.database "off") }}
+      {{- if .Values.enabled }}
       initContainers:
       {{- include "kong.wait-for-db" . | nindent 6 }}
+      {{ end }}
       {{ end }}
       containers:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
+      {{- if .Values.enabled }}
       - name: "proxy"
         {{- if .Values.image.unifiedRepoTag }}
         image: "{{ .Values.image.unifiedRepoTag }}"
@@ -193,6 +196,7 @@ spec:
           hostPort: {{ .Values.portalapi.tls.hostPort }}
           {{- end}}
           protocol: TCP
+        {{- end }}
         {{- end }}
         {{- end }}
         volumeMounts:

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.enabled .Values.ingressController.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -221,3 +222,4 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
       volumes:
       {{- include "kong.volumes" . | nindent 8 -}}
+{{- end }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.enabled .Values.ingressController.enabled }}
+{{- if or .Values.deployment.kong.enabled .Values.ingressController.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,7 +54,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if not (eq .Values.env.database "off") }}
-      {{- if .Values.enabled }}
+      {{- if .Values.deployment.kong.enabled }}
       initContainers:
       {{- include "kong.wait-for-db" . | nindent 6 }}
       {{ end }}
@@ -63,7 +63,7 @@ spec:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
-      {{- if .Values.enabled }}
+      {{- if .Values.deployment.kong.enabled }}
       - name: "proxy"
         {{- if .Values.image.unifiedRepoTag }}
         image: "{{ .Values.image.unifiedRepoTag }}"

--- a/charts/kong/templates/ingress-admin.yaml
+++ b/charts/kong/templates/ingress-admin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.admin.ingress.enabled -}}
 {{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 {{- $serviceName := include "kong.fullname" . -}}
@@ -61,5 +62,6 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/ingress-admin.yaml
+++ b/charts/kong/templates/ingress-admin.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.admin.ingress.enabled -}}
 {{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 {{- $serviceName := include "kong.fullname" . -}}

--- a/charts/kong/templates/ingress-manager.yaml
+++ b/charts/kong/templates/ingress-manager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.manager.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
@@ -30,5 +31,6 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/ingress-manager.yaml
+++ b/charts/kong/templates/ingress-manager.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.manager.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}

--- a/charts/kong/templates/ingress-portal-api.yaml
+++ b/charts/kong/templates/ingress-portal-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.portalapi.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}

--- a/charts/kong/templates/ingress-portal-api.yaml
+++ b/charts/kong/templates/ingress-portal-api.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.portalapi.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
@@ -30,5 +31,6 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/ingress-portal.yaml
+++ b/charts/kong/templates/ingress-portal.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.portal.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
@@ -30,5 +31,6 @@ spec:
     - {{ $hostname }}
     secretName: {{ $tls }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/ingress-portal.yaml
+++ b/charts/kong/templates/ingress-portal.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.portal.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}

--- a/charts/kong/templates/ingress-proxy.yaml
+++ b/charts/kong/templates/ingress-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.proxy.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
@@ -37,4 +38,5 @@ spec:
   tls:
 {{ toYaml .Values.proxy.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/ingress-proxy.yaml
+++ b/charts/kong/templates/ingress-proxy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.proxy.ingress.enabled -}}
 {{- $serviceName := include "kong.fullname" . -}}
 {{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if (and (or (.Values.runMigrations) (.Values.migrations.postUpgrade)) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
@@ -54,4 +55,5 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
+{{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if (and (or (.Values.runMigrations) (.Values.migrations.postUpgrade)) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if (and (or (.Values.runMigrations) (.Values.migrations.preUpgrade)) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if (and (or (.Values.runMigrations) (.Values.migrations.preUpgrade)) (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
@@ -54,4 +55,5 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
+{{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Release.IsInstall -}}
 {{/* .migrations.init isn't normally exposed in values.yaml. In testing,
 however, adding it with value "false" didn't actually disable this job. Not

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Release.IsInstall -}}
 {{/* .migrations.init isn't normally exposed in values.yaml. In testing,
 however, adding it with value "false" didn't actually disable this job. Not
@@ -54,5 +55,6 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 {{- if .Values.admin.enabled -}}
 apiVersion: v1

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
 {{- if .Values.admin.enabled -}}
 apiVersion: v1
@@ -84,5 +85,6 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-manager.yaml
+++ b/charts/kong/templates/service-kong-manager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.manager.enabled (or .Values.manager.http.enabled .Values.manager.tls.enabled) -}}
 apiVersion: v1
@@ -48,5 +49,6 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-manager.yaml
+++ b/charts/kong/templates/service-kong-manager.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.manager.enabled (or .Values.manager.http.enabled .Values.manager.tls.enabled) -}}
 apiVersion: v1

--- a/charts/kong/templates/service-kong-portal-api.yaml
+++ b/charts/kong/templates/service-kong-portal-api.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.portalapi.enabled (or .Values.portalapi.http.enabled .Values.portalapi.tls.enabled) -}}
 apiVersion: v1

--- a/charts/kong/templates/service-kong-portal-api.yaml
+++ b/charts/kong/templates/service-kong-portal-api.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.portalapi.enabled (or .Values.portalapi.http.enabled .Values.portalapi.tls.enabled) -}}
 apiVersion: v1
@@ -48,5 +49,6 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-portal.yaml
+++ b/charts/kong/templates/service-kong-portal.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.portal.enabled (or .Values.portal.http.enabled .Values.portal.tls.enabled) -}}
 apiVersion: v1
@@ -48,5 +49,6 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-portal.yaml
+++ b/charts/kong/templates/service-kong-portal.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if .Values.enterprise.enabled }}
 {{- if and .Values.portal.enabled (or .Values.portal.http.enabled .Values.portal.tls.enabled) -}}
 apiVersion: v1

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if and .Values.proxy.enabled (or .Values.proxy.http.enabled .Values.proxy.tls.enabled) -}}
 apiVersion: v1
 kind: Service
@@ -64,4 +65,5 @@ spec:
   {{- end }}
   selector:
     {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.enabled }}
+{{- if .Values.deployment.kong.enabled }}
 {{- if and .Values.proxy.enabled (or .Values.proxy.http.enabled .Values.proxy.tls.enabled) -}}
 apiVersion: v1
 kind: Service

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -2,6 +2,7 @@
 # Declare variables to be passed into your templates.
 #
 # Sections:
+# - Deployment parameters
 # - Kong parameters
 # - Ingress Controller parameters
 # - Postgres sub-chart parameters
@@ -9,13 +10,19 @@
 # - Kong Enterprise parameters
 
 # -----------------------------------------------------------------------------
-# Kong parameters
+# Deployment parameters
 # -----------------------------------------------------------------------------
 
-# Enable or disable Kong itself
-# Setting this to false with ingressController.enabled=true will create a
-# controller-only release.
-enabled: true
+deployment:
+  kong:
+    # Enable or disable Kong itself
+    # Setting this to false with ingressController.enabled=true will create a
+    # controller-only release.
+    enabled: true
+
+# -----------------------------------------------------------------------------
+# Kong parameters
+# -----------------------------------------------------------------------------
 
 # Specify Kong configurations
 # Kong configurations guide https://docs.konghq.com/latest/configuration

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -12,6 +12,11 @@
 # Kong parameters
 # -----------------------------------------------------------------------------
 
+# Enable or disable Kong itself
+# Setting this to false with ingressController.enabled=true will create a
+# controller-only release.
+enabled: true
+
 # Specify Kong configurations
 # Kong configurations guide https://docs.konghq.com/latest/configuration
 # Values here take precedence over values from other sections of values.yaml,


### PR DESCRIPTION
#### What this PR does / why we need it:
Add a new `enabled` setting to values.yaml. When set to `true`, Kong and associated resources are rendered. When set to false, they are not.

This allows deploying the controller alone, which has been requested often.

#### Special notes for your reviewer:
CCed Satwant as he asked about this recently.

I'm not thrilled about the naming, and feel like we should eventually move the Kong-specific top-level configuration under a `kong` block. That's breaking, however, so we can't do it in the near future.

Thoughts on whether there's some better name we can use for this?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
