### PR TITLE
[kong] disable unused Services in minimal Enterprise examples

### DIFF
--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -34,6 +34,12 @@ enterprise:
   smtp:
     enabled: false
 
+portal:
+  enabled: false
+
+portalapi:
+  enabled: false
+
 env:
   prefix: /kong_prefix/
   database: postgres

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -1,4 +1,3 @@
-# WARNING: this deployment example is currently in beta. It is not suited for production.
 # Basic values.yaml for Kong for Kubernetes with Kong Enterprise (DB-less)
 # Several settings (search for the string "CHANGEME") require user-provided
 # Secrets. These Secrets must be created before installation.
@@ -22,6 +21,14 @@ enterprise:
   rbac:
     enabled: false
 
+manager:
+  enabled: false
+
+portal:
+  enabled: false
+
+portalapi:
+  enabled: false
 
 env:
   database: "off"


### PR DESCRIPTION
#### What this PR does / why we need it:
Updates examples to disable Services that they don't actually use.

The Service/Ingress settings are decoupled from their prerequisites (enabling the Portal for the Portal Services and exposing the admin API for Manager). These examples previously disabled the prerequisites but not the examples.

#### Which issue this PR fixes
  - Partially fixes Jira FTI-2247

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
