### PR TITLE
[kong ] use policy API since v1.11

### DIFF
--- a/charts/kong/templates/psp.yaml
+++ b/charts/kong/templates/psp.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "kong.metaLabels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     verbs:


### PR DESCRIPTION
Signed-off-by: Kevin Lefevre <lefevre.kevin@gmail.com>


#### What this PR does / why we need it:

Use policy API for PSP clusterrole which is available since 1.11. extensions is not available in later Kubernetes versions. Since 1.11 has been EOL for a while I think it is safe to use policy anyway.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [X] New or modified sections of values.yaml are documented in the README.md
- [X] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
