### PR TITLE
[kong] clarify terminationGracePeriodSeconds docs

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -594,7 +594,7 @@ For a complete list of all configuration values you can set in the
 | readinessProbe                     | Kong readiness probe                                                                  |                     |
 | livenessProbe                      | Kong liveness probe                                                                   |                     |
 | lifecycle                          | Proxy container lifecycle hooks                                                       | see `values.yaml`   |
-| terminationGracePeriodSeconds      | Related to lifecycle hook                                                             | 30                  |
+| terminationGracePeriodSeconds      | Sets the [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for Deployment pods | 30                  |
 | affinity                           | Node/pod affinities                                                                   |                     |
 | nodeSelector                       | Node labels for pod assignment                                                        | `{}`                |
 | deploymentAnnotations              | Annotations to add to deployment                                                      |  see `values.yaml`  |

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -483,7 +483,7 @@ lifecycle:
       # Note kong quit has a default timeout of 10 seconds
       command: ["/bin/sh", "-c", "/bin/sleep 15 && kong quit"]
 
-# terminationGracePeriodSeconds is closely related to the lifecycle preStop hook
+# Sets the termination grace period for pods spawned by the Kubernetes Deployment.
 # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
 terminationGracePeriodSeconds: 30
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Doc changes suggested in #300.

#### Special notes for your reviewer:
Pulled out separately since I didn't want to add new stuff in the merge from next to main in #300 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
