### PR TITLE
[kong] release 1.13.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.13.0
+
+### Improvements
+
+* Updated default Kong Enterprise version to 2.2.1.0-alpine.
+* Updated default Kong Ingress Controller version to 1.1.
+* Add `namespace` to values.yaml to override release namespace if desired.
+  ([#231](https://github.com/Kong/charts/pull/231))
+
+### Fixed
+
+* Migration Jobs now use the same nodeSelector configuration as the main Kong
+  Deployment.
+  ([#238](https://github.com/Kong/charts/pull/238))
+* Disabled custom Kong template mount if Kong is not enabled.
+  ([#240](https://github.com/Kong/charts/pull/240))
+* Changed YAML string to a YAML boolean.
+  ([#240](https://github.com/Kong/charts/pull/240))
+
+### Documentation
+
+* Clarify requirements for using horizontal pod autoscalers.
+  ([#236](https://github.com/Kong/charts/pull/236))
+
 ## 1.12.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.12.0
+version: 1.13.0
 appVersion: 2.2

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.1.4.1-alpine
+  tag: 2.2.1.0-alpine
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-edition-docker

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.1.4.1-alpine
+  tag: 2.2.1.0-alpine
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
     - kong-enterprise-edition-docker

--- a/charts/kong/example-values/minimal-kong-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-controller.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: kong
-  tag: "2.1"
+  tag: "2.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -5,7 +5,7 @@
 
 image:
   repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.1.4.1-alpine
+  tag: 2.2.1.0-alpine
 
   pullSecrets:
     # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.1"
+  tag: "2.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -11,7 +11,7 @@
 
 image:
   repository: kong
-  tag: "2.1"
+  tag: "2.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.1"
+  tag: "2.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -60,7 +60,7 @@ image:
   tag: "2.2"
   # Kong Enterprise
   # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  # tag: "2.1.4.1-alpine"
+  # tag: "2.2.1.0-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -312,7 +312,7 @@ ingressController:
   enabled: true
   image:
     repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
-    tag: "1.0"
+    tag: "1.1"
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases 1.13.0 to next. Nothing too interesting--wrap up of staged bugfixes, namespace override, and recent image versions.

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
