### PR TITLE
Revert "[kong] readme: pull secrets are not needed anymore since Kong Enterprise 2.3 (#296)"

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -684,9 +684,7 @@ Set the secret name in `values.yaml`, in the `.enterprise.license_secret` key.
 Please ensure the above secret is created in the same namespace in which
 Kong is going to be deployed.
 
-#### Kong Enterprise Docker registry access (only for Kong <2.3)
-
-:bulb: This is needed only for Kong Enterprise versions older than 2.3 - from 2.3 onwards, the image can be downloaded without those pullSecrets.
+#### Kong Enterprise Docker registry access
 
 Next, we need to setup Docker credentials in order to allow Kubernetes
 nodes to pull down Kong Enterprise Docker images, which are hosted in a private


### PR DESCRIPTION
This reverts commit f678a0ffa26881847bcd63185c1f29ea70a55420 (#296).

This is because the PR should have gone to `next`, not to `main`.