### PR TITLE
[kong] Replace underscore in secret keys

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -775,7 +775,7 @@ $ cat admin_gui_session_conf
 {"cookie_name":"admin_session","cookie_samesite":"off","secret":"admin-secret-CHANGEME","cookie_secure":true,"storage":"kong"}
 $ cat portal_session_conf
 {"cookie_name":"portal_session","cookie_samesite":"off","secret":"portal-secret-CHANGEME","cookie_secure":true,"storage":"kong"}
-$ kubectl create secret generic kong-session-config --from-file=admin_gui_session_conf --from-file=portal_session_conf
+$ kubectl create secret generic kong-session-config --from-file=admin-gui-session-conf=admin_gui_session_conf --from-file=portal-session-conf=portal_session_conf
 secret/kong-session-config created
 ```
 The exact plugin settings may vary in your environment. The `secret` should
@@ -784,6 +784,15 @@ always be changed for both configurations.
 After creating your secret, set its name in values.yaml in
 `.enterprise.rbac.session_conf_secret`. If you create a Portal configuration,
 add it at `env.portal_session_conf` using a secretKeyRef.
+
+```yaml
+env:
+  portal_session_conf:
+    valueFrom:
+      secretKeyRef:
+        key: kong-session-config
+        name: portal-session-conf
+```
 
 ### Email/SMTP
 
@@ -797,7 +806,7 @@ Setting `.enterprise.smtp.disabled: true` will set `KONG_SMTP_MOCK=on` and
 allow Admin/Developer invites to proceed without sending email. Note, however,
 that these have limited functionality without sending email.
 
-If your SMTP server requires authentication, you must provide the `username` and `smtp_password_secret` keys under `.enterprise.smtp.auth`. `smtp_password_secret` must be a Secret containing an `smtp_password` key whose value is your SMTP password.
+If your SMTP server requires authentication, you must provide the `username` and `smtp_password_secret` keys under `.enterprise.smtp.auth`. `smtp_password_secret` must be a Secret containing an `smtp-password` key whose value is your SMTP password.
 
 By default, SMTP uses `AUTH` `PLAIN` when you provide credentials. If your provider requires `AUTH LOGIN`, set `smtp_auth_type: login`.
 

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -387,5 +387,5 @@ env:
     valueFrom:
       secretKeyRef:
         name: portal-session
-        key: portal_session_conf
+        key: portal-session-conf
 ```

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -535,7 +535,7 @@ TODO: remove legacy admin listen behavior at a future date
 
     {{- if .Values.enterprise.portal.portal_auth }} {{/* TODO: deprecated, remove in a future version */}}
       {{- $_ := set $autoEnv "KONG_PORTAL_AUTH" .Values.enterprise.portal.portal_auth -}}
-      {{- $portalSession := include "secretkeyref" (dict "name" .Values.enterprise.portal.session_conf_secret "key" "portal_session_conf") -}}
+      {{- $portalSession := include "secretkeyref" (dict "name" .Values.enterprise.portal.session_conf_secret "key" "portal-session-conf") -}}
       {{- $_ := set $autoEnv "KONG_PORTAL_SESSION_CONF" $portalSession -}}
     {{- end }}
   {{- end }}
@@ -545,11 +545,11 @@ TODO: remove legacy admin listen behavior at a future date
     {{- $_ := set $autoEnv "KONG_ADMIN_GUI_AUTH" .Values.enterprise.rbac.admin_gui_auth | default "basic-auth" -}}
 
     {{- if not (eq .Values.enterprise.rbac.admin_gui_auth "basic-auth") }}
-      {{- $guiAuthConf := include "secretkeyref" (dict "name" .Values.enterprise.rbac.admin_gui_auth_conf_secret "key" "admin_gui_auth_conf") -}}
+      {{- $guiAuthConf := include "secretkeyref" (dict "name" .Values.enterprise.rbac.admin_gui_auth_conf_secret "key" "admin-gui-auth-conf") -}}
       {{- $_ := set $autoEnv "KONG_ADMIN_GUI_AUTH_CONF" $guiAuthConf -}}
     {{- end }}
 
-    {{- $guiSessionConf := include "secretkeyref" (dict "name" .Values.enterprise.rbac.session_conf_secret "key" "admin_gui_session_conf") -}}
+    {{- $guiSessionConf := include "secretkeyref" (dict "name" .Values.enterprise.rbac.session_conf_secret "key" "admin-gui-session-conf") -}}
     {{- $_ := set $autoEnv "KONG_ADMIN_GUI_SESSION_CONF" $guiSessionConf -}}
   {{- end }}
 
@@ -567,7 +567,7 @@ TODO: remove legacy admin listen behavior at a future date
     {{- $_ := set $autoEnv "KONG_SMTP_STARTTLS" (quote .Values.enterprise.smtp.smtp_starttls) -}}
     {{- if .Values.enterprise.smtp.auth.smtp_username }}
       {{- $_ := set $autoEnv "KONG_SMTP_USERNAME" .Values.enterprise.smtp.auth.smtp_username -}}
-      {{- $smtpPassword := include "secretkeyref" (dict "name" .Values.enterprise.smtp.auth.smtp_password_secret "key" "smtp_password") -}}
+      {{- $smtpPassword := include "secretkeyref" (dict "name" .Values.enterprise.smtp.auth.smtp_password_secret "key" "smtp-password") -}}
       {{- $_ := set $autoEnv "KONG_SMTP_PASSWORD" $smtpPassword -}}
     {{- end }}
   {{- else }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -558,12 +558,12 @@ enterprise:
   rbac:
     enabled: false
     admin_gui_auth: basic-auth
-    # If RBAC is enabled, this Secret must contain an admin_gui_session_conf key
+    # If RBAC is enabled, this Secret must contain an admin-gui-session-conf key
     # The key value must be a secret configuration, following the example at
     # https://docs.konghq.com/enterprise/latest/kong-manager/authentication/sessions
     session_conf_secret: kong-session-config
     # If admin_gui_auth is not set to basic-auth, provide a secret name which
-    # has an admin_gui_auth_conf key containing the plugin config JSON
+    # has an admin-gui-auth-conf key containing the plugin config JSON
     admin_gui_auth_conf_secret: CHANGEME-admin-gui-auth-conf-secret
   # For configuring emails and SMTP, please read through:
   # https://docs.konghq.com/enterprise/latest/developer-portal/configuration/smtp
@@ -583,7 +583,7 @@ enterprise:
     auth:
       # If your SMTP server does not require authentication, this section can
       # be left as-is. If smtp_username is set to anything other than an empty
-      # string, you must create a Secret with an smtp_password key containing
+      # string, you must create a Secret with an smtp-password key containing
       # your SMTP password and specify its name here.
       smtp_username: ''  # e.g. postmaster@example.com
       smtp_password_secret: CHANGEME-smtp-password


### PR DESCRIPTION
#### What this PR does / why we need it:

Kubernetes doesn't accept `_` characters in resources (https://github.com/helm/helm/issues/6477).
This commit fixes the secrets keys by replacing `_` by `-` which Kubernetes is accepting.

#### Special notes for your reviewer:

To test this change you must add the session config to values.yaml and activate enterprise features.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
