### PR TITLE
[kong] Move the end of the {{- else -}} block to correct position

### DIFF
--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -43,11 +43,11 @@ spec:
               serviceName: {{ $serviceName }}-proxy
               servicePort: {{ $servicePort }}
     {{- end -}}
-    {{- end -}}
   {{- if .Values.proxy.ingress.tls }}
   tls:
   {{ toYaml .Values.proxy.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR moves the end of the {{- else -}} from https://github.com/Kong/charts/blob/main/charts/kong/templates/service-kong-proxy.yaml#L18 block to correct position. Otherwise the value of `proxy.ingress.tls` is added twice, which resolves to broken yaml.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #265

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [X] New or modified sections of values.yaml are documented in the README.md
- [X] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
