### PR TITLE
[repo] update chart-testing-action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,9 +17,10 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        uses: helm/chart-testing-action@v1.0.0
         with:
-          command: lint --config=ct-main.yaml
+          command: lint
+          config: ct-main.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-alpha.3
@@ -28,9 +29,10 @@ jobs:
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        uses: helm/chart-testing-action@v1.0.0
         with:
-          command: install --config=ct-main.yaml
+          command: install
+          config: ct-main.yaml
   release:
     needs: lint-test
     runs-on: ubuntu-latest

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
 
@@ -31,6 +31,6 @@ jobs:
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        uses: helm/chart-testing-action@v1.0.0
         with:
           command: install

--- a/charts/kong/ci/default-values.yaml
+++ b/charts/kong/ci/default-values.yaml
@@ -7,3 +7,4 @@ env:
 ingressController:
   env:
     anonymous_reports: "false"
+  installCRDs: false

--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -13,3 +13,4 @@ ingressController:
     anonymous_reports: "false"
   image:
     single: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.8.1
+  installCRDs: false

--- a/charts/kong/ci/test1-values.yaml
+++ b/charts/kong/ci/test1-values.yaml
@@ -7,6 +7,7 @@ autoscaling:
 # - ingressController deploys without a database (default)
 ingressController:
   enabled: true
+  installCRDs: false
 # - webhook is enabled and deploys
   admissionWebhook:
     enabled: true

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -2,6 +2,7 @@
 # - ingressController deploys with a database
 ingressController:
   enabled: true
+  installCRDs: false
   env:
     anonymous_reports: "false"
 postgresql:

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -2,6 +2,7 @@
 # - disable ingress controller
 ingressController:
   enabled: false
+  installCRDs: false
 # - disable DB for kong
 env:
   anonymous_reports: "off"

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -3,6 +3,7 @@
 # - disable ingress controller
 ingressController:
   enabled: false
+  installCRDs: false
   env:
     anonymous_reports: "false"
 # - use legacy admin listen config

--- a/ct-main.yaml
+++ b/ct-main.yaml
@@ -4,5 +4,5 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
-helm-extra-args: --timeout 200
+helm-extra-args: --timeout 200s
 check-version-increment: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,5 +4,5 @@ chart-dirs:
   - charts
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
-helm-extra-args: --timeout 200
+helm-extra-args: --timeout 200s
 check-version-increment: false


### PR DESCRIPTION
Release action is acting up. Scattered GH reports aren't conclusive, but they all mention issues with arguments, so hopefully updating to the final 1.0.0 and using the `config:` syntax will clear that.