### PR TITLE
[kong] release 1.9.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,12 +1,27 @@
 # Changelog
 
+## 1.9.1
+
+### Documentation
+
+* Clarified documentation for [breaking changes in 1.9.0](#190) to indicate
+  that any values.yaml that sets `waitImage.repository` requires changes,
+  including those that set the old default.
+* Updated Enterprise examples to use latest Enterprise image version.
+
 ## 1.9.0
 
 ### Breaking changes
 
-Changes to the pre-migration database check require [performing an initial chart version upgrade with migrations disabled](https://github.com/Kong/charts/blob/next/charts/kong/UPGRADE.md#changes-to-wait-for-postgres-image).
+1.9.0 now uses a bash-based pre-migration database availability check. If you
+set `waitImage.repository` in values.yaml, either to the previous default
+(`busybox`) or to a custom image, you must change it to an image that includes
+a `bash` executable.
 
-If you use a custom image for this check, you will need to change it to an image that provides a `bash` executable.
+Once you have `waitImage.repository` set to an image with bash, [perform an
+initial chart version upgrade with migrations disabled](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-wait-for-postgres-image)
+before re-enabling migrations, updating your Kong image version, and performing
+a second release upgrade.
 
 ### Improvements
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.9.0
+version: 1.9.1
 appVersion: 2.0

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -76,8 +76,10 @@ netcat](https://github.com/Kong/charts/blob/kong-1.8.0/charts/kong/templates/_he
 
 As of 1.9.0, the chart uses a [bash
 script](https://github.com/Kong/charts/blob/kong-1.9.0/charts/kong/templates/wait-for-postgres-script.yaml)
-to perform the same connectivity check. The default `waitImage.repository` value
-is now `bash` rather than `busybox`.
+to perform the same connectivity check. The default `waitImage.repository`
+value is now `bash` rather than `busybox`. Double-check your values.yaml to
+confirm that you do not set `waitImage.repository` and `waitImage.tag` to the
+old defaults: if you do, remove that configuration before upgrading.
 
 The Helm upgrade cycle requires this script be available for upgrade jobs. On
 existing installations, you must first perform an initial `helm upgrade --set

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 1.5.0.4-alpine
+  tag: 2.1.3.0-alpine
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-edition-docker

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 1.5.0.4-alpine
+  tag: 2.1.3.0-alpine
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-edition-docker

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -5,7 +5,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.1.0.0-beta1-alpine
+  tag: 2.1.3.0-alpine
 
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access


### PR DESCRIPTION
#### What this PR does / why we need it:

Clarifies the upgrade documentation for 1.9.0 to indicate that _any_ values.yaml that sets the waitImage must be modified, not only those that set custom images. This is targeted at users who copy all of the default values.yaml, as they will likely have set waitImage to the old default inadvertently.

#### Notes for reviewers

Direct to main, will merge into next after.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
