### PR TITLE
[kong] release 1.11.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,10 +1,43 @@
 # Changelog
 
+## 1.11.0
+
+### Breaking changes
+
+* Kong Ingress Controller 1.0 removes support for several deprecated flags and
+  the KongCredential custom resource. Please see the [controller changelog](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#breaking-changes)
+  for details. Note that Helm 3 will not remove the KongCredential CRD by
+  default: you should delete it manually after converting KongCredentials to
+  [credential Secrets](https://github.com/Kong/kubernetes-ingress-controller/blob/next/docs/guides/using-consumer-credential-resource.md#provision-a-consumer).
+  If you manage CRDs using Helm (check to see if your KongCredential CRD has a
+  `app.kubernetes.io/managed-by: Helm` label), perform the credential Secret
+  conversion **before** upgrading to chart 1.11.0 to avoid losing credential
+  configuration.
+* The chart no longer uses the `extensions` API for PodSecurityPolicy, and now
+  uses the modern `policy` API. This breaks compatibility with Kubernetes
+  versions 1.11 and older.
+  ([#195](https://github.com/Kong/charts/pull/195))
+
+### Improvements
+
+* Updated default controller version to 1.0.
+* The chart now adds namespace information to manifests explicitly. This
+  simplifies workflows that use `helm template`.
+  ([#193](https://github.com/Kong/charts/pull/193))
+
+### Fixed
+* Changes to annotation block generation prevent incorrect YAML indentation
+  when specifying annotations via command line arguments to Helm commands.
+  ([#200](https://github.com/Kong/charts/pull/200))
+
 ## 1.10.0
 
 ### Breaking changes
 
-* Kong Ingress Controller 0.10.0 comes with breaking changes to global `KongPlugin`s and to resources without an ingress class defined. Refer to the [`UPGRADE.md notes for chart 1.10.0`](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#1100) for details.
+* Kong Ingress Controller 0.10.0 comes with breaking changes to global
+  `KongPlugin`s and to resources without an ingress class defined. Refer to the
+  [`UPGRADE.md notes for chart 1.10.0`](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#1100)
+  for details.
 
 ### Improvements
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.10.0
+
+### Breaking changes
+
+* Kong Ingress Controller 0.10.0 comes with breaking changes to global `KongPlugin`s and to resources without an ingress class defined. Refer to the [`UPGRADE.md notes for chart 1.10.0`](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#1100) for details.
+
+### Improvements
+
+* Updated default controller version to 0.10.0.
+
+### Fixed
+
+* Removed the `status` field from the `TCPIngress` CRD.
+  ([#188](https://github.com/Kong/charts/pull/188))
+
 ## 1.9.1
 
 ### Documentation
@@ -118,11 +133,11 @@ issue with our release automation.
 * Added ability to apply user-defined labels to pods.
   ([#121](https://github.com/Kong/charts/pull/121))
 * Filtered serviceMonitor to disable metrics collection from non-proxy
-  services. 
+  services.
   ([#112](https://github.com/Kong/charts/pull/112))
 * Set admin API to listen on localhost only if possible.
   ([#125](https://github.com/Kong/charts/pull/125))
-* Add `auth_type` and `ssl` settings to `smtp` block. 
+* Add `auth_type` and `ssl` settings to `smtp` block.
   ([#127](https://github.com/Kong/charts/pull/127))
 * Remove UID from default securityContext.
   ([#138](https://github.com/Kong/charts/pull/138))

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.10.0
-appVersion: 2.0
+version: 1.11.0
+appVersion: 2.1

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.9.1
+version: 1.10.0
 appVersion: 2.0

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -53,6 +53,16 @@ text ending with `field is immutable`. This is typically due to a bug with the
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
 
+## 1.10.0
+
+### `KongClusterPlugin` replaces global `KongPlugin`s
+
+Kong Ingress Controller 0.10.0 no longer supports `KongPlugin`s with a `global: true` label. See the [KIC changelog for 0.10.0](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#0100---20200915) for migration hints.
+
+### Dropping support for resources not specifying an ingress class
+
+Kong Ingress Controller 0.10.0 drops support for certain kinds of resources without a `kubernetes.io/ingress.class` annotation. See the [KIC changelog for 0.10.0](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#0100---20200915) for the exact list of those kinds, and for possible migration paths.
+
 ## 1.9.0
 
 ### New image for Enterprise controller-managed DB-less deployments
@@ -227,7 +237,7 @@ This is a new annotation that is equivalent to the `route.strip_path` setting
 in KongIngress resources. Note that if you have already set this to `false`,
 you should leave it as-is and not add an annotation to the ingress.
 
-### Changes to Kong service configuration 
+### Changes to Kong service configuration
 
 1.4.0 reworks the templates and configuration used to generate Kong
 configuration and Kuberenetes resources for Kong's services (the admin API,

--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -1,71 +1,3 @@
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongconsumers.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  version: v1
-  scope: Namespaced
-  names:
-    kind: KongConsumer
-    plural: kongconsumers
-    shortNames:
-    - kc
-  additionalPrinterColumns:
-  - name: Username
-    type: string
-    description: Username of a Kong Consumer
-    JSONPath: .username
-  - name: Age
-    type: date
-    description: Age
-    JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      properties:
-        username:
-          type: string
-        custom_id:
-          type: string
-        credentials:
-          type: array
-          items:
-            type: string
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: kongcredentials.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  version: v1
-  scope: Namespaced
-  names:
-    kind: KongCredential
-    plural: kongcredentials
-  additionalPrinterColumns:
-  - name: Credential-type
-    type: string
-    description: Type of credential
-    JSONPath: .type
-  - name: Age
-    type: date
-    description: Age
-    JSONPath: .metadata.creationTimestamp
-  - name: Consumer-Ref
-    type: string
-    description: Owner of the credential
-    JSONPath: .consumerRef
-  validation:
-    openAPIV3Schema:
-      required:
-      - consumerRef
-      - type
-      properties:
-        consumerRef:
-          type: string
-        type:
-          type: string
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -140,6 +72,9 @@ spec:
             - grpcs
             - tcp
             - tls
+  subresources:
+    status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -217,6 +152,46 @@ spec:
             - grpcs
             - tcp
             - tls
+  subresources:
+    status: {}
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kongconsumers.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  version: v1
+  scope: Namespaced
+  names:
+    kind: KongConsumer
+    plural: kongconsumers
+    shortNames:
+    - kc
+  additionalPrinterColumns:
+  - name: Username
+    type: string
+    description: Username of a Kong Consumer
+    JSONPath: .username
+  - name: Age
+    type: date
+    description: Age
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        username:
+          type: string
+        custom_id:
+          type: string
+        credentials:
+          type: array
+          items:
+            type: string
+  subresources:
+    status: {}
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -377,6 +352,8 @@ spec:
                   properties:
                     healthy: *healthy
                     unhealthy: *unhealthy
+  subresources:
+    status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -443,3 +420,11 @@ spec:
                         type: integer
         status:
           type: object
+  subresources:
+    status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -215,7 +215,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" (printf "%s/%s-proxy" .Release.Namespace (include "kong.fullname" .)) -}}
 {{- $_ := set $autoEnv "CONTROLLER_INGRESS_CLASS" .Values.ingressController.ingressClass -}}
 {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}
-{{- $_ := set $autoEnv "CONTROLLER_KONG_URL" (include "kong.adminLocalURL" .) -}}
+{{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_URL" (include "kong.adminLocalURL" .) -}}
 {{- if .Values.ingressController.admissionWebhook.enabled }}
   {{- $_ := set $autoEnv "CONTROLLER_ADMISSION_WEBHOOK_LISTEN" (printf "0.0.0.0:%d" (int64 .Values.ingressController.admissionWebhook.port)) -}}
 {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -304,7 +304,7 @@ ingressController:
   enabled: true
   image:
     repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
-    tag: 0.9.1
+    tag: 0.10.0
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -304,7 +304,7 @@ ingressController:
   enabled: true
   image:
     repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
-    tag: 0.10.0
+    tag: "1.0"
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables


### PR DESCRIPTION
#### What this PR does / why we need it:
- Updates the chart to 1.11.0.
- Bumps controller version to 1.0.
- Updates CRDs to controller 1.0 version.
- Adds changelog and upgrade documentation.
- Fixes formatting and ToC issues from 1.10.0.
- Integrates commits from main that were not already in next.

#### Special notes for your reviewer:

For 1.10, we merged main into next and then added several 1.10 changes directly to main, and the tip of next was behind main.

For this PR, I've merged main into the release branch, which incorporates those changes. Using a rebase and merge for this merge into next and the subsequent merger of next into main should bring the branches back into alignment.

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
