### PR TITLE
[kong] Add runAsUser parameter to ingress controller

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -570,6 +570,7 @@ section of `values.yaml` file:
 | admissionWebhook.enabled           | Whether to enable the validating admission webhook                                    | false                                                                        |
 | admissionWebhook.failurePolicy     | How unrecognized errors from the admission endpoint are handled (Ignore or Fail)      | Fail                                                                         |
 | admissionWebhook.port              | The port the ingress controller will listen on for admission webhooks                 | 8080                                                                         |
+| securityContext                    | Set the securityContext for ingress controller                                        | `{}`                                                                         |
 
 For a complete list of all configuration values you can set in the
 `env` section, please read the Kong Ingress Controller's

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -560,7 +560,6 @@ section of `values.yaml` file:
 | image.tag                          | Version of the ingress controller                                                     | 0.9.1                                                                        |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
-| runAsUser                          | User ID (UID) of the ingress controller                                               |                                                                              |
 | installCRDs                        | Create CRDs. **FOR HELM3, MAKE SURE THIS VALUE IS SET TO `false`.**  Regardless of value of this, Helm v3+ will install the CRDs if those are not present already. Use `--skip-crds` with `helm install` if you want to skip CRD creation.                 | true                                                                         |
 | serviceAccount.create              | Create Service Account for ingress controller                                         | true
 | serviceAccount.name                | Use existing Service Account, specify its name                                        | ""

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -23,40 +23,28 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
 
 ## Table of contents
 
