### PR TITLE
Add namespace to generated manifests

### DIFF
--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -10,6 +10,7 @@ apiVersion: admissionregistration.k8s.io/v1beta1
 {{- end }}
 metadata:
   name: {{ template "kong.fullname" . }}-validations
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 webhooks:
@@ -38,6 +39,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.service.validationWebhook" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
@@ -54,6 +56,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "kong.fullname" . }}-validation-webhook-keypair
+  namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 type: kubernetes.io/tls

--- a/charts/kong/templates/config-custom-server-blocks.yaml
+++ b/charts/kong/templates/config-custom-server-blocks.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kong.fullname" . }}-default-custom-server-blocks
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 data:

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kong.dblessConfig.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 data:

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kong.fullname" . }}
+  namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: app

--- a/charts/kong/templates/hpa.yaml
+++ b/charts/kong/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ .Capabilities.APIVersions.Has "autoscaling/v2beta2" | ternary "au
 kind: HorizontalPodAutoscaler
 metadata:
   name: "{{ template "kong.fullname" . }}"
+  namespace:  {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 spec:

--- a/charts/kong/templates/ingress-admin.yaml
+++ b/charts/kong/templates/ingress-admin.yaml
@@ -10,6 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "kong.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
   annotations:

--- a/charts/kong/templates/ingress-manager.yaml
+++ b/charts/kong/templates/ingress-manager.yaml
@@ -10,6 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "kong.fullname" . }}-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
   annotations:

--- a/charts/kong/templates/ingress-portal-api.yaml
+++ b/charts/kong/templates/ingress-portal-api.yaml
@@ -10,6 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "kong.fullname" . }}-portalapi
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
   annotations:

--- a/charts/kong/templates/ingress-portal.yaml
+++ b/charts/kong/templates/ingress-portal.yaml
@@ -10,6 +10,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "kong.fullname" . }}-portal
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
   annotations:

--- a/charts/kong/templates/ingress-proxy.yaml
+++ b/charts/kong/templates/ingress-proxy.yaml
@@ -8,6 +8,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "kong.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
   annotations:

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -6,6 +6,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "kong.fullname" . }}-post-upgrade-migrations
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: post-upgrade-migrations

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -6,6 +6,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "kong.fullname" . }}-pre-upgrade-migrations
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: pre-upgrade-migrations

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -9,6 +9,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "kong.fullname" . }}-init-migrations
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations

--- a/charts/kong/templates/pdb.yaml
+++ b/charts/kong/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kong.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 spec:

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-admin
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := .Values.admin.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/kong/templates/service-kong-cluster-telemetry.yaml
+++ b/charts/kong/templates/service-kong-cluster-telemetry.yaml
@@ -13,6 +13,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-clustertelemetry
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := .Values.clustertelemetry.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/kong/templates/service-kong-cluster.yaml
+++ b/charts/kong/templates/service-kong-cluster.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-cluster
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := .Values.cluster.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/kong/templates/service-kong-manager.yaml
+++ b/charts/kong/templates/service-kong-manager.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-manager
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := .Values.manager.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/kong/templates/service-kong-portal-api.yaml
+++ b/charts/kong/templates/service-kong-portal-api.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-portalapi
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := .Values.portalapi.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/kong/templates/service-kong-portal.yaml
+++ b/charts/kong/templates/service-kong-portal.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-portal
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := .Values.portal.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kong.fullname" . }}-proxy
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- range $key, $value := .Values.proxy.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/charts/kong/templates/wait-for-postgres-script.yaml
+++ b/charts/kong/templates/wait-for-postgres-script.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 data:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
It explicitely adds namespace to generated manifests (e.g. by `helm template`), not to rely on automated Helm inclusion. See https://github.com/Kong/charts/issues/192 for more detail.

#### Which issue this PR fixes
fixes #192 

#### Special notes for your reviewer:

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
