### PR TITLE
clusterroles become roles for restricted clusters

### DIFF
--- a/charts/kong/templates/controller-rbac-resources.yaml
+++ b/charts/kong/templates/controller-rbac-resources.yaml
@@ -59,11 +59,17 @@ subjects:
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- if .Values.ingressController.rbac.clusterroles.enabled }}
 kind: ClusterRole
 metadata:
+  name:  {{ template "kong.fullname" . }}
+{{- else }}
+kind: Role
+metadata:
+  name:  {{ template "kong.fullname" . }}-role
+{{- end }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-  name:  {{ template "kong.fullname" . }}
 rules:
   - apiGroups:
       - ""
@@ -135,15 +141,26 @@ rules:
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- if .Values.ingressController.rbac.clusterroles.enabled }}
 kind: ClusterRoleBinding
 metadata:
   name:  {{ template "kong.fullname" . }}
+{{- else }}
+kind: RoleBinding
+metadata:
+  name:  {{ template "kong.fullname" . }}-rolebind
+{{- end }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.ingressController.rbac.clusterroles.enabled }}
   kind: ClusterRole
   name:  {{ template "kong.fullname" . }}
+{{- else }}
+  kind: Role
+  name:  {{ template "kong.fullname" . }}-role
+{{- end }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "kong.serviceAccountName" . }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -302,7 +302,11 @@ ingressController:
   rbac:
     # Specifies whether RBAC resources should be created
     create: true
-    # Restricted clusters won't allow clusterroles
+    # Create cluster roles
+    # Cluster roles allow the controller to use resources from all namespaces for Kong configuration
+    # Depending on your K8S cluster configuration, you may not be able to create cluster roles, and can
+    # disable this setting if so. This limits the controller to resources in the namespace it's installed in,
+    # and should be used along with "ingressController.env.watch_namespace: INSTALL_NAMEPSACE"
     clusterroles:
       enabled: true
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -302,6 +302,9 @@ ingressController:
   rbac:
     # Specifies whether RBAC resources should be created
     create: true
+    # Restricted clusters won't allow clusterroles
+    clusterroles:
+      enabled: true
 
   serviceAccount:
     # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION

#### What this PR does / why we need it:

#### Which issue this PR fixes

This is somewhat related to https://github.com/Kong/charts/issues/152

#### Special notes for your reviewer:

#### Checklist

This PR makes ClusterRoles changeable into Roles for single-namespace deployments is restricted clusters.

