### PR TITLE
[kong] add nodeSelector to migration Jobs

### DIFF
--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -60,7 +60,7 @@ spec:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
-      {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -58,6 +58,10 @@ spec:
         {{- include "kong.volumeMounts" . | nindent 8 }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -60,7 +60,7 @@ spec:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
-      {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -58,6 +58,10 @@ spec:
         {{- include "kong.volumeMounts" . | nindent 8 }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -60,7 +60,7 @@ spec:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
-      {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
       volumes:

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -58,6 +58,10 @@ spec:
         {{- include "kong.volumeMounts" . | nindent 8 }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
The nodeSelector value was previously only applied to the main Deployment. It should be applied to migration Jobs also, since they run Kong also, and have the same platform requirements.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes FTI-2152

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
