### PR TITLE
[kong] revamp database wait init containers

### DIFF
--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -88,14 +88,14 @@ to proceed. Chart versions greater than 1.5.0 delete the job automatically.
 
 #### DB-backed instances do not start when deployed within a service mesh
 
-Service meshes, such as Istio and Kuma, commonly enforce restrictions on
-traffic between Pods and require that traffic pass through a sidecar proxy.
-These sidecars are not available for init containers.
+Service meshes, such as Istio and Kuma, if deployed in a mode that injects
+a sidecar to Kong, don't make the mesh available to `InitContainer`s,
+because the sidecar starts _after_ all `InitContainer`s finish.
 
 By default, this chart uses init containers to ensure that the database is
 online and has migrations applied before starting Kong. This provides for a
 smoother startup, but isn't compatible with service mesh sidecar requirements
-if both Kong and its database are in the mesh.
+if Kong is to access the database through the mesh.
 
 Setting `waitImage.enabled=false` in values.yaml disables these init containers
 and resolves this issue. However, during the initial install, your Kong

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -471,8 +471,8 @@ directory.
 | migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |`
 | migrations.jobAnnotations          | Additional annotations for migration jobs                                             | `{}`                |
 | waitImage.enabled                  | Spawn init containers that wait for the database before starting Kong                 | `false              |
-| waitImage.repository               | Image used to wait for database to become ready                                       | `bash`              |
-| waitImage.tag                      | Tag for image used to wait for database to become ready                               | `5`                 |
+| waitImage.repository               | Image used to wait for database to become ready. Uses the Kong image if none set      |                     |
+| waitImage.tag                      | Tag for image used to wait for database to become ready                               |                     |
 | waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |
 | postgresql.enabled                 | Spin up a new postgres instance for Kong                                              | `false`             |
 | dblessConfig.configMap             | Name of an existing ConfigMap containing the `kong.yml` file. This must have the key `kong.yml`.| `` |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -468,7 +468,7 @@ directory.
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
-| migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |`
+| migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false" |
 | migrations.jobAnnotations          | Additional annotations for migration jobs                                             | `{}`                |
 | waitImage.enabled                  | Spawn init containers that wait for the database before starting Kong                 | `false              |
 | waitImage.repository               | Image used to wait for database to become ready. Uses the Kong image if none set      |                     |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -468,8 +468,9 @@ directory.
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
-| migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |
+| migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false", "kuma.io/sidecar-injection": "disabled"}` |`
 | migrations.jobAnnotations          | Additional annotations for migration jobs                                             | `{}`                |
