### PR TITLE
[kong] release 1.14.4

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.14.4
+
+### Fixed
+
+* Status listens now include parameters in the default values.yaml. The absence
+  of these defaults caused a template rendering error when the TLS listen was
+  enabled.
+
+### Documentation
+
+* Updated status listen comments to reflect TLS listen availability on Kong
+  2.1+.
+
 ## 1.14.3
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.14.3
+version: 1.14.4
 appVersion: 2.2

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -130,12 +130,16 @@ status:
     # Enable plaintext HTTP listen for the status listen
     enabled: true
     containerPort: 8100
+    parameters: []
 
   tls:
     # Enable HTTPS listen for the status listen
-    # Kong does not currently support HTTPS status listens, so this should remain false
+    # Kong versions prior to 2.1 do not support TLS status listens.
+    # This setting must remain false on those versions
     enabled: false
     containerPort: 8543
+    parameters:
+    - http2
 
 # Specify Kong cluster service and listener configuration
 #


### PR DESCRIPTION
#### What this PR does / why we need it:
Release 1.14.4, which fixes a bug with the default values.yaml settings for status listens.

#### Which issue this PR fixes
Internally reported issue Jira FTI-2270

#### Special notes for your reviewer:

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
