### PR TITLE
PR template: allow master for non-breaking changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,6 @@ when it is merged.
 
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
-- [ ] PR is based off the current tip of the `next` branch and targets `next`, not `master`
+- [ ] The PR is a non-breaking change and it targets `master` **OR** the PR is a breaking change and it targets `next`
 - [ ] New or modified sections of values.yaml are documented in the README.md
 - [ ] Title of the PR and commit headers start with chart name (e.g. `[kong]`)


### PR DESCRIPTION
This PR updates the pull request template to allow non-breaking changes to go to `master` instead of `next`.

Following an out-of-band discussion with @hbagdi.
