### PR TITLE
[kong] clarify HPA requirements

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -368,7 +368,14 @@ ingressController:
     periodSeconds: 10
     successThreshold: 1
     failureThreshold: 3
+  # Remove "{}" and uncomment the block below to set controller resources
   resources: {}
+  # limits:
+  #  cpu: 100m
+  #  memory: 256Mi
+  # requests:
+  #  cpu: 50m
+  #  memory: 128Mi
 
 # -----------------------------------------------------------------------------
 # Postgres sub-chart parameters
@@ -480,6 +487,8 @@ deploymentAnnotations:
   traffic.sidecar.istio.io/includeInboundPorts: ""
 
 # Enable autoscaling using HorizontalPodAutoscaler
+# When configuring an HPA, you must set resource limits on all containers via
+# "resources" and, if using the controller, "ingressController.resources" in values.yaml
 autoscaling:
   enabled: false
   minReplicas: 2

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -368,14 +368,15 @@ ingressController:
     periodSeconds: 10
     successThreshold: 1
     failureThreshold: 3
-  # Remove "{}" and uncomment the block below to set controller resources
   resources: {}
-  # limits:
-  #  cpu: 100m
-  #  memory: 256Mi
-  # requests:
-  #  cpu: 50m
-  #  memory: 128Mi
+  # Example reasonable setting for "resources":
+  # resources:
+  #   limits:
+  #     cpu: 100m
+  #     memory: 256Mi
+  #   requests:
+  #     cpu: 50m
+  #     memory: 128Mi
 
 # -----------------------------------------------------------------------------
 # Postgres sub-chart parameters
@@ -487,7 +488,7 @@ deploymentAnnotations:
   traffic.sidecar.istio.io/includeInboundPorts: ""
 
 # Enable autoscaling using HorizontalPodAutoscaler
-# When configuring an HPA, you must set resource limits on all containers via
+# When configuring an HPA, you must set resource requests on all containers via
 # "resources" and, if using the controller, "ingressController.resources" in values.yaml
 autoscaling:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds values.yaml comments to clarify HPA requirements and `ingressController.resources` usage.

#### Special notes for your reviewer:
Thought it was possible to do this instead at the Pod level, since the controller doesn't consume a significant amount of resources and there's not much reason to handle it separately from the Kong container's requests, but it looks like that's a no go--docs sorta imply you can do it, but there's not actually any way to do that in the Pod spec.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