+| waitImage.enabled                  | Spawn init containers that wait for the database before starting Kong                 | `false              |
 | waitImage.repository               | Image used to wait for database to become ready                                       | `bash`              |
 | waitImage.tag                      | Tag for image used to wait for database to become ready                               | `5`                 |
 | waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -470,7 +470,7 @@ directory.
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
 | migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false" |
 | migrations.jobAnnotations          | Additional annotations for migration jobs                                             | `{}`                |
-| waitImage.enabled                  | Spawn init containers that wait for the database before starting Kong                 | `false              |
+| waitImage.enabled                  | Spawn init containers that wait for the database before starting Kong                 | `true`              |
 | waitImage.repository               | Image used to wait for database to become ready. Uses the Kong image if none set      |                     |
 | waitImage.tag                      | Tag for image used to wait for database to become ready                               |                     |
 | waitImage.pullPolicy               | Wait image pull policy                                                                | `IfNotPresent`      |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -37,6 +37,7 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
   - [Standalone controller nodes](#standalone-controller-nodes)
   - [Hybrid mode](#hybrid-mode)
   - [CRDs only](#crds-only)
+  - [Sidecar containers](#sidecar-containers)
   - [Example configurations](#example-configurations)
 - [Configuration](#configuration)
   - [Kong Parameters](#kong-parameters)
@@ -154,26 +155,13 @@ Following sections detail on various high-level architecture options available:
 
 ### Database
 
-Kong can run with or without a database (DB-less).
-By default, this chart installs Kong without a database.
+Kong can run with or without a database (DB-less). By default, this chart
+installs Kong without a database.
 
-Although Kong can run with Postgres and Cassandra, the recommended database,
-if you would like to use one, is Postgres for Kubernetes installations.
-If your use-case warrants Cassandra, you should run the Cassandra cluster
-outside of Kubernetes.
+You can set the database the `env.database` parameter. For more details, please
+read the [env](#the-env-section) section.
 
-The database to use for Kong can be controlled via the `env.database` parameter.
-For more details, please read the [env](#the-env-section) section.
-
-Furthermore, this chart allows you to bring your own database that you manage
-or spin up a new Postgres instance using the `postgres.enabled` parameter.
-
-> Cassandra deployment via a sub-chart was previously supported but
-the support has now been dropped due to stability issues.
-You can still deploy Cassandra on your own and configure Kong to use
-that via the `env.database` parameter.
-
-#### DB-less  deployment
+#### DB-less deployment
 
 When deploying Kong in DB-less mode(`env.database: "off"`)
 and without the Ingress Controller(`ingressController.enabled: false`),
@@ -183,6 +171,18 @@ The configuration can be provided using an existing ConfigMap
 `values.yaml` file for deployment itself, under the `dblessConfig.config`
 parameter. See the example configuration in the default values.yaml
 for more details.
+
+#### Using the Postgres sub-chart
+
+The chart can optionally spawn a Postgres instance using [Bitnami's Postgres
+chart](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/README.md)
+as a sub-chart. Set `postgresql.enabled=true` to enable the sub-chart. Enabling
+this will auto-populate Postgres connection settings in Kong's environment.
+
+The Postgres sub-chart is best used to quickly provision temporary environments
+without installing and configuring your database separately. For longer-lived
+environments, we recommend you manage your database outside the Kong Helm
+release.
 
 ### Runtime package
 

--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -2,7 +2,7 @@
 # use single image strings instead of repository/tag
 
 image:
-  single: kong:2.0
+  unifiedRepoTag: kong:2.3
 proxy:
   type: NodePort
 
@@ -12,5 +12,5 @@ ingressController:
   env:
     anonymous_reports: "false"
   image:
-    single: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:0.8.1
+    unifiedRepoTag: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1.1
   installCRDs: false

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -365,7 +365,7 @@ The name of the service used for the ingress controller's validation webhook
   emptyDir: {}
 - name: {{ template "kong.fullname" . }}-tmp
   emptyDir: {}
-{{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
+{{- if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
 - name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
   configMap:
     name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
@@ -699,7 +699,7 @@ TODO: remove legacy admin listen behavior at a future date
   {{- $_ := set $autoEnv "KONG_PG_PORT" .Values.postgresql.service.port -}}
   {{- $pgPassword := include "secretkeyref" (dict "name" (include "kong.postgresql.fullname" .) "key" "postgresql-password") -}}
   {{- $_ := set $autoEnv "KONG_PG_PASSWORD" $pgPassword -}}
-{{- else if eq .Values.env.database "postgres" }}
+{{- else if .Values.postgresql.enabled }}
   {{- $_ := set $autoEnv "KONG_PG_PORT" "5432" }}
 {{- end }}
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -490,11 +490,7 @@ The name of the service used for the ingress controller's validation webhook
 
 {{- define "kong.wait-for-db" -}}
 - name: wait-for-db
-{{- if .Values.image.unifiedRepoTag }}
-  image: "{{ .Values.image.unifiedRepoTag }}"
-{{- else }}
-  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-{{- end }}
+  image: {{ include "kong.getRepoTag" .Values.image }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   env:
   {{- include "kong.env" . | nindent 2 }}
@@ -524,11 +520,7 @@ The name of the service used for the ingress controller's validation webhook
         apiVersion: v1
         fieldPath: metadata.namespace
 {{- include "kong.ingressController.env" .  | indent 2 }}
-{{- if .Values.ingressController.image.unifiedRepoTag }}
-  image: "{{ .Values.ingressController.image.unifiedRepoTag }}"
-{{- else }}
-  image: "{{ .Values.ingressController.image.repository }}:{{ .Values.ingressController.image.tag }}"
-{{- end }}
+  image: {{ include "kong.getRepoTag" .Values.ingressController.image }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   readinessProbe:
 {{ toYaml .Values.ingressController.readinessProbe | indent 4 }}
@@ -761,16 +753,10 @@ Environment variables are sorted alphabetically
 
 {{- define "kong.wait-for-postgres" -}}
 - name: wait-for-postgres
-{{- if .Values.waitImage.unifiedRepoTag }}
-  image: "{{ .Values.waitImage.unifiedRepoTag }}"
-{{- else if .Values.waitImage.repository }}
-  image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+{{- if (or .Values.waitImage.unifiedRepoTag .Values.waitImage.repository) }}
+  image: {{ include "kong.getRepoTag" .Values.waitImage }}
 {{- else }} {{/* default to the Kong image */}}
-{{- if .Values.image.unifiedRepoTag }}
-  image: "{{ .Values.image.unifiedRepoTag }}"
-{{- else }}
-  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-{{- end }}
+  image: {{ include "kong.getRepoTag" .Values.image }}
 {{- end }}
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:
@@ -789,4 +775,12 @@ Environment variables are sorted alphabetically
   {{- end -}}
   {{- $warningString := ($warnings | join "") -}}
   {{- $warningString -}}
+{{- end -}}
+
+{{- define "kong.getRepoTag" -}}
+{{- if .unifiedRepoTag }}
+{{- .unifiedRepoTag }}
+{{- else if .repository }}
+{{- .repository }}:{{ .tag }}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -763,8 +763,14 @@ Environment variables are sorted alphabetically
 - name: wait-for-postgres
 {{- if .Values.waitImage.unifiedRepoTag }}
   image: "{{ .Values.waitImage.unifiedRepoTag }}"
-{{- else }}
+{{- else if .Values.waitImage.repository }}
   image: "{{ .Values.waitImage.repository }}:{{ .Values.waitImage.tag }}"
+{{- else }} {{/* default to the Kong image */}}
+{{- if .Values.image.unifiedRepoTag }}
+  image: "{{ .Values.image.unifiedRepoTag }}"
+{{- else }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+{{- end }}
 {{- end }}
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -365,10 +365,12 @@ The name of the service used for the ingress controller's validation webhook
   emptyDir: {}
 - name: {{ template "kong.fullname" . }}-tmp
   emptyDir: {}
+{{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
 - name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
   configMap:
     name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
     defaultMode: 0755
+{{- end }}
 {{- range .Values.plugins.configMaps }}
 - name: kong-plugin-{{ .pluginName }}
   configMap:

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -62,8 +62,10 @@ spec:
       {{- end }}
       {{- if not (eq .Values.env.database "off") }}
       {{- if .Values.deployment.kong.enabled }}
+      {{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
       initContainers:
       {{- include "kong.wait-for-db" . | nindent 6 }}
+      {{- end }}
       {{ end }}
       {{ end }}
       containers:

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -60,14 +60,10 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if not (eq .Values.env.database "off") }}
-      {{- if .Values.deployment.kong.enabled }}
-      {{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
+      {{- if (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) }}
       initContainers:
       {{- include "kong.wait-for-db" . | nindent 6 }}
       {{- end }}
-      {{ end }}
-      {{ end }}
       containers:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -73,11 +73,7 @@ spec:
       {{- end }}
       {{- if .Values.deployment.kong.enabled }}
       - name: "proxy"
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -39,8 +39,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
       initContainers:
-      {{- if (eq .Values.env.database "postgres") }}
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}
       containers:

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -45,11 +45,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-post-upgrade-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -39,7 +39,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
+      {{- if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
       initContainers:
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -45,11 +45,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-upgrade-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -39,8 +39,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
       initContainers:
-      {{- if (eq .Values.env.database "postgres") }}
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}
       containers:

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -39,7 +39,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
+      {{- if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
       initContainers:
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -22,6 +22,7 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
+  annotations:
   {{- range $key, $value := .Values.migrations.jobAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -48,8 +48,8 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
       initContainers:
-      {{- if (eq .Values.env.database "postgres") }}
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}
       containers:

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -55,11 +55,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "kong.name" . }}-migrations
-        {{- if .Values.image.unifiedRepoTag }}
-        image: "{{ .Values.image.unifiedRepoTag }}"
-        {{- else }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- end }}
+        image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -49,7 +49,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
+      {{- if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
       initContainers:
       {{- include "kong.wait-for-postgres" . | nindent 6 }}
       {{- end }}

--- a/charts/kong/templates/wait-for-postgres-script.yaml
+++ b/charts/kong/templates/wait-for-postgres-script.yaml
@@ -1,4 +1,4 @@
-{{ if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
+{{ if (and (.Values.postgresql.enabled) .Values.waitImage.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/kong/templates/wait-for-postgres-script.yaml
+++ b/charts/kong/templates/wait-for-postgres-script.yaml
@@ -1,3 +1,4 @@
+{{ if (and (eq .Values.env.database "postgres") .Values.waitImage.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,4 +12,4 @@ data:
       do echo "waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}"
       sleep 2
     done
-
+{{ end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -408,6 +408,8 @@ postgresql:
 # -----------------------------------------------------------------------------
 
 waitImage:
+  # Wait for the database to come online before starting Kong or running migrations
+  enabled: false
   repository: bash
   tag: 5
   pullPolicy: IfNotPresent

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -408,8 +408,10 @@ postgresql:
 
 waitImage:
   # Wait for the database to come online before starting Kong or running migrations
-  # If Kong and its database are deployed within a service mesh that restricts
-  # traffic between pods, this must be disabled
+  # If Kong is to access the database through a service mesh that injects a sidecar to
+  # Kong's container, this must be disabled. Otherwise there'll be a deadlock:
+  # InitContainer waiting for DB access that requires the sidecar, and the sidecar
+  # waiting for InitContainers to finish.
   enabled: true
   # Optionally specify an image that provides bash for pre-migration database
   # checks. If none is specified, the chart uses the Kong image. The official

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -410,8 +410,11 @@ postgresql:
 waitImage:
   # Wait for the database to come online before starting Kong or running migrations
   enabled: false
-  repository: bash
-  tag: 5
+  # Optionally specify an image that provides bash for pre-migration database
+  # checks. If none is specified, the chart uses the Kong image. The official
+  # Kong images provide bash
+  # repository: bash
+  # tag: 5
   pullPolicy: IfNotPresent
 
 # update strategy

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -408,7 +408,9 @@ postgresql:
 
 waitImage:
   # Wait for the database to come online before starting Kong or running migrations
-  enabled: false
+  # If Kong and its database are deployed within a service mesh that restricts
+  # traffic between pods, this must be disabled
+  enabled: true
   # Optionally specify an image that provides bash for pre-migration database
   # checks. If none is specified, the chart uses the Kong image. The official
   # Kong images provide bash

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -274,7 +274,6 @@ migrations:
   # as the sidecar containers do not terminate and prevent the jobs from completing
   annotations:
     sidecar.istio.io/inject: false
-    kuma.io/sidecar-injection: "disabled"
   # Additional annotations to apply to migration jobs
   # This is helpful in certain non-Helm installation situations such as GitOps
   # where additional control is required around this job creation.


### PR DESCRIPTION
#### What this PR does / why we need it:
The main rationale for these changes is similar to [the proposal to remove these waits entirely](https://github.com/Kong/charts/pull/283#issue-575317230). Based on discussion in that PR, we favor this approach instead.

- Allows users to disable database waits for compatibility with service meshes.
- Uses the Kong image for wait-for-postgres init containers by default. This is fine for our stock images, as they include bash. The wait image configuration is now optional, for custom Kong images that don't include bash.
- Disables the wait-for-postgres ConfigMap and mounts if it isn't actually in use.
- Re-enables mesh proxies on Jobs.
- Cleans up some DB documentation.
- Adds a missing labels block to the init migrations job.

#### Special notes for your reviewer:
Supersedes #283 (similar goal, different approach) and #278 (cherry-picks that commit and rewords the title to follow this repo's format).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
