### PR TITLE
[kong] remove default securityContext

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -403,6 +403,7 @@ For a complete list of all configuration values you can set in the
 | podSecurityPolicy.spec             | Collection of [PodSecurityPolicy settings](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#what-is-a-pod-security-policy) | |
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | `""`                |
 | secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
+| securityContext                    | Set the securityContext for Kong Pods                                                 | `{}`                |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | `false`             |
 | serviceMonitor.interval            | Scraping interval                                                                     | `30s`               |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -481,8 +481,7 @@ podSecurityPolicy:
 priorityClassName: ""
 
 # securityContext for Kong pods.
-securityContext:
-  runAsUser: 1000
+securityContext: {}
 
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created


### PR DESCRIPTION
#### What this PR does / why we need it:
Removes the default security context (which ran the container as UID 1000). This does not appear to be necessary and removing it improves compatibility with OpenShift.

#### Which issue this PR fixes
  - fixes #137 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
