### PR TITLE
[kong] define KONG_PORT_MAPS for the proxy service

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -92,6 +92,25 @@ Generic tool for creating KONG_PROXY_LISTEN, KONG_ADMIN_LISTEN, etc.
 {{- end -}}
 
 {{/*
+Create KONG_PORT_MAPS string
+Parameters: takes a service (e.g. .Values.proxy) as its argument and returns KONG_PORT_MAPS for that service.
+*/}}
+{{- define "kong.port_maps" -}}
+  {{- $portMaps := list -}}
+
+  {{- if .http.enabled -}}
+		{{- $portMaps = append $portMaps (printf "%d:%d" (int64 .http.servicePort) (int64 .http.containerPort)) -}}
+  {{- end -}}
+
+  {{- if .tls.enabled -}}
+		{{- $portMaps = append $portMaps (printf "%d:%d" (int64 .tls.servicePort) (int64 .tls.containerPort)) -}}
+  {{- end -}}
+
+  {{- $portMapsString := ($portMaps | join ", ") -}}
+  {{- $portMapsString -}}
+{{- end -}}
+
+{{/*
 Create KONG_STREAM_LISTEN string
 */}}
 {{- define "kong.streamListen" -}}
@@ -438,6 +457,10 @@ TODO: remove legacy admin listen behavior at a future date
 {{- $_ := set $autoEnv "KONG_STREAM_LISTEN" (include "kong.streamListen" .Values.proxy) -}}
 
 {{- $_ := set $autoEnv "KONG_STATUS_LISTEN" (include "kong.listen" .Values.status) -}}
+
+{{- if .Values.proxy.enabled -}}
+  {{- $_ := set $autoEnv "KONG_PORT_MAPS" (include "kong.port_maps" .Values.proxy) -}}
+{{- end -}}
 
 {{- if .Values.enterprise.enabled }}
   {{- $_ := set $autoEnv "KONG_ADMIN_GUI_LISTEN" (include "kong.listen" .Values.manager) -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Defines `KONG_PORT_MAPS` for the `proxy` service.
Before this PR, a request coming to the proxy service on port `80` would get `X-Forwarded-Port: 8000` (and equivalent for `https`).
After this PR, a request coming to the proxy service on port `80` would get `X-Forwarded-Port: 80` (and equivalent for `https`).

Makes use of the new feature introduced in Kong/kong#5861.
This PR makes a fix equivalent to Kong/kubernetes-ingress-controller#691, but for a different deployment method.

#### Which issue this PR fixes
fixes #168 

#### Special notes for your reviewer:
Note that `KONG_PORT_MAPS` get defined only for the `proxy` service.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
