### PR TITLE
[kong] add user-configurable Service labels

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -53,6 +53,7 @@ $ helm install kong/kong --generate-name --set ingressController.installCRDs=fal
   - [RBAC](#rbac)
   - [Sessions](#sessions)
   - [Email/SMTP](#emailsmtp)
+- [Prometheus Operator integration](#prometheus-operator-integration)
 - [Changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md)
 - [Upgrading](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md)
 - [Seeking help](#seeking-help)
@@ -536,6 +537,7 @@ nodes.
 | SVC.ingress.path                   | Ingress path.                                                                         | `/`                 |
 | SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
 | SVC.annotations                    | Service annotations                                                                   | `{}`                |
+| SVC.annotations                    | Service labels                                                                        | `{}`                |
 
 #### Stream listens
 
@@ -804,6 +806,30 @@ that these have limited functionality without sending email.
 If your SMTP server requires authentication, you must provide the `username` and `smtp_password_secret` keys under `.enterprise.smtp.auth`. `smtp_password_secret` must be a Secret containing an `smtp_password` key whose value is your SMTP password.
 
 By default, SMTP uses `AUTH` `PLAIN` when you provide credentials. If your provider requires `AUTH LOGIN`, set `smtp_auth_type: login`.
+
+## Prometheus Operator integration
+
+The chart can configure a ServiceMonitor resource to instruct the [Prometheus
+Operator](https://github.com/prometheus-operator/prometheus-operator) to
+collect metrics from Kong Pods. To enable this, set
+`serviceMonitor.enabled=true` in values.yaml.
+
+Kong exposes memory usage and connection counts by default. You can enable
+traffic metrics for routes and services by configuring the [Prometheus
+plugin](https://docs.konghq.com/hub/kong-inc/prometheus/).
+
+The ServiceMonitor requires an `enable-metrics: "true"` label on one of the
+chart's Services to collect data. By default, this label is set on the proxy
+Service. It should only be set on a single chart Service to avoid duplicate
+data. If you disable the proxy Service (e.g. on a hybrid control plane instance
+or Portal-only instance) and still wish to collect memory usage metrics, add
+this label to another Service, e.g. on the admin API Service:
+
+```
+admin:
+  labels:
+    enable-metrics: "true"
+```
 
 ## Seeking help
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -537,7 +537,7 @@ nodes.
 | SVC.ingress.path                   | Ingress path.                                                                         | `/`                 |
 | SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
 | SVC.annotations                    | Service annotations                                                                   | `{}`                |
-| SVC.annotations                    | Service labels                                                                        | `{}`                |
+| SVC.labels                         | Service labels                                                                        | `{}`                |
 
 #### Stream listens
 
@@ -812,7 +812,7 @@ By default, SMTP uses `AUTH` `PLAIN` when you provide credentials. If your provi
 The chart can configure a ServiceMonitor resource to instruct the [Prometheus
 Operator](https://github.com/prometheus-operator/prometheus-operator) to
 collect metrics from Kong Pods. To enable this, set
-`serviceMonitor.enabled=true` in values.yaml.
+`serviceMonitor.enabled=true` in `values.yaml`.
 
 Kong exposes memory usage and connection counts by default. You can enable
 traffic metrics for routes and services by configuring the [Prometheus

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -110,6 +110,9 @@ metadata:
   {{- end }}
   labels:
     {{- .metaLabels | nindent 4 }}
+  {{- range $key, $value := .labels }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   type: {{ .type }}
   {{- if eq .type "LoadBalancer" }}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -4,10 +4,7 @@
 {{- $serviceConfig := merge $serviceConfig .Values.proxy -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
-{{/* Only the proxy should have metrics enabled, but our labels generation is neither configurable nor flexible.
-     Pending a broader need for something more flexible, using string manipulation.
-*/}}
-{{- $_ := set $serviceConfig "metaLabels" (printf "%s\n%s" (include "kong.metaLabels" .) "enable-metrics: \"true\"") -}}
+{{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
 {{- $_ := set $serviceConfig "serviceName" "proxy" -}}
 {{- include "kong.service" $serviceConfig }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -78,8 +78,8 @@ admin:
   # Enterprise users that wish to use Kong Manager with the controller should enable this
   enabled: false
   type: NodePort
-  # To specify annotations or labels for the admin service, remove the "{}" and add indented lines
-  # after, similar to the commented aws-load-balancer-proxy-protocol example
+  # To specify annotations or labels for the admin service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
   labels: {}
@@ -153,8 +153,8 @@ status:
 # provider's documentation, as the configuration required for this varies).
 cluster:
   enabled: false
-  # To specify annotations or labels for the cluster service, remove the "{}" and add indented lines
-  # after, similar to the commented aws-load-balancer-proxy-protocol example
+  # To specify annotations or labels for the cluster service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
   labels: {}
@@ -172,8 +172,8 @@ proxy:
   # Enable creating a Kubernetes service for the proxy
   enabled: true
   type: LoadBalancer
-  # To specify annotations or labels for the proxy service, remove the "{}" and add indented lines
-  # after, similar to the commented aws-load-balancer-proxy-protocol example
+  # To specify annotations or labels for the proxy service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
   labels:
@@ -625,8 +625,8 @@ manager:
   # Enable creating a Kubernetes service for Kong Manager
   enabled: true
   type: NodePort
-  # To specify annotations or labels for the Manager service, remove the "{}" and add indented lines
-  # after, similar to the commented aws-load-balancer-proxy-protocol example
+  # To specify annotations or labels for the Manager service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
   labels: {}
@@ -668,8 +668,8 @@ portal:
   # Enable creating a Kubernetes service for the Developer Portal
   enabled: true
   type: NodePort
-  # To specify annotations or labels for the Portal service, remove the "{}" and add indented lines
-  # after, similar to the commented aws-load-balancer-proxy-protocol example
+  # To specify annotations or labels for the Portal service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
   labels: {}
@@ -711,8 +711,8 @@ portalapi:
   # Enable creating a Kubernetes service for the Developer Portal API
   enabled: true
   type: NodePort
-  # To specify annotations or labels for the Portal API service, remove the "{}" and add indented lines
-  # after, similar to the commented aws-load-balancer-proxy-protocol example
+  # To specify annotations or labels for the Portal API service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
   labels: {}
@@ -752,8 +752,8 @@ portalapi:
 
 clustertelemetry:
   enabled: false
-  # To specify annotations or labels for the cluster telemetry service, remove the "{}" and add indented lines
-  # after, similar to the commented aws-load-balancer-proxy-protocol example
+  # To specify annotations or labels for the cluster telemetry service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
   labels: {}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -78,10 +78,11 @@ admin:
   # Enterprise users that wish to use Kong Manager with the controller should enable this
   enabled: false
   type: NodePort
-  # If you want to specify annotations for the admin service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the admin service, remove the "{}" and add indented lines
+  # after, similar to the commented aws-load-balancer-proxy-protocol example
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   http:
     # Enable plaintext HTTP listen for the admin API
@@ -152,10 +153,11 @@ status:
 # provider's documentation, as the configuration required for this varies).
 cluster:
   enabled: false
-  # If you want to specify annotations for the cluster service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the cluster service, remove the "{}" and add indented lines
+  # after, similar to the commented aws-load-balancer-proxy-protocol example
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   tls:
     enabled: false
@@ -170,10 +172,12 @@ proxy:
   # Enable creating a Kubernetes service for the proxy
   enabled: true
   type: LoadBalancer
-  # If you want to specify annotations for the proxy service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the proxy service, remove the "{}" and add indented lines
+  # after, similar to the commented aws-load-balancer-proxy-protocol example
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels:
+    enable-metrics: "true"
 
   http:
     # Enable plaintext HTTP listen for the proxy
@@ -621,10 +625,11 @@ manager:
   # Enable creating a Kubernetes service for Kong Manager
   enabled: true
   type: NodePort
-  # If you want to specify annotations for the Manager service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the Manager service, remove the "{}" and add indented lines
+  # after, similar to the commented aws-load-balancer-proxy-protocol example
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   http:
     # Enable plaintext HTTP listen for Kong Manager
@@ -663,10 +668,11 @@ portal:
   # Enable creating a Kubernetes service for the Developer Portal
   enabled: true
   type: NodePort
-  # If you want to specify annotations for the Portal service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the Portal service, remove the "{}" and add indented lines
+  # after, similar to the commented aws-load-balancer-proxy-protocol example
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   http:
     # Enable plaintext HTTP listen for the Developer Portal
@@ -705,10 +711,11 @@ portalapi:
   # Enable creating a Kubernetes service for the Developer Portal API
   enabled: true
   type: NodePort
-  # If you want to specify annotations for the Portal API service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the Portal API service, remove the "{}" and add indented lines
+  # after, similar to the commented aws-load-balancer-proxy-protocol example
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   http:
     # Enable plaintext HTTP listen for the Developer Portal API
@@ -745,10 +752,11 @@ portalapi:
 
 clustertelemetry:
   enabled: false
-  # If you want to specify annotations for the cluster telemetry service, uncomment the following
-  # line, add additional or adjust as needed, and remove the curly braces after 'annotations:'.
+  # To specify annotations or labels for the cluster telemetry service, remove the "{}" and add indented lines
+  # after, similar to the commented aws-load-balancer-proxy-protocol example
   annotations: {}
   #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
 
   tls:
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds configurable Service labels with a default proxy Service label.

Adds documentation for the Prometheus Operator integration.

#### Which issue this PR fixes
Indirectly fixes https://github.com/Kong/charts/issues/272. Currently the ServiceMonitor does nothing if the proxy Service is disabled, as we hard-coded the monitor label on it and did not have any means for users to add labels themselves.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
