### PR TITLE
[kong] use bash wait-for-postgres implementation

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -456,8 +456,8 @@ directory.
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
 | migrations.annotations             | Annotations for migration jobs                                                        | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |
-| waitImage.repository               | Image used to wait for database to become ready                                       | `busybox`           |
-| waitImage.tag                      | Tag for image used to wait for database to become ready                               | `latest`            |
+| waitImage.repository               | Image used to wait for database to become ready                                       | `bash`              |
+| waitImage.tag                      | Tag for image used to wait for database to become ready                               | `5`                 |
 | waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |
 | postgresql.enabled                 | Spin up a new postgres instance for Kong                                              | `false`             |
 | dblessConfig.configMap             | Name of an existing ConfigMap containing the `kong.yml` file. This must have the key `kong.yml`.| `` |

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -66,8 +66,15 @@ script](https://github.com/Kong/charts/blob/kong-1.9.0/charts/kong/templates/wai
 to perform the same connectivity check. The default `waitImage.repository` value
 is now `bash` rather than `busybox`.
 
+The Helm upgrade cycle requires this script be available for upgrade jobs. On
+existing installations, you must first perform an initial `helm upgrade --set
+migrations.preUpgrade=false --migrations.postUpgrade=false` to chart 1.9.0.
+Perform this initial upgrade without making changes to your Kong image version:
+if you are upgrading Kong along with the chart, perform a separate upgrade
+after with the migration jobs re-enabled.
+
 If you do not override `waitImage.repository` in your releases, you do not need
-to make any changes when upgrading to 1.9.0.
+to make any other configuration changes when upgrading to 1.9.0.
 
 If you do override `waitImage.repository` to use a custom image, you must
 switch to a custom image that provides a `bash` executable. Note that busybox

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -17,6 +17,7 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [1.9.0](#190)
 - [1.6.0](#160)
 - [1.5.0](#150)
 - [1.4.0](#140)
@@ -51,6 +52,28 @@ text ending with `field is immutable`. This is typically due to a bug with the
 `init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+## 1.9.0
+
+### Changes to wait-for-postgres image
+
+Prior to 1.9.0, the chart launched a busybox initContainer for migration Pods
+to check Postgres' reachability [using
+netcat](https://github.com/Kong/charts/blob/kong-1.8.0/charts/kong/templates/_helpers.tpl#L626).
+
+As of 1.9.0, the chart uses a [bash
+script](https://github.com/Kong/charts/blob/kong-1.9.0/charts/kong/templates/wait-for-postgres-script.yaml)
+to perform the same connectivity check. The default `waitImage.repository` value
+is now `bash` rather than `busybox`.
+
+If you do not override `waitImage.repository` in your releases, you do not need
+to make any changes when upgrading to 1.9.0.
+
+If you do override `waitImage.repository` to use a custom image, you must
+switch to a custom image that provides a `bash` executable. Note that busybox
+images, or images derived from it, do _not_ include a `bash` executable. We
+recommend switching to an image derived from the public bash Docker image or a
+base operating system image that provides a `bash` executable.
 
 ## 1.6.0
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -245,6 +245,10 @@ The name of the service used for the ingress controller's validation webhook
   emptyDir: {}
 - name: {{ template "kong.fullname" . }}-tmp
   emptyDir: {}
+- name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
+  configMap:
+    name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
+    defaultMode: 0755
 {{- range .Values.plugins.configMaps }}
 - name: kong-plugin-{{ .pluginName }}
   configMap:
@@ -623,5 +627,8 @@ Environment variables are sorted alphabetically
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:
   {{- include "kong.no_daemon_env" . | nindent 2 }}
-  command: [ "/bin/sh", "-c", "set -u; until nc -zv $KONG_PG_HOST $KONG_PG_PORT -w1; do echo \"waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}\"; sleep 1; done" ]
+  command: [ "/bin/bash", "/wait_postgres/wait.sh" ]
+  volumeMounts:
+  - name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
+    mountPath: /wait_postgres
 {{- end -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -627,7 +627,7 @@ Environment variables are sorted alphabetically
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:
   {{- include "kong.no_daemon_env" . | nindent 2 }}
-  command: [ "/bin/bash", "/wait_postgres/wait.sh" ]
+  command: [ "/usr/local/bin/bash", "/wait_postgres/wait.sh" ]
   volumeMounts:
   - name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
     mountPath: /wait_postgres

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -627,7 +627,7 @@ Environment variables are sorted alphabetically
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:
   {{- include "kong.no_daemon_env" . | nindent 2 }}
-  command: [ "/usr/local/bin/bash", "/wait_postgres/wait.sh" ]
+  command: [ "bash", "/wait_postgres/wait.sh" ]
   volumeMounts:
   - name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
     mountPath: /wait_postgres

--- a/charts/kong/templates/wait-for-postgres-script.yaml
+++ b/charts/kong/templates/wait-for-postgres-script.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+data:
+  wait.sh: |
+    until timeout 2 bash -c "9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}"
+      do echo "waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}"
+      sleep 2
+    done
+

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -398,8 +398,8 @@ postgresql:
 # -----------------------------------------------------------------------------
 
 waitImage:
-  repository: centos
-  tag: latest
+  repository: bash
+  tag: 5
   pullPolicy: IfNotPresent
 
 # update strategy

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -398,7 +398,7 @@ postgresql:
 # -----------------------------------------------------------------------------
 
 waitImage:
-  repository: busybox
+  repository: centos
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Replaces the existing busybox+netcat wait-for-postgres implementation with a centos+bash implementation. This allows for easier drop-in replacements of other waitImage options (namely the Red Hat UBI).

See discussion in https://github.com/Kong/kong-operator/issues/24 as to why this should be promoted from the `fork/redhat` branch into mainline releases.

#### Special notes for your reviewer:
The script is stored in a static ConfigMap template to work around some issues I encountered getting it to run correctly when placed directly in the Job definition as the initContainer command. This probably isn't a strict requirement, but it's a lightweight workaround and I'm not too concerned with getting rid of it absent some compelling reason to.

Example failure when DNS lookups fail:

```
waiting for db - trying ohno:5432
bash: ohno: Name or service not known
bash: /dev/tcp/ohno/5432: Invalid argument
waiting for db - trying ohno:5432
```
Example failure (or several checks before succeeding) when DNS succeeds:

```
waiting for db - trying example.com:5432
waiting for db - trying example.com:5432
waiting for db - trying example.com:5432
```
Although there's no direct relation between them, we may wish to merge and do a patch release of the example #175 before this. We can alternately add both and do a minor release, since the example can still be used with older versions of the chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `master`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
