### PR TITLE
[kong] release 1.6.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 1.6.0
+
+### Improvements
+
+* Updated default controller version to 0.9.0.
+  ([#132](https://github.com/Kong/charts/pull/132))
+* Updated default Enterprise versions to 2.0.4.1 and 1.5.0.2.
+  ([#130](https://github.com/Kong/charts/pull/130))
+* Added ability to override chart lifecycle.
+  ([#116](https://github.com/Kong/charts/pull/116))
+* Added ability to apply user-defined labels to pods.
+  ([#121](https://github.com/Kong/charts/pull/121))
+* Filtered serviceMonitor to disable metrics collection from non-proxy
+  services. 
+  ([#112](https://github.com/Kong/charts/pull/112))
+* Set admin API to listen on localhost only if possible.
+  ([#125](https://github.com/Kong/charts/pull/125))
+* Add `auth_type` and `ssl` settings to `smtp` block. 
+  ([#127](https://github.com/Kong/charts/pull/127))
+* Remove UID from default securityContext.
+  ([#138](https://github.com/Kong/charts/pull/138))
+
+### Documentation
+
+* Corrected invalid default serviceMonitor.interval value.
+  ([#110](https://github.com/Kong/charts/pull/110))
+* Removed duplicate `installCRDs` documentation.
+  ([#115](https://github.com/Kong/charts/pull/115))
+* Simplified example license Secret creation command.
+  ([#131](https://github.com/Kong/charts/pull/131))
+
 ## 1.5.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.5.0
+version: 1.6.0
 appVersion: 2.0

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -13,6 +13,7 @@ install/status/upgrade`.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [1.6.0](#160)
 - [1.5.0](#150)
 - [1.4.0](#140)
 - [1.3.0](#130)
@@ -46,6 +47,38 @@ text ending with `field is immutable`. This is typically due to a bug with the
 `init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+## 1.6.0
+
+### Changes to Custom Resource Definitions
+
+The KongPlugin and KongClusterPlugin resources have changed. Helm 3's CRD
+management system does not modify CRDs during `helm upgrade`, and these must be
+updated manually:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/Kong/charts/kong-1.6.0/charts/kong/crds/custom-resource-definitions.yaml
+```
+
+Existing plugin resources do not require changes; the CRD update only adds new
+fields.
+
+### Removal of default security context UID setting
+
+Versions of Kong prior to 2.0 and Kong Enterprise prior to 1.3 use Docker
+images that required setting a UID via Kubernetes in some environments
+(primarily OpenShift). This is no longer necessary with modern Docker images
+and can cause issues depending on other environment settings, so it was
+removed.
+
+Most users should not need to take any action, but if you encounter permissions
+errors when upgrading (`kubectl describe pod PODNAME` should contain any), you
+can restore it by adding the following to your values.yaml:
+
+```
+securityContext:
+  runAsUser: 1000
+```
 
 ## 1.5.0
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases version 1.6.0 of the Kong chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
