### PR TITLE
[kong] Add custom extra configmaps/secrets

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -609,6 +609,9 @@ For a complete list of all configuration values you can set in the
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |
 | serviceMonitor.labels              | ServiceMonitor labels                                                                 | `{}`                |
 | serviceMonitor.targetLabels        | ServiceMonitor targetLabels                                                           | `{}`                |
+| extraConfigMaps                    | ConfigMaps to add to mounted volumes                                                  | `[]`                |
+| extraSecrets                       | Secrets to add to mounted volumes                                                     | `[]`                |
+
 
 #### The `env` section
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -350,10 +350,6 @@ The name of the service used for the ingress controller's validation webhook
   {{- if .subPath }}
   subPath: {{ .subPath }}
   {{- end }}
-
-  {{- if .readOnly }}
-  readOnly: {{ .readOnly }}
-  {{- end }}
 {{- end }}
 {{- range .Values.extraSecrets }}
 - name:  {{ .name }}
@@ -361,10 +357,6 @@ The name of the service used for the ingress controller's validation webhook
 
   {{- if .subPath }}
   subPath: {{ .subPath }}
-  {{- end }}
-
-  {{- if .readOnly }}
-  readOnly: {{ .readOnly }}
   {{- end }}
 {{- end }}
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -293,6 +293,16 @@ The name of the service used for the ingress controller's validation webhook
   secret:
     secretName: {{ . }}
 {{- end }}
+{{- range .Values.extraConfigMaps }}
+- name: {{ .name }}
+  configMap:
+    name: {{ .name }}
+{{- end }}
+{{- range .Values.extraSecrets }}
+- name: {{ .name }}
+  secret:
+    secretName: {{ .name }}
+{{- end }}
 {{- end -}}
 
 {{- define "kong.volumeMounts" -}}
@@ -332,6 +342,32 @@ The name of the service used for the ingress controller's validation webhook
   readOnly: true
 {{- end }}
 {{- end }}
+
+{{- range .Values.extraConfigMaps }}
+- name:  {{ .name }}
+  mountPath: {{ .mountPath }}
+
+  {{- if .subPath }}
+  subPath: {{ .subPath }}
+  {{- end }}
+
+  {{- if .readOnly }}
+  readOnly: {{ .readOnly }}
+  {{- end }}
+{{- end }}
+{{- range .Values.extraSecrets }}
+- name:  {{ .name }}
+  mountPath: {{ .mountPath }}
+
+  {{- if .subPath }}
+  subPath: {{ .subPath }}
+  {{- end }}
+
+  {{- if .readOnly }}
+  readOnly: {{ .readOnly }}
+  {{- end }}
+{{- end }}
+
 {{- end -}}
 
 {{- define "kong.plugins" -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -741,12 +741,10 @@ extraConfigMaps: []
 # extraConfigMaps:
 # - name: my-config-map
 #   mountPath: /mount/to/my/location
-#   subPath: my-subpath [OPTIONAL]
-#   readOnly: true [OPTIONAL]
+#   subPath: my-subpath # Optional, if you wish to mount a single key and not the entire ConfigMap
 
 extraSecrets: []
 # extraSecrets:
 # - name: my-secret
 #   mountPath: /mount/to/my/location
-#   subPath: my-subpath [OPTIONAL]
-#   readOnly: true [OPTIONAL]
+#   subPath: my-subpath # Optional, if you wish to mount a single key and not the entire ConfigMap

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -736,3 +736,17 @@ clustertelemetry:
   type: ClusterIP
 
   externalIPs: []
+
+extraConfigMaps: []
+# extraConfigMaps:
+# - name: my-config-map
+#   mountPath: /mount/to/my/location
+#   subPath: my-subpath [OPTIONAL]
+#   readOnly: true [OPTIONAL]
+
+extraSecrets: []
+# extraSecrets:
+# - name: my-secret
+#   mountPath: /mount/to/my/location
+#   subPath: my-subpath [OPTIONAL]
+#   readOnly: true [OPTIONAL]


### PR DESCRIPTION
Add extraConfigMaps and extraSecrets fields to values file that will be added to volumes/volumeMounts template helpers.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Adds ability to mount arbitrary config maps/secrets

#### Which issue this PR fixes
closes #196

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X ] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ X ] New or modified sections of values.yaml are documented in the README.md
- [ X ] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
