### PR TITLE
[kong] add example Enterprise DB-less config

### DIFF
--- a/charts/kong/example-values/README.md
+++ b/charts/kong/example-values/README.md
@@ -14,6 +14,11 @@ change this value to `true` if you use Helm 2).
 * [minimal-k4k8s-enterprise.yaml](minimal-k4k8s-enterprise.yaml) installs Kong
   for Kubernetes Enterprise with the ingress controller in DB-less mode.
 
+* [minimal-kong-enterprise-dbless.yaml](minimal-kong-enterprise-dbless.yaml)
+  installs Kong for Kubernetes with Kong Enterprise with the ingress controller
+  in DB-less mode. This deployment option is in beta and is not suited for
+  production environments.
+
 * [minimal-k4k8s-with-kong-enterprise.yaml](minimal-k4k8s-with-kong-enterprise.yaml)
   installs Kong for Kubernetes with Kong Enterprise with the ingress controller
   and PostgreSQL. It does not enable Enterprise features other than Kong

--- a/charts/kong/example-values/README.md
+++ b/charts/kong/example-values/README.md
@@ -16,8 +16,8 @@ change this value to `true` if you use Helm 2).
 
 * [minimal-kong-enterprise-dbless.yaml](minimal-kong-enterprise-dbless.yaml)
   installs Kong for Kubernetes with Kong Enterprise with the ingress controller
-  in DB-less mode. This deployment option is in beta and is not suited for
-  production environments.
+  in DB-less mode. **This deployment option is in beta and is not suited for
+  production environments.**
 
 * [minimal-k4k8s-with-kong-enterprise.yaml](minimal-k4k8s-with-kong-enterprise.yaml)
   installs Kong for Kubernetes with Kong Enterprise with the ingress controller

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -13,8 +13,8 @@ image:
 
 enterprise:
   enabled: true
-  # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-license
-  license_secret: kong-enterprise-license
+  # See instructions regarding enterprise licenses at https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-license
+  license_secret: kong-enterprise-license # CHANGEME
   vitals:
     enabled: false
   portal:

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -1,0 +1,36 @@
+# WARNING: this deployment example is currently in beta. It is not suited for production.
+# Basic values.yaml for Kong for Kubernetes with Kong Enterprise (DB-less)
+# Several settings (search for the string "CHANGEME") require user-provided
+# Secrets. These Secrets must be created before installation.
+
+image:
+  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
+  tag: 2.1.0.0-beta1-alpine
+
+  pullSecrets:
+    # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
+    - kong-enterprise-edition-docker
+
+enterprise:
+  enabled: true
+  # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-license
+  license_secret: kong-enterprise-license
+  vitals:
+    enabled: false
+  portal:
+    enabled: false
+  rbac:
+    enabled: false
+
+
+env:
+  database: "off"
+
+ingressController:
+  enabled: true
+  installCRDs: false
+
+proxy:
+  # Enable creating a Kubernetes service for the proxy
+  enabled: true
+  type: NodePort


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a beta example for K4K8S using the kong-enterprise-edition image.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