-- [Kong for Kubernetes](#kong-for-kubernetes)
-- [TL;DR;](#tldr)
-- [Table of contents](#table-of-contents)
 - [Prerequisites](#prerequisites)
-- [Important: Helm 2 vs Helm 3](#important-helm-2-vs-helm-3)
-    - [Helm 2](#helm-2)
-    - [Helm 3](#helm-3)
+- [Helm 2 vs Helm 3](#important-helm-2-vs-helm-3)
 - [Install](#install)
 - [Uninstall](#uninstall)
-- [FAQs](#faqs)
 - [Kong Enterprise](#kong-enterprise)
+- [FAQs](#faqs)
 - [Deployment Options](#deployment-options)
   - [Database](#database)
-    - [DB-less  deployment](#db-less-deployment)
   - [Runtime package](#runtime-package)
   - [Configuration method](#configuration-method)
   - [Separate admin and proxy nodes](#separate-admin-and-proxy-nodes)
   - [Standalone controller nodes](#standalone-controller-nodes)
   - [Hybrid mode](#hybrid-mode)
-    - [Certificates](#certificates)
-    - [Control plane node configuration](#control-plane-node-configuration)
-    - [Data plane node configuration](#data-plane-node-configuration)
   - [CRDs only](#crds-only)
-  - [Sidecar Containers](#sidecar-containers)
   - [Example configurations](#example-configurations)
 - [Configuration](#configuration)
-  - [Kong parameters](#kong-parameters)
+  - [Kong Parameters](#kong-parameters)
     - [Kong Service Parameters](#kong-service-parameters)
-    - [Stream listens](#stream-listens)
   - [Ingress Controller Parameters](#ingress-controller-parameters)
   - [General Parameters](#general-parameters)
-    - [The `env` section](#the-env-section)
+  - [The `env` section](#the-env-section)
 - [Kong Enterprise Parameters](#kong-enterprise-parameters)
-  - [Overview](#overview)
   - [Prerequisites](#prerequisites-1)
     - [Kong Enterprise License](#kong-enterprise-license)
     - [Kong Enterprise Docker registry access](#kong-enterprise-docker-registry-access)
@@ -64,6 +52,8 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
   - [RBAC](#rbac)
   - [Sessions](#sessions)
   - [Email/SMTP](#emailsmtp)
+- [Changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md)
+- [Upgrading](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md)
 - [Seeking help](#seeking-help)
 
 ## Prerequisites
@@ -580,7 +570,6 @@ section of `values.yaml` file:
 | admissionWebhook.enabled           | Whether to enable the validating admission webhook                                    | false                                                                        |
 | admissionWebhook.failurePolicy     | How unrecognized errors from the admission endpoint are handled (Ignore or Fail)      | Fail                                                                         |
 | admissionWebhook.port              | The port the ingress controller will listen on for admission webhooks                 | 8080                                                                         |
-| securityContext                    | Set the securityContext for ingress controller                                        | `{}`                                                                         |
 
 For a complete list of all configuration values you can set in the
 `env` section, please read the Kong Ingress Controller's

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -23,28 +23,40 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
 
 ## Table of contents
 
+- [Kong for Kubernetes](#kong-for-kubernetes)
+- [TL;DR;](#tldr)
+- [Table of contents](#table-of-contents)
 - [Prerequisites](#prerequisites)
-- [Helm 2 vs Helm 3](#important-helm-2-vs-helm-3)
+- [Important: Helm 2 vs Helm 3](#important-helm-2-vs-helm-3)
+    - [Helm 2](#helm-2)
+    - [Helm 3](#helm-3)
 - [Install](#install)
 - [Uninstall](#uninstall)
-- [Kong Enterprise](#kong-enterprise)
 - [FAQs](#faqs)
+- [Kong Enterprise](#kong-enterprise)
 - [Deployment Options](#deployment-options)
   - [Database](#database)
+    - [DB-less  deployment](#db-less-deployment)
   - [Runtime package](#runtime-package)
   - [Configuration method](#configuration-method)
   - [Separate admin and proxy nodes](#separate-admin-and-proxy-nodes)
   - [Standalone controller nodes](#standalone-controller-nodes)
   - [Hybrid mode](#hybrid-mode)
+    - [Certificates](#certificates)
+    - [Control plane node configuration](#control-plane-node-configuration)
+    - [Data plane node configuration](#data-plane-node-configuration)
   - [CRDs only](#crds-only)
+  - [Sidecar Containers](#sidecar-containers)
   - [Example configurations](#example-configurations)
 - [Configuration](#configuration)
-  - [Kong Parameters](#kong-parameters)
+  - [Kong parameters](#kong-parameters)
     - [Kong Service Parameters](#kong-service-parameters)
+    - [Stream listens](#stream-listens)
   - [Ingress Controller Parameters](#ingress-controller-parameters)
   - [General Parameters](#general-parameters)
-  - [The `env` section](#the-env-section)
+    - [The `env` section](#the-env-section)
 - [Kong Enterprise Parameters](#kong-enterprise-parameters)
+  - [Overview](#overview)
   - [Prerequisites](#prerequisites-1)
     - [Kong Enterprise License](#kong-enterprise-license)
     - [Kong Enterprise Docker registry access](#kong-enterprise-docker-registry-access)
@@ -52,8 +64,6 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
   - [RBAC](#rbac)
   - [Sessions](#sessions)
   - [Email/SMTP](#emailsmtp)
-- [Changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md)
-- [Upgrading](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md)
 - [Seeking help](#seeking-help)
 
 ## Prerequisites
@@ -570,6 +580,7 @@ section of `values.yaml` file:
 | admissionWebhook.enabled           | Whether to enable the validating admission webhook                                    | false                                                                        |
 | admissionWebhook.failurePolicy     | How unrecognized errors from the admission endpoint are handled (Ignore or Fail)      | Fail                                                                         |
 | admissionWebhook.port              | The port the ingress controller will listen on for admission webhooks                 | 8080                                                                         |
+| securityContext                    | Set the securityContext for ingress controller                                        | `{}`                                                                         |
 
 For a complete list of all configuration values you can set in the
 `env` section, please read the Kong Ingress Controller's

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -560,6 +560,7 @@ section of `values.yaml` file:
 | image.tag                          | Version of the ingress controller                                                     | 0.9.1                                                                        |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
+| runAsUser                          | User ID (UID) of the ingress controller                                               |                                                                              |
 | installCRDs                        | Create CRDs. **FOR HELM3, MAKE SURE THIS VALUE IS SET TO `false`.**  Regardless of value of this, Helm v3+ will install the CRDs if those are not present already. Use `--skip-crds` with `helm install` if you want to skip CRD creation.                 | true                                                                         |
 | serviceAccount.create              | Create Service Account for ingress controller                                         | true
 | serviceAccount.name                | Use existing Service Account, specify its name                                        | ""

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -393,6 +393,8 @@ The name of the service used for the ingress controller's validation webhook
 {{ toYaml .Values.ingressController.livenessProbe | indent 4 }}
   resources:
 {{ toYaml .Values.ingressController.resources | indent 4 }}
+  securityContext:
+{{ toYaml .Values.ingressController.securityContext | indent 4 }}
 {{- if .Values.ingressController.admissionWebhook.enabled }}
   volumeMounts:
   - name: webhook-cert

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -391,10 +391,6 @@ The name of the service used for the ingress controller's validation webhook
 {{ toYaml .Values.ingressController.readinessProbe | indent 4 }}
   livenessProbe:
 {{ toYaml .Values.ingressController.livenessProbe | indent 4 }}
-{{- if .Values.ingressController.runAsUser }}
-  securityContext:
-    runAsUser: {{.Values.ingressController.runAsUser }}
-{{- end }}
   resources:
 {{ toYaml .Values.ingressController.resources | indent 4 }}
 {{- if .Values.ingressController.admissionWebhook.enabled }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -391,6 +391,10 @@ The name of the service used for the ingress controller's validation webhook
 {{ toYaml .Values.ingressController.readinessProbe | indent 4 }}
   livenessProbe:
 {{ toYaml .Values.ingressController.livenessProbe | indent 4 }}
+{{- if .Values.ingressController.runAsUser }}
+  securityContext:
+    runAsUser: {{.Values.ingressController.runAsUser }}
+{{- end }}
   resources:
 {{ toYaml .Values.ingressController.resources | indent 4 }}
 {{- if .Values.ingressController.admissionWebhook.enabled }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -237,7 +237,11 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
       securityContext:
+      {{- if (and .Values.ingressController.enabled (not .Values.ingressController.securityContext) ) }}
+      {{ .Values.ingressController.securityContext | toYaml | nindent 8 }}
+      {{- else }}
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
+      {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -237,11 +237,7 @@ spec:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
       securityContext:
-      {{- if (and .Values.ingressController.enabled (not .Values.ingressController.securityContext) ) }}
-      {{ .Values.ingressController.securityContext | toYaml | nindent 8 }}
-      {{- else }}
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
-      {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -365,7 +365,6 @@ ingressController:
     successThreshold: 1
     failureThreshold: 3
   resources: {}
-  securityContext: {}
 
 # -----------------------------------------------------------------------------
 # Postgres sub-chart parameters

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -365,6 +365,7 @@ ingressController:
     successThreshold: 1
     failureThreshold: 3
   resources: {}
+  securityContext: {}
 
 # -----------------------------------------------------------------------------
 # Postgres sub-chart parameters


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the ability to configure the user ID for the ingress controller. In this example, this is useful for connecting kong to AWS App Mesh. By specifying the user ID, the kong traffic will not be filtered by the envoy proxy.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - None

#### Special notes for your reviewer:
Per conversation with @shapirov103.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [X] New or modified sections of values.yaml are documented in the README.md
- [X] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
