### PR TITLE
[kong] support daemonset deployment for kong pods

### DIFF
--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -85,3 +85,18 @@ This occurs if a `RELEASE-NAME-kong-init-migrations` Job is left over from a
 previous `helm install` or `helm upgrade`. Deleting it with
 `kubectl delete job RELEASE-NAME-kong-init-migrations` will allow the upgrade
 to proceed. Chart versions greater than 1.5.0 delete the job automatically.
+
+#### Can we deploy kong as a `Daemonset` ?
+Yes. You can deploy kong as a daemonset. Set `deployment.daemonset: true` to deploy the kong pods as a daemonset.
+Else by default, the pods are deployed as a deployment.
+
+#### How to deploy kong if the kubernetes cluster does not support Loadbalancer type service ?
+One way you can deploy the kong pods and expose it as `NodePort`.
+But the problem is we cannot access the ingress directly with well known ports http or https. 
+Instead we need to access this cluster using http[s]://<host-ip>:<node-port>/<some-path>.
+
+
+Another way is to deploy kong as Daemonset and expose the pods as hostPort. This is not recommended unless 
+it is pretty much needed because of the security reasons. But by this way, we can expose the well known ports
+80 and 443 of the pods as hostport and hence using the http://<host-ip> or https://<host-ip> we can directly
+access the ingress. If we have a loadbalancer in front of the hosts, then just http[s]://<lb-ip>/<some-path>

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -463,7 +463,7 @@ directory.
 | image.tag                          | Kong image version                                                                    | `2.0`               |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
-| replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true         | `1`                 |
+| replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` or `deployment.daemonset` is set to true   | `1`                 |
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
@@ -582,6 +582,7 @@ For a complete list of all configuration values you can set in the
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
+| deployment.daemonset               | If set to true kong is deployed as `Daemonset`. Else, by default, Kong is deployed as `Deployment`              | `false`      |
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |
 | autoscaling.minReplicas            | Set minimum number of replicas                                                        | `2`                 |
 | autoscaling.maxReplicas            | Set maximum number of replicas                                                        | `5`                 |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -1,6 +1,10 @@
 {{- if or .Values.deployment.kong.enabled .Values.ingressController.enabled }}
 apiVersion: apps/v1
+{{- if .Values.deployment.daemonset }}
+kind: DaemonSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ template "kong.fullname" . }}
   namespace:  {{ template "kong.namespace" . }}
@@ -15,7 +19,9 @@ metadata:
   {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
+  {{- if not .Values.deployment.daemonset }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -19,6 +19,12 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+    # Deploy as daemon set
+  ## Setting this to true will deploy kong as a daemonset
+  ## Else by default it creates as a deployment
+  ##
+  # daemonset: true
+  ##
   ## Optionally specify any extra sidecar containers to be included in the deployment
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
   # sidecarContainers:
@@ -590,7 +596,7 @@ enterprise:
     smtp_admin_emails: none@example.com
     smtp_host: smtp.example.com
     smtp_port: 587
-    smtp_auth_type: ''
+    smtp_auth_type: nil
     smtp_ssl: nil
     smtp_starttls: true
     auth:


### PR DESCRIPTION
This commit enables the clients to deploy the kong pods as daemonset, so one instance of pod is deployed in each node.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
