### PR TITLE
[kong] support changing terminationGracePeriodSeconds

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -591,6 +591,7 @@ For a complete list of all configuration values you can set in the
 | readinessProbe                     | Kong readiness probe                                                                  |                     |
 | livenessProbe                      | Kong liveness probe                                                                   |                     |
 | lifecycle                          | Proxy container lifecycle hooks                                                       | see `values.yaml`   |
+| terminationGracePeriodSeconds      | Related to lifecycle hook                                                             | 30                  |
 | affinity                           | Node/pod affinities                                                                   |                     |
 | nodeSelector                       | Node labels for pod assignment                                                        | `{}`                |
 | deploymentAnnotations              | Annotations to add to deployment                                                      |  see `values.yaml`  |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -241,6 +241,7 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       volumes:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -456,7 +456,12 @@ livenessProbe:
 lifecycle:
   preStop:
     exec:
+      # Note kong quit has a default timeout of 10 seconds
       command: ["/bin/sh", "-c", "/bin/sleep 15 && kong quit"]
+
+# terminationGracePeriodSeconds is closely related to the lifecycle preStop hook
+# Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
+terminationGracePeriodSeconds: 30
 
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Modifying the `lifecycle.preStop` hook is supported, but the `terminationGracePeriodSeconds` is not and should often be modified in tandem with the preStop hook.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
