### PR TITLE
[repo] add CI to release kong 1-x patches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - main
+    - kong-1.x
 
 jobs:
   lint-test:
@@ -20,7 +20,7 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
-          config: ct-main.yaml
+          config: ct-kong-1-x.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-alpha.3
@@ -32,7 +32,7 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: install
-          config: ct-main.yaml
+          config: ct-kong-1-x.yaml
   release:
     needs: lint-test
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,10 +3,10 @@ name: Lint and Test Charts
 on:
   push:
     branches-ignore:
-    - 'main'
+    - kong-1.x
   pull_request:
     branches:
-    - '**'
+    - kong-1.x
 
 jobs:
   lint-test:
@@ -23,6 +23,7 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
+          config: ct-kong-1-x.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-alpha.3
@@ -34,3 +35,4 @@ jobs:
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: install
+          config: ct-kong-1-x.yaml

--- a/ct-kong-1-x.yaml
+++ b/ct-kong-1-x.yaml
@@ -1,5 +1,6 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
+target-branch: kong-1.x
 chart-dirs:
   - charts
 chart-repos:

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,8 +1,0 @@
-# See https://github.com/helm/chart-testing#configuration
-remote: origin
-chart-dirs:
-  - charts
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
-helm-extra-args: --timeout 200s
-check-version-increment: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Add a new workflow based on the main workflow for releasing Kong 1.x
chart patch releases after 2.0 is out. It still checks version bumps,
but targets the kong-1.x branch instead of main/master.

#### Special notes for your reviewer:
This goes into main first to exclude the kong-1.x branch from the default CI job. We need to merge it into main and next after.

The top-level configs (ct-main.yaml and such) will presumably eventually disappear from main and next entirely. The new chart-tester actions for Helm 3 won't use them, and the kong-1.x branch (which will continue to use the old-style workflow) only needs its config in its branch.

See https://github.com/rainest/charts/pull/6 and https://github.com/rainest/charts/actions/runs/513586226 for PoC.