### PR TITLE
[kong] Release 1.12.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## 1.11.0
 
+### Improvements
+
+* Increased default worker count to 2 to avoid issues with latency during
+  blocking tasks, such as DB-less config updates. This change increases memory
+  usage, but the increase should not be a concern for any but the smallest
+  deployments (deployments with memory limits below 512MB).
+* Updated default Kong version to 2.2.
+  ([#221](https://github.com/Kong/charts/pull/221))
+* Updated default Kong Enterprise version to 2.1.4.1.
+* Added a means to mount extra ConfigMap and Secret resources.
+  ([#208](https://github.com/Kong/charts/pull/208))
+* Added configurable annotations for migration Jobs.
+  ([#219](https://github.com/Kong/charts/pull/219))
+* Added template for deprecation warnings to automate formatting and avoid
+  excess newlines.
+
+### Fixed
+
+* Upgrades no longer force auto-scaling Deployments back to the replica count.
+  ([#222](https://github.com/Kong/charts/pull/222))
+
+## 1.11.0
+
 ### Breaking changes
 
 * Kong Ingress Controller 1.0 removes support for several deprecated flags and

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.11.0
-appVersion: 2.1
+version: 1.12.0
+appVersion: 2.2

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.1.3.0-alpine
+  tag: 2.1.4.1-alpine
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-edition-docker

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.1.3.0-alpine
+  tag: 2.1.4.1-alpine
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-edition-docker

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -5,7 +5,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.1.3.0-alpine
+  tag: 2.1.4.1-alpine
 
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -11,23 +11,20 @@ curl $PROXY_IP
 Once installed, please follow along the getting started guide to start using
 Kong: https://bit.ly/k4k8s-get-started
 
-{{ if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}} {{/* Legacy Portal auth handling */}}
-/!\ WARNING: You are currently using legacy Portal authentication configuration
-in values.yaml. Support for this will be removed in a future release. Please
-see the upgrade guide for instructions to update your configuration:
-https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-dedicated-portal-authentication-configuration-parameters
-{{- end }}
+{{ $warnings := list -}}
 
-{{ if .Values.admin.containerPort -}} {{/* Legacy admin API listen */}}
-/!\ WARNING: You are currently using legacy admin API configuration in
-values.yaml. Support for this will be removed in a future release. Please see
-the upgrade guide for instructions to update your configuration:
-https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration
-{{- end }}
+{{- if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}}
+{{/* Legacy Portal auth handling */}}
+{{- $warnings = append $warnings "You are currently using legacy Portal authentication configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-dedicated-portal-authentication-configuration-parameters" -}}
+{{- end -}}
 
-{{ if .Values.runMigrations -}} {{/* Legacy migration toggle */}}
-/!\ WARNING: You are currently using the legacy runMigrations setting in
-values.yaml. Support for this will be removed in a future release. Please see
-the upgrade guide for instructions to update your configuration:
-https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-migration job-configuration
-{{- end }}
+{{- if .Values.admin.containerPort -}}
+{{/* Legacy admin API listen */}}
+{{- $warnings = append $warnings "You are currently using legacy admin API configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration" -}}
+{{- end -}}
+
+{{- if .Values.runMigrations -}}
+{{/* Legacy migration toggle */}}
+{{- $warnings = append $warnings "You are currently using the legacy runMigrations setting in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-migration job-configuration" -}}
+{{- end -}}
+{{- include "kong.deprecation-warnings" $warnings -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -661,3 +661,13 @@ Environment variables are sorted alphabetically
   - name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
     mountPath: /wait_postgres
 {{- end -}}
+
+{{- define "kong.deprecation-warnings" -}}
+  {{- $warnings := list -}}
+  {{- range $warning := . }}
+    {{- $warnings = append $warnings (wrap 80 (printf "WARNING: %s" $warning)) -}}
+    {{- $warnings = append $warnings "\n\n" -}}
+  {{- end -}}
+  {{- $warningString := ($warnings | join "") -}}
+  {{- $warningString -}}
+{{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -39,7 +39,7 @@ deployment:
 # is set below. In general, you should not set values here if they are set elsewhere.
 env:
   database: "off"
-  nginx_worker_processes: "1"
+  nginx_worker_processes: "2"
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout
   admin_gui_access_log: /dev/stdout
@@ -415,10 +415,10 @@ updateStrategy: {}
 resources: {}
   # limits:
   #  cpu: 100m
-  #  memory: 128Mi
+  #  memory: 256Mi
   # requests:
   #  cpu: 100m
-  #  memory: 128Mi
+  #  memory: 256Mi
 
 # readinessProbe for Kong pods
 # If using Kong Enterprise with RBAC, you must add a Kong-Admin-Token header

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -56,7 +56,7 @@ image:
   tag: "2.2"
   # Kong Enterprise
   # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  # tag: "2.1.3.0-alpine"
+  # tag: "2.1.4.1-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases 1.12 to next. Includes several additional changes:

- Bump the default Enterprise tags to the latest 2.1 patch, 2.1.4.1.
- Increase the default worker count to 2.
- Handle deprecation warnings via a template to simplify and improve formatting.

#### Which issue this PR fixes
  - fixes #227 
  - fixes #144

#### Special notes for your reviewer:
Re conversations about worker count increase and memory usage from planning:
- By default, the chart does not apply memory limits to Kong deployments. However, it did include commented example limits with an unreasonably low default limit (128MB). From personal experience, this limit is too low for _any_ deployment (even single-worker deployments), and would cause issues if applied. I've increased the commented example to 256MB, which is much more reasonable, though that's essentially a minimum lower bound for Kong to function at all rather than what I'd expect for most actual deployments. Non-demo/test environments that actually handle traffic will likely start around 1GB, and will usually have even higher limits.
- There was a brief interlude where additional workers allocated resulted in unexpected higher memory use due to removal of limits elsewhere. AFAIK we've since re-introduced those limits (https://github.com/Kong/kong/pull/5864), and increasing worker count no longer causes the consumption issues we observed in earlier 2.x releases, so I don't expect the chart change to cause issues.

We still want to explore resource usage guidelines further, but the minimums proposed here should be reasonable.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
