### PR TITLE
chore(*) re-enable the sidecar injection for Kuma

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -468,7 +468,7 @@ directory.
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
-| migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |
+| migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false" |
 | migrations.jobAnnotations          | Additional annotations for migration jobs                                             | `{}`                |
 | waitImage.repository               | Image used to wait for database to become ready                                       | `bash`              |
 | waitImage.tag                      | Tag for image used to wait for database to become ready                               | `5`                 |

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -274,7 +274,6 @@ migrations:
   # as the sidecar containers do not terminate and prevent the jobs from completing
   annotations:
     sidecar.istio.io/inject: false
-    kuma.io/sidecar-injection: "disabled"
   # Additional annotations to apply to migration jobs
   # This is helpful in certain non-Helm installation situations such as GitOps
   # where additional control is required around this job creation.


### PR DESCRIPTION
Kuma supports Jobs since 1.0.7, therefore no need to disable the sidecar injection for it.

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
