### PR TITLE
[kong] release 1.15.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## 1.15.0
+
+1.15.0 is an interim release before the planned release of 2.0.0. There were
+several feature changes we wanted to release prior to the removal of deprecated
+functionality for 2.0. The original planned deprecations covered in the [1.14.0
+changelog](#1140) are still planned for 2.0.0.
+
+### Improvements
+
+* The default Kong version is now 2.3 and the default Kong Enterprise version
+  is now 2.3.2.0.
+* Added configurable `terminationGracePeriodSeconds` for the pre-stop lifecycle
+  hook.
+  ([#271](https://github.com/Kong/charts/pull/271)).
+* Initial migration database wait init containers no longer have a default
+  image configuration in values.yaml. When no image is specified, the chart
+  will use the Kong image. The standard Kong images include bash, and can run
+  the database wait script without downloading a separate image. Configuring a
+  wait image is now only necessary if you use a custom Kong image that lacks
+  bash.
+  ([#285](https://github.com/Kong/charts/pull/285)).
+* Init containers for database availability and migration completeness can now
+  be disabled. They cause compatibility issues with many service meshes.
+  ([#285](https://github.com/Kong/charts/pull/285)).
+* Removed the default migration Job annotation that disabled Kuma's mesh proxy.
+  The latest version of Kuma no longer prevents Jobs from completing.
+  ([#285](https://github.com/Kong/charts/pull/285)).
+* Services now support user-configurable labels, and the Prometheus
+  ServiceMonitor label is included on the proxy Service by default. Users that
+  disable the proxy Service and add this label to another Service to collect
+  metrics.
+  ([#290](https://github.com/Kong/charts/pull/290)).
+* Migration Jobs now allow resource quota configuration. Init containers
+  inherit their resource quotas from their associated Kong container.
+  ([#294](https://github.com/Kong/charts/pull/294)).
+
+### Fixed
+
+* The database readiness wait script ConfigMap and associated mounts are no
+  longer created if that feature is not in use.
+  ([#285](https://github.com/Kong/charts/pull/285)).
+* Removed a duplicated field from CRDs.
+  ([#281](https://github.com/Kong/charts/pull/281)).
+
 ## 1.14.5
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.14.5
-appVersion: 2.2
+version: 1.15.0
+appVersion: 2.3

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -690,11 +690,10 @@ Kong is going to be deployed.
 
 #### Kong Enterprise Docker registry access
 
-Next, we need to setup Docker credentials in order to allow Kubernetes
-nodes to pull down Kong Enterprise Docker images, which are hosted in a private
-registry.
+Kong Enterprise versions 2.2 and earlier use a private Docker registry and
+require a pull secret. If you use 2.3 or newer, you can skip this step.
 
-You should received credentials to log into https://bintray.com/kong after
+You should have received credentials to log into https://bintray.com/kong after
 purchasing Kong Enterprise. After logging in, you can retrieve your API key
 from \<your username\> \> Edit Profile \> API Key. Use this to create registry
 secrets:

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -691,7 +691,7 @@ Kong is going to be deployed.
 #### Kong Enterprise Docker registry access
 
 Kong Enterprise versions 2.2 and earlier use a private Docker registry and
-require a pull secret. If you use 2.3 or newer, you can skip this step.
+require a pull secret. **If you use 2.3 or newer, you can skip this step.**
 
 You should have received credentials to log into https://bintray.com/kong after
 purchasing Kong Enterprise. After logging in, you can retrieve your API key

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -1,8 +1,11 @@
 # This tests the following unrelated aspects of Ingress Controller
 # - ingressController deploys with a database
-# - TODO database-backed proxy works _without_ stream listens
-#   This test is a duplicate of test2-values.yaml to handle the https://github.com/Kong/charts/issues/295
-#   workaround when the socket file is _not_ created
+# - TODO remove this test when https://github.com/Kong/charts/issues/295 is solved
+#   and its associated wait-for-db workaround is removed.
+#   This test is similar to test2-values.yaml, but lacks a stream listen.
+#   wait-for-db will _not_ create a socket file. This test ensures the workaround
+#   does not interfere with startup when there is no file to remove.
+
 ingressController:
   enabled: true
   installCRDs: false

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -1,6 +1,8 @@
 # This tests the following unrelated aspects of Ingress Controller
 # - ingressController deploys with a database
-# - stream listens work
+# - TODO database-backed proxy works _without_ stream listens
+#   This test is a duplicate of test2-values.yaml to handle the https://github.com/Kong/charts/issues/295
+#   workaround when the socket file is _not_ created
 ingressController:
   enabled: true
   installCRDs: false
@@ -29,15 +31,6 @@ proxy:
     hostname: proxy.kong.example
     annotations: {}
     path: /
-# - add stream listens
-  stream:
-  - containerPort: 9000
-    servicePort: 9000
-    parameters: []
-  - containerPort: 9001
-    servicePort: 9001
-    parameters:
-    - ssl
 
 # - PDB is enabled
 podDisruptionBudget:

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -11,11 +11,8 @@
 #   the Portal and Portal API.
 
 image:
-  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.2.1.0-alpine
-  pullSecrets:
-    # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
-    - kong-enterprise-edition-docker
+  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
+  tag: "2.3.2.0-alpine"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -8,11 +8,8 @@
 # kubectl port-forward deploy/your-deployment-kong 8001:8001 8002:8002
 
 image:
-  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.2.1.0-alpine
-  pullSecrets:
-    # CHANGEME: https://github.com/Kong/charts/blob/main/charts/kong/README.md#kong-enterprise-docker-registry-access
-    - kong-enterprise-edition-docker
+  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
+  tag: "2.3.2.0-alpine"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-controller.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -3,12 +3,8 @@
 # Secrets. These Secrets must be created before installation.
 
 image:
-  repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  tag: 2.2.1.0-alpine
-
-  pullSecrets:
-    # CHANGEME: https://github.com/Kong/charts/blob/master/charts/kong/README.md#kong-enterprise-docker-registry-access
-    - kong-enterprise-edition-docker
+  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
+  tag: "2.3.2.0-alpine"
 
 enterprise:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -11,7 +11,7 @@
 
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -500,7 +500,7 @@ The name of the service used for the ingress controller's validation webhook
   {{- include "kong.env" . | nindent 2 }}
 {{/* TODO: the rm command here is a workaround for https://github.com/Kong/charts/issues/295
      It should be removed once that's fixed */}}
-  command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop; if stat {{ $sockFile }} > /dev/null; then rm {{ $sockFile }}; else true; fi"]
+  command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop; rm -fv {{ $sockFile | squote }}"]
   volumeMounts:
   {{- include "kong.volumeMounts" . | nindent 4 }}
   resources:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -57,10 +57,10 @@ env:
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "2.2"
+  tag: "2.3"
   # Kong Enterprise
-  # repository: kong-docker-kong-enterprise-edition-docker.bintray.io/kong-enterprise-edition
-  # tag: "2.2.1.0-alpine"
+  # repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
+  # tag: "2.3.2.0-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
#### What this PR does / why we need it:
Bumps Kong image versions and releases 1.15.0 to next.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #291 

#### Special notes for your reviewer:
This is blocked on:
- Approval and merger of #290.
- Review of the compatibility concerns from #291 

The content of this PR is not expected to change if those are complete and we don't see a reason to hold off on the 2.3 bump.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
