### PR TITLE
[kong] Removed duplicate subresources entry from CRD

### DIFF
--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -375,8 +375,6 @@ spec:
     type: date
     description: Age
     JSONPath: .metadata.creationTimestamp
-  subresources:
-    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Removed duplicate subresources entry from CRD. Fixes #280.
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Removes duplicate entry for subresources in CRD as this breaks the yaml specification and also break some tools - it broke a Kustomize step in the deployment process for us.

#### Which issue this PR fixes
#280 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ X] New or modified sections of values.yaml are documented in the README.md
- [ X] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
