### PR TITLE
[kong] fix legacy proxy ingress template

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.14.3
+
+### Fixed
+
+* Fix issues with legacy proxy Ingress object template.
+
 ## 1.14.2
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.14.2
+version: 1.14.3
 appVersion: 2.2

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -45,7 +45,7 @@ spec:
     {{- end -}}
   {{- if .Values.proxy.ingress.tls }}
   tls:
-  {{ toYaml .Values.proxy.ingress.tls | indent 4 }}
+{{ toYaml .Values.proxy.ingress.tls | indent 2 }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -43,11 +43,11 @@ spec:
               serviceName: {{ $serviceName }}-proxy
               servicePort: {{ $servicePort }}
     {{- end -}}
-    {{- end -}}
   {{- if .Values.proxy.ingress.tls }}
   tls:
   {{ toYaml .Values.proxy.ingress.tls | indent 4 }}
   {{- end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
I goofed on the block for legacy proxy Ingress objects. https://github.com/Kong/charts/blob/kong-1.13.0/charts/kong/templates/ingress-proxy.yaml#L22 no longer exists, but I left the end for it in, and that end caught the legacy block gate :facepalm:

The indent on the legacy stuff was also broken, since `toYaml` blocks can't have leading indents, as that will get added on top of the indent function for the first line only. Also should have been 2 to align the elements with the start of the array block. Gotemplate+YAML continue to be great fun.

CI doesn't catch these because secret references without corresponding secrets aren't accepted, so we lack tests for blocks with secret references.

#### Which issue this PR fixes
  - fixes #267 

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)