### PR TITLE
[kong] release 1.14.2

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.14.2
+
+### Fixed
+
+* Corrected invalid default value for `enterprise.smtp.smtp_auth`.
+
 ## 1.14.1
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.14.1
+version: 1.14.2
 appVersion: 2.2

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -96,7 +96,7 @@ enterprise:
     smtp_admin_emails: none@example.com
     smtp_host: smtp.example.com
     smtp_port: 587
-    smtp_auth_type: nil
+    smtp_auth_type: ''
     smtp_ssl: nil
     smtp_starttls: true
     auth:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -590,7 +590,7 @@ enterprise:
     smtp_admin_emails: none@example.com
     smtp_host: smtp.example.com
     smtp_port: 587
-    smtp_auth_type: nil
+    smtp_auth_type: ''
     smtp_ssl: nil
     smtp_starttls: true
     auth:


### PR DESCRIPTION
#### What this PR does / why we need it:
Release 1.14.2, which contains one minor bugfix.

#### Which issue this PR fixes
This default has been broken since https://github.com/Kong/charts/pull/127. Uncovered during discussion with @doctorwu 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
