### PR TITLE
[kong] release 1.14.5

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.14.5
+
+### Fixed
+
+* Removed `http2` from default status listen TLS parameters. It only supports a
+  limited subset of the extra listen parameters, and does not allow `http2`.
+
 ## 1.14.4
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.14.4
+version: 1.14.5
 appVersion: 2.2

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -138,8 +138,7 @@ status:
     # This setting must remain false on those versions
     enabled: false
     containerPort: 8543
-    parameters:
-    - http2
+    parameters: []
 
 # Specify Kong cluster service and listener configuration
 #


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove default `http2` from status TLS parameters. I forgot that we apply additional restrictions on these in Lua above and beyond what NGINX listen directives allow :facepalm: 

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
