### PR TITLE
Add annotations for initmigrations job

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -469,7 +469,7 @@ directory.
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
 | migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |
-| migrations.initAnnotations         | Annotations for init migration job                                                    | `{}`                |
+| migrations.jobAnnotations          | Additional annotations for migration jobs                                             | `{}`                |
 | waitImage.repository               | Image used to wait for database to become ready                                       | `bash`              |
 | waitImage.tag                      | Tag for image used to wait for database to become ready                               | `5`                 |
 | waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -468,7 +468,8 @@ directory.
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
-| migrations.annotations             | Annotations for migration jobs                                                        | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |
+| migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |
+| migrations.initAnnotations         | Annotations for init migration job                                                    | `{}`                |
 | waitImage.repository               | Image used to wait for database to become ready                                       | `bash`              |
 | waitImage.tag                      | Tag for image used to wait for database to become ready                               | `5`                 |
 | waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -13,6 +13,9 @@ metadata:
   annotations:
     helm.sh/hook: "post-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
+  {{- range $key, $value := .Values.migrations.jobAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -13,6 +13,9 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
+  {{- range $key, $value := .Values.migrations.jobAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -13,7 +13,7 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
-  {{- range $key, $value := .Values.migrations.initAnnotations }}
+  {{- range $key, $value := .Values.migrations.jobAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -13,6 +13,9 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
+  {{- range $key, $value := .Values.migrations.initAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   template:
     metadata:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -274,10 +274,10 @@ migrations:
   annotations:
     sidecar.istio.io/inject: false
     kuma.io/sidecar-injection: "disabled"
-  # Annotations to apply to the init migration job
+  # Additional annotations to apply to migration jobs
   # This is helpful in certain non-Helm installation situations such as GitOps
   # where additional control is required around this job creation.
-  initAnnotations: {}
+  jobAnnotations: {}
 
 # Kong's configuration for DB-less mode
 # Note: Use this section only if you are deploying Kong in DB-less mode

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -268,12 +268,16 @@ migrations:
   preUpgrade: true
   # Enable post-upgrade migrations (run "kong migrations finish")
   postUpgrade: true
-  # Annotations to apply to migrations jobs
+  # Annotations to apply to migrations job pods
   # By default, these disable service mesh sidecar injection for Istio and Kuma,
   # as the sidecar containers do not terminate and prevent the jobs from completing
   annotations:
     sidecar.istio.io/inject: false
     kuma.io/sidecar-injection: "disabled"
+  # Annotations to apply to the init migration job
+  # This is helpful in certain non-Helm installation situations such as GitOps
+  # where additional control is required around this job creation.
+  initAnnotations: {}
 
 # Kong's configuration for DB-less mode
 # Note: Use this section only if you are deploying Kong in DB-less mode


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
This enables users to specify optional specific annotations for the init migrations job. This allows more control when deploying Kong via systems other than standard Helm installs, like ArgoCD. The use case for us is to allow setting some custom annotations that allow us to clean up this job after running.

I've additionally clarified the documentation for existing `.migrations.annotations` to state that they modify the job's pod annotations and not the job itself.

#### Special notes for your reviewer:



#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [X] New or modified sections of values.yaml are documented in the README.md
- [X] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
