### PR TITLE
[kong] re-use admission certificates if present

### DIFF
--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -1,7 +1,20 @@
-{{- if .Values.ingressController.admissionWebhook.enabled }}
-{{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) }}
+{{- if .Values.ingressController.admissionWebhook.enabled -}}
+{{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) -}}
 {{- $ca := genCA "kong-admission-ca" 3650 -}}
 {{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+{{- $certCert := $cert.Cert -}}
+{{- $certKey := $cert.Key -}}
+{{- $caCert := $ca.Cert -}}
+{{- $caKey := $ca.Key -}}
+
+{{- $caSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-ca-keypair" (include "kong.fullname" .))) -}}
+{{- $certSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-keypair" (include "kong.fullname" .))) -}}
+{{- if $certSecret -}}
+{{- $certCert = (b64dec (get $certSecret.data "tls.crt")) -}}
+{{- $certKey = (b64dec (get $certSecret.data "tls.key")) -}}
+{{- $caCert = (b64dec (get $caSecret.data "tls.crt")) -}}
+{{- $caKey = (b64dec (get $caSecret.data "tls.key")) -}}
+{{- end -}}
 kind: ValidatingWebhookConfiguration
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -30,7 +43,7 @@ webhooks:
     - kongconsumers
     - kongplugins
   clientConfig:
-    caBundle: {{ b64enc $ca.Cert }}
+    caBundle: {{ b64enc $caCert }}
     service:
       name: {{ template "kong.service.validationWebhook" . }}
       namespace: {{ template "kong.namespace" . }}
@@ -55,12 +68,24 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ template "kong.fullname" . }}-validation-webhook-ca-keypair
+  namespace:  {{ template "kong.namespace" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+    tls.crt: {{ b64enc $caCert  }}
+    tls.key: {{ b64enc $caKey  }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: {{ template "kong.fullname" . }}-validation-webhook-keypair
   namespace:  {{ template "kong.namespace" . }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ b64enc $cert.Cert }}
-  tls.key: {{ b64enc $cert.Key }}
+  tls.crt: {{ b64enc $certCert }}
+  tls.key: {{ b64enc $certKey }}
 {{ end }}

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -2,16 +2,16 @@
 {{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) -}}
 {{- $ca := genCA "kong-admission-ca" 3650 -}}
 {{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
-{{- $certCert := $cert.Cert -}}
-{{- $certKey := $cert.Key -}}
+{{- $webhookCert := $cert.Cert -}}
+{{- $webhookKey := $cert.Key -}}
 {{- $caCert := $ca.Cert -}}
 {{- $caKey := $ca.Key -}}
 
 {{- $caSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-ca-keypair" (include "kong.fullname" .))) -}}
 {{- $certSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-keypair" (include "kong.fullname" .))) -}}
 {{- if $certSecret -}}
-{{- $certCert = (b64dec (get $certSecret.data "tls.crt")) -}}
-{{- $certKey = (b64dec (get $certSecret.data "tls.key")) -}}
+{{- $webhookCert = (b64dec (get $certSecret.data "tls.crt")) -}}
+{{- $webhookKey = (b64dec (get $certSecret.data "tls.key")) -}}
 {{- $caCert = (b64dec (get $caSecret.data "tls.crt")) -}}
 {{- $caKey = (b64dec (get $caSecret.data "tls.key")) -}}
 {{- end -}}
@@ -86,6 +86,6 @@ metadata:
     {{- include "kong.metaLabels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ b64enc $certCert }}
-  tls.key: {{ b64enc $certKey }}
+  tls.crt: {{ b64enc $webhookCert }}
+  tls.key: {{ b64enc $webhookKey }}
 {{ end }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -29,7 +29,9 @@ spec:
     metadata:
       annotations:
         {{- if .Values.ingressController.admissionWebhook.enabled }}
-        checksum/admission-webhook.yaml: {{ include (print $.Template.BasePath "/admission-webhook.yaml") . | sha256sum }}
+        {{/* Generating a checksum from the entire template causes the checksum to change depending on whether you install or upgrade
+             even though the resources do not actually change. Not sure why. Extracting the certificates only works around this. */}}
+        checksum/admission-webhook.yaml: {{ (regexFindAll "tls.crt: .*$" (include (print $.Template.BasePath "/admission-webhook.yaml") .) -1 | join ",") | sha256sum }}
         {{- end }}
         {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
         {{- if .Values.dblessConfig.config }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -28,11 +28,6 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.ingressController.admissionWebhook.enabled }}
-        {{/* Generating a checksum from the entire template causes the checksum to change depending on whether you install or upgrade
-             even though the resources do not actually change. Not sure why. Extracting the certificates only works around this. */}}
-        checksum/admission-webhook.yaml: {{ (regexFindAll "tls.crt: .*$" (include (print $.Template.BasePath "/admission-webhook.yaml") .) -1 | join ",") | sha256sum }}
-        {{- end }}
         {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
         {{- if .Values.dblessConfig.config }}
         checksum/dbless.config: {{ toYaml .Values.dblessConfig.config | sha256sum }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Reuses admission webhook certificate Secrets if they are already present.

#### Which issue this PR fixes
  - fixes #126 
  - fixes #253 

#### Special notes for your reviewer:
We currently generate our checksum by using the entire admission webhook template output as input to SHA256. For some reason I cannot determine, the checksum still changes with the new lookup functionality between installs and upgrades, although a diff between the two shows no difference in the generated resources. Subsequent upgrades do not change the checksum.

To avoid this, I've modified the checksum generator to extract the `tls.crt` lines from the template, concatenate those, and checksum that, since we shouldn't need to care about anything else. It's ugly, but it works.

IMO this de facto solves #252 also: the certificate and CA Secret names are predictable, and if you create those Secrets in advance of the install, it should use them instead. Need to check to confirm. We'd only need additional changes for that if we want to make the Secret names user-selectable.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
