### PR TITLE
[kong] add cluster telemetry service

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -514,7 +514,7 @@ authentication, which cannot pass through an ingress proxy).
 | SVC.externalTrafficPolicy          | k8s service's externalTrafficPolicy. Options: Cluster, Local                          |                     |
 | SVC.ingress.enabled                | Enable ingress resource creation (works with SVC.type=ClusterIP)                      | `false`             |
 | SVC.ingress.tls                    | Name of secret resource, containing TLS secret                                        |                     |
-| SVC.ingress.hosts                  | List of ingress hosts.                                                                | `[]`                |
+| SVC.ingress.hostname               | Ingress hostname                                                                      | `""`                |
 | SVC.ingress.path                   | Ingress path.                                                                         | `/`                 |
 | SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
 | SVC.annotations                    | Service annotations                                                                   | `{}`                |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -502,7 +502,7 @@ only.
 `cluster` is used on hybrid mode control plane nodes. It does not support the
 `SVC.http.*` settings (cluster communications must be TLS-only) or the
 `SVC.ingress.*` settings (cluster communication requires TLS client
-authentication, which cannot pass through an ingress proxy). `clustertelemetry
+authentication, which cannot pass through an ingress proxy). `clustertelemetry`
 is similar, and used when Vitals is enabled on Kong Enterprise control plane
 nodes.
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -363,6 +363,18 @@ proxy:
   enabled: false
 ```
 
+Enterprise users with Vitals enabled must also enable the cluster telemetry
+service:
+
+```yaml
+clustertelemetry:
+  enabled: true
+  tls:
+    enabled: true
+    servicePort: 8006
+    containerPort: 8006
+```
+
 If using the ingress controller, you must also specify the DP proxy service as
 its publish target to keep Ingress status information up to date:
 
@@ -404,6 +416,7 @@ env:
   cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
   lua_ssl_trusted_certificate: /etc/secrets/kong-cluster-cert/tls.crt
   cluster_control_plane: control-plane-release-name-kong-cluster.hybrid.svc.cluster.local:8005
+  cluster_telemetry_endpoint: control-plane-release-name-kong-clustertelemetry.hybrid.svc.cluster.local:8006 # Enterprise-only
 ```
 
 Note that the `cluster_control_plane` value will differ depending on your
@@ -478,6 +491,7 @@ individual services: see values.yaml for their individual default values.
 * `portal`
 * `portalapi`
 * `cluster`
+* `clustertelemetry`
 * `status`
 
 `status` is intended for internal use within the cluster. Unlike other
@@ -488,7 +502,9 @@ only.
 `cluster` is used on hybrid mode control plane nodes. It does not support the
 `SVC.http.*` settings (cluster communications must be TLS-only) or the
 `SVC.ingress.*` settings (cluster communication requires TLS client
-authentication, which cannot pass through an ingress proxy).
+authentication, which cannot pass through an ingress proxy). `clustertelemetry
+is similar, and used when Vitals is enabled on Kong Enterprise control plane
+nodes.
 
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -485,6 +485,7 @@ TODO: remove legacy admin listen behavior at a future date
   {{- if not .Values.enterprise.vitals.enabled }}
     {{- $_ := set $autoEnv "KONG_VITALS" "off" -}}
   {{- end }}
+  {{- $_ := set $autoEnv "KONG_CLUSTER_TELEMETRY_LISTEN" (include "kong.listen" .Values.clustertelemetry) -}}
 
   {{- if .Values.enterprise.portal.enabled }}
     {{- $_ := set $autoEnv "KONG_PORTAL" "on" -}}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -144,6 +144,14 @@ spec:
           {{- end}}
           protocol: TCP
         {{- end }}
