### PR TITLE
Release Kong 1.8.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 1.8.0
 
+**Kong Enterprise users:** please review documentation for the [Kong Enterprise
+2.1.x beta
+release](https://docs.konghq.com/enterprise/2.1.x/release-notes/#coming-soon)
+and [hybrid mode on Kong
+Enterprise](https://docs.konghq.com/enterprise/2.1.x/deployment/hybrid-mode/#kubernetes-support)
+as well. Version 1.8 of the Kong Helm chart adds support for hybrid mode, which
+is currently only available in the 2.1.x beta. Production systems should
+continue to use the Kong Enterprise 1.5.x stable releases, which do not support
+hybrid mode.
+
 ### Improvements
 
 * Update default Kong version to 2.1.

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 1.8.0
+
+### Improvements
+
+* Update default Kong version to 2.1.
+* Update Kong Enterprise images to 1.5.0.4 (kong-enterprise-edition) and
+  2.0.4.2 (kong-enterprise-k8s).
+* Updated default controller version to 0.9.1.
+  ([#150](https://github.com/Kong/charts/pull/150))
+* Added support for ServiceMonitor targetLabels (for use with the Prometheus
+  Operator).
+  ([#162](https://github.com/Kong/charts/pull/162))
+* Automatically handle the [new port_maps
+  setting](https://github.com/Kong/kong/pull/5861) for the proxy service.
+  ([#169](https://github.com/Kong/charts/pull/169))
+* Add support for [hybrid mode
+  deployments](https://docs.konghq.com/latest/hybrid-mode/).
+  ([#160](https://github.com/Kong/charts/pull/160))
+
+
+### Fixed
+
+* Fixed an issue with improperly-rendered listen strings.
+  ([#155](https://github.com/Kong/charts/pull/155))
+
+### Documentation
+
+* Improved inline documentation of `env` in values.yaml.
+  ([#163](https://github.com/Kong/charts/pull/163))
+
 ## 1.7.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.7.0
+version: 1.8.0
 appVersion: 2.0

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -298,10 +298,10 @@ requires that a single controller generate a complete Kong configuration.
 
 Kong supports [hybrid mode
 deployments](https://docs.konghq.com/2.0.x/hybrid-mode/) as of Kong 2.0.0 and
-Kong Enterprise 2.1.0. These deployments split Kong nodes into control plane
-(CP) nodes, which provide the admin API and interact with the database, and
-data plane (DP) nodes, which provide the proxy and receive configuration from
-control plane nodes.
+[Kong Enterprise 2.1.0](https://docs.konghq.com/enterprise/2.1.x/deployment/hybrid-mode/).
+These deployments split Kong nodes into control plane (CP) nodes, which provide
+the admin API and interact with the database, and data plane (DP) nodes, which
+provide the proxy and receive configuration from control plane nodes.
 
 You can deploy hybrid mode Kong clusters by [creating separate releases for each node
 type](#separate-admin-and-proxy-nodes), i.e. use separate control and data

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -10,6 +10,10 @@ entirely. While support for the old functionality remains, the chart will show
 a warning about the outdated configuration when running `helm
 install/status/upgrade`.
 
+Note that not all versions contain breaking changes. If a version is not
+present in the table of contents, it requires no version-specific changes when
+upgrading from a previous version.
+
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 1.5.0.2-alpine
+  tag: 1.5.0.4-alpine
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-edition-docker

--- a/charts/kong/example-values/minimal-k4k8s-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-enterprise.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
-  tag: 2.0.4.1-centos
+  tag: 2.0.4.2-centos
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-k8s-docker

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 1.5.0.2-alpine
+  tag: 1.5.0.4-alpine
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-edition-docker

--- a/charts/kong/example-values/minimal-kong-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-controller.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: kong
-  tag: "2.0"
+  tag: "2.1"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.0"
+  tag: "2.1"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -11,7 +11,7 @@
 
 image:
   repository: kong
-  tag: "2.0"
+  tag: "2.1"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.0"
+  tag: "2.1"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -48,13 +48,13 @@ env:
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "2.0"
+  tag: "2.1"
   # kong-enterprise-k8s image (Kong OSS + Enterprise plugins)
   # repository: kong-docker-kong-enterprise-k8s.bintray.io/kong-enterprise-k8s
-  # tag: "2.0.4.1-alpine"
+  # tag: "2.0.4.2-alpine"
   # kong-enterprise image
   # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  # tag: "1.5.0.2-alpine"
+  # tag: "1.5.0.4-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
#### What this PR does / why we need it:

Releases version 1.8.0 of the Kong chart, which integrates existing changes from `next` and updates image versions to the latest release.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
