### PR TITLE
[repo] replace old Helm stable with Bitnami

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-alpha.2


### PR DESCRIPTION
#### What this PR does / why we need it:
Per https://helm.sh/blog/new-location-stable-incubator-charts/ the
previous location used here is now unavailable, breaking releases.

We furthermore no longer actually use the dependency in the old repo in
the actual chart, so changing this to the Bitnami repo rather than the
new Helm repo.

#### Which issue this PR fixes
See failure at https://github.com/Kong/charts/runs/1664313187?check_suite_focus=true

#### Special notes for your reviewer:
CI change only; going direct to main.