+        {{- if (and .Values.cluster.tls.enabled .Values.cluster.enabled) }}
+        - name: cluster-tls
+          containerPort: {{ .Values.cluster.tls.containerPort }}
+          {{- if .Values.cluster.tls.hostPort }}
+          hostPort: {{ .Values.cluster.tls.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
         - name: metrics
           containerPort: 9542
           protocol: TCP
@@ -198,6 +206,14 @@ spec:
           containerPort: {{ .Values.portalapi.tls.containerPort }}
           {{- if .Values.portalapi.tls.hostPort }}
           hostPort: {{ .Values.portalapi.tls.hostPort }}
+          {{- end}}
+          protocol: TCP
+        {{- end }}
+        {{- if (and .Values.clustertelemetry.tls.enabled .Values.clustertelemetry.enabled) }}
+        - name: clustertelemetry-tls
+          containerPort: {{ .Values.clustertelemetry.tls.containerPort }}
+          {{- if .Values.clustertelemetry.tls.hostPort }}
+          hostPort: {{ .Values.clustertelemetry.tls.hostPort }}
           {{- end}}
           protocol: TCP
         {{- end }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -210,7 +210,7 @@ spec:
           protocol: TCP
         {{- end }}
         {{- if (and .Values.clustertelemetry.tls.enabled .Values.clustertelemetry.enabled) }}
-        - name: clustertelemetry-tls
+        - name: clustert-tls
           containerPort: {{ .Values.clustertelemetry.tls.containerPort }}
           {{- if .Values.clustertelemetry.tls.hostPort }}
           hostPort: {{ .Values.clustertelemetry.tls.hostPort }}

--- a/charts/kong/templates/service-kong-cluster-telemetry.yaml
+++ b/charts/kong/templates/service-kong-cluster-telemetry.yaml
@@ -1,0 +1,53 @@
+{{- /*
+Note that "http.enabled" should never be true for this service--the feature
+does not support plaintext mode.
+
+As such, it does not exist in the default values.yaml and is omitted from the
+initial render/do not render logic at the top, which is different from other
+Service templates.
+*/ -}}
+{{- if .Values.deployment.kong.enabled }}
+{{- if .Values.enterprise.enabled }}
+{{- if and .Values.clustertelemetry.enabled .Values.clustertelemetry.tls.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-clustertelemetry
+  annotations:
+    {{- range $key, $value := .Values.clustertelemetry.annotations }}
+      {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.clustertelemetry.type }}
+  {{- if eq .Values.clustertelemetry.type "LoadBalancer" }}
+  {{- if .Values.clustertelemetry.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.clustertelemetry.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.clustertelemetry.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.clustertelemetry.loadBalancerSourceRanges }}
+  - {{ $cidr }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  externalIPs:
+  {{- range $ip := .Values.clustertelemetry.externalIPs }}
+  - {{ $ip }}
+  {{- end }}
+  ports:
+  {{- if or .Values.clustertelemetry.tls.enabled }}
+  - name: kong-clustertelemetry-tls
+    port: {{ .Values.clustertelemetry.tls.servicePort }}
+    targetPort: {{ .Values.clustertelemetry.tls.containerPort }}
+  {{- if (and (eq .Values.clustertelemetry.type "NodePort") (not (empty .Values.clustertelemetry.tls.nodePort))) }}
+    nodePort: {{ .Values.clustertelemetry.tls.nodePort }}
+  {{- end }}
+    protocol: TCP
+  {{- end }}
+  selector:
+    {{- include "kong.selectorLabels" . | nindent 4 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -722,3 +722,20 @@ portalapi:
     path: /
 
   externalIPs: []
+
+clustertelemetry:
+  enabled: false
+  # If you want to specify annotations for the cluster telemetry service, uncomment the following
+  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  annotations: {}
+  #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+
+  tls:
+    enabled: false
+    servicePort: 8006
+    containerPort: 8006
+    parameters: []
+
+  type: ClusterIP
+
+  externalIPs: []


### PR DESCRIPTION
#### What this PR does / why we need it:
- Add support for the cluster telemetry service. This service is similar to the cluster service, but is used to ship Vitals data from Enterprise DP nodes.

#### Which issue this PR fixes
  - fixes #184 (minor doc rollup fix unrelated to the main PR)
  - fixes an issue reported internally, where DP nodes with Vitals enabled would complain about cluster service failures. These are in fact cluster telemetry service failures, and do not interfere with the main cluster service. Inbound core changes will make those error reports less confusing, as they will indicate the specific failing endpoint.

#### Special notes for your reviewer:
- Also adds a cluster port to the deployment. It was previously omitted, and while omitting it doesn't break communication, it does misreport things (the port was open, but not declared).
- The Service name is too long for port names, so this uses a shortened `clustert-tls` name in the Deployment, whereas most stuff uses `clustertelemetry-tls`
- We don't currently have automated hybrid tests. At present, the `hybrid` namespace on our test cluster contains a pair of `silly-rabbit` releases that have Enterprise CP/DP nodes that share configuration and Vitals data. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
