### PR TITLE
[kong] fix Kong container if block and release 1.14.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.14.1
+
+### Fixed
+
+* Moved several Kong container settings into the appropriate template block.
+  Previously these were rendered whether or not the Kong container was enabled,
+  which unintentionally applied them to the controller container.
+
 ## 1.14.0
 
 ### Breaking changes

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.14.0
+version: 1.14.1
 appVersion: 2.2

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -222,7 +222,6 @@ spec:
           protocol: TCP
         {{- end }}
         {{- end }}
-        {{- end }}
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 10 }}
         readinessProbe:
@@ -231,6 +230,7 @@ spec:
 {{ toYaml .Values.livenessProbe | indent 10 }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- end }} {{/* End of Kong container spec */}}
     {{- if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
- Several Kong container settings were after the end of the if block for the Kong container. This shoved them into the controller container instead (assuming that was enabled). This change moves that if block end after them.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes FTI-2224

#### Special notes for your reviewer:
Patch release direct to main.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
