### PR TITLE
[kong] add support for sidecar containers

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -425,6 +425,15 @@ On Helm 3, CRDs are created if necessary, but are not managed along with the
 release. Releases can be deleted without affecting CRDs; CRDs are only removed
 if you delete them manually.
 
+### Sidecar Containers
+
+The chart can deploy additional containers along with the Kong and Ingress
+Controller containers, sometimes referred to as "sidecar containers".  This can
+be useful to include network proxies or logging services along with Kong.  The
+`deployment.sidecarContainers` field in values.yaml takes an array of objects
+that get appended as-is to the existing `spec.template.spec.containers` array
+in the Kong deployment resource.
+
 ### Example configurations
 
 Several example values.yaml are available in the

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
+      {{- if .Values.deployment.sidecarContainers }}
+      {{- toYaml .Values.deployment.sidecarContainers | nindent 6 }}
+      {{- end }}
       {{- if .Values.deployment.kong.enabled }}
       - name: "proxy"
         {{- if .Values.image.unifiedRepoTag }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -20,6 +20,7 @@ deployment:
     # controller-only release.
     enabled: true
   ## Optionally specify any extra sidecar containers to be included in the deployment
+  ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
   # sidecarContainers:
   #   - name: sidecar
   #     image: sidecar:latest

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -19,6 +19,10 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+  ## Optionally specify any extra sidecar containers to be included in the deployment
+  # sidecarContainers:
+  #   - name: sidecar
+  #     image: sidecar:latest
 
 # -----------------------------------------------------------------------------
 # Kong parameters


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds support for arbitrary sidecar containers to the Deployment resource.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
