### PR TITLE
[kong] release 1.14.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 1.14.0
+
+### Breaking changes
+
+1.14 is the last planned 1.x version of the Kong chart. 2.x will remove support
+for Helm 2.x and all deprecated configuration. The chart prints a warning when
+upgrading or installing if it detects any configuration still using an old
+format.
+
+* All Ingress and Service resources now use the same template. This ensures
+  that all chart Ingresses and Services support the same configuration. The
+  proxy previously used a unique Ingress configuration, which is now
+  deprecated. If you use the proxy Ingress, [see the instructions in
+  UPGRADE.md](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress)
+  to update your configuration. No changes are required for other Service and
+  Ingress configurations.
+  ([#251](https://github.com/Kong/charts/pull/251)).
+* The chart now uses the standard Kong status endpoint instead of custom
+  configuration, allowing users to specify their own custom configuration. The
+  status endpoint is no available in versions older than Kong 1.4.0 or Kong
+  Enterprise 1.5.0; if you use an older version, you will need to [add and load
+  the old custom configuration](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#default-custom-server-block-replaced-with-status-listen).
+
+  If you use a newer version and include Kong container readinessProbe and/or
+  livenessProbe configuration in your values.yaml, you must change the port
+  from `metrics` to `status`.
+  ([#255](https://github.com/Kong/charts/pull/255)).
+
+### Fixed
+
+* Correct an issue with migrations Job toggles.
+  ([#231](https://github.com/Kong/charts/pull/231))
+
 ## 1.13.0
 
 ### Improvements

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -13,7 +13,7 @@ format.
   that all chart Ingresses and Services support the same configuration. The
   proxy previously used a unique Ingress configuration, which is now
   deprecated. If you use the proxy Ingress, [see the instructions in
-  UPGRADE.md](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress)
+  UPGRADE.md](https://github.com/Kong/charts/blob/kong-1.14.0/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress)
   to update your configuration. No changes are required for other Service and
   Ingress configurations.
   ([#251](https://github.com/Kong/charts/pull/251)).

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.13.0
+version: 1.14.0
 appVersion: 2.2

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -67,7 +67,7 @@ Ingress configuration; it is now identical to all other Kong services. If you
 do not need to configure multiple Ingress rules for your proxy, you will
 change:
 
-```
+```yaml
 ingress:
   hosts: ["proxy.kong.example"]
   tls:
@@ -78,7 +78,7 @@ ingress:
 ```
 to:
 
-```
+```yaml
 ingress:
   tls: example-tls-secret
   hostname: proxy.kong.example

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -391,7 +391,7 @@ ingressController:
 #   along-with Kong as part of a single Helm release.
 
 # PostgreSQL chart documentation:
-# https://github.com/helm/charts/blob/main/stable/postgresql/README.md
+# https://github.com/bitnami/charts/blob/master/bitnami/postgresql/README.md
 
 postgresql:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases Kong chart 1.14.0 to next.

#### Special notes for your reviewer:
This is the last planned 1.x-series release of the Kong chart. The plan for 2.x is to wait ~2 months after 1.14 to catch any bugs or feedback on deprecated configuration while staging 2.x changes in a dedicated branch:
- Remove support for deprecated configuration (https://github.com/Kong/charts/blob/next/charts/kong/templates/NOTES.txt covers what currently exists)
- Update CI to use Helm 3.
- Merge #256 and any other changes that require Helm 3 into the 2.x staging branch.

During the waiting period, we can continue accepting PRs that do not require Helm 3 to next, and will update the staging branch to track it. Barring anything urgent, however, we shouldn't expect to release those until 2.0.0.

Unrelated: this also includes a minor doc fix that doesn't warrant a separate PR.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
