### PR TITLE
[kong] Add support for SSL connections to Postgres

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -172,6 +172,15 @@ the support has now been dropped due to stability issues.
 You can still deploy Cassandra on your own and configure Kong to use
 that via the `env.database` parameter.
 
+### Enabling SSL for Postgres connections
+
+For Postgres SSL connections you will need to provide the client certificate.
+This can be done via a secret that needs to be created in advance. More information about kubernetes secrets can be found
+[here](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+Once the secret has been created, SSL can be enabled using the `pgSSL.enabled` parameter. The secret name and the key 
+name can be specified via the `pgCertSecretName` and `pgCertSecretDataKeyName` parameters. 
+
 #### DB-less  deployment
 
 When deploying Kong in DB-less mode(`env.database: "off"`)

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -437,6 +437,16 @@ podLabels: {}
 # Kong pod count
 replicaCount: 1
 
+# Enable SSL connection to Postgres. To be used when env database: "postgres"
+pgSSL:
+  # Enable SSL connections to Postgres.
+  # Enabling this will start kong with KONG_PG_SSL: 'on' and KONG_PG_SSL_VERIFY: 'on'
+  enabled: false
+  # A secret containing the ssl certificate should be created in advance.
+  # This is required in order to specify the KONG_LUA_SSL_TRUSTED_CERTIFICATE
+  pgCertSecretName: ""
+  pgCertSecretDataKeyName: ""
+
 # Annotations to be added to Kong deployment
 deploymentAnnotations:
   kuma.io/gateway: enabled


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/master/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Chart deployment fails when SSL is forced on Postgres. This PR is adding the ability to set the client certificate for Postgres SSL connections. 

#### Which issue this PR fixes

  - fixes #5423

#### Special notes for your reviewer:
In order to test the change:

Create a `pg_secret.yml` file with the following content, adding your base-64 encoded certificate:

```
apiVersion: v1
kind: Secret
metadata:
  name: kong-pg-cert
data:
  pg-cert.pem: Q0xJRU5UIENFUlRJRklDQVRFIFRPIEJFIElOU1RFUlRFRCBIRVJF
```
Create the certificate:

`kubectl create -f pg_secret.yml`

Update `values.yml` accordingly:

```
pgSSL:
  enabled: true
  pgCertSecretName: "kong-pg-cert"
  pgCertSecretDataKeyName: "pg-cert.pem"
```

#### Checklist

- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
