### PR TITLE
[kong] remove deprecated configuration slated for removal in 2.x

### DIFF
--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -1,20 +1,10 @@
 # CI test for testing dbless deployment without ingress controllers using legacy admin listen and stream listens
-# TODO: remove legacy admin listen behavior at a future date
 # - disable ingress controller
 ingressController:
   enabled: false
   installCRDs: false
   env:
     anonymous_reports: "false"
-# - use legacy admin listen config
-admin:
-  enabled: true
-  useTLS: true
-  servicePort: 8444
-  containerPort: 8444
-  ingress:
-    enabled: true
-    hostname: admin.kong.example
 
 # - disable DB for kong
 env:

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -42,6 +42,3 @@ proxy:
     - ssl
   ingress:
     enabled: true
-    hosts:
-    - foo.kong.example
-    - bar.kong.example

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -13,11 +13,6 @@ Kong: https://bit.ly/k4k8s-get-started
 
 {{ $warnings := list -}}
 
-{{- if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}}
-{{/* Legacy Portal auth handling */}}
-{{- $warnings = append $warnings "You are currently using legacy Portal authentication configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-dedicated-portal-authentication-configuration-parameters" -}}
-{{- end -}}
-
 {{- if .Values.admin.containerPort -}}
 {{/* Legacy admin API listen */}}
 {{- $warnings = append $warnings "You are currently using legacy admin API configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration" -}}

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -18,11 +18,6 @@ Kong: https://bit.ly/k4k8s-get-started
 {{- $warnings = append $warnings "You are currently using legacy admin API configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration" -}}
 {{- end -}}
 
-{{- if .Values.runMigrations -}}
-{{/* Legacy migration toggle */}}
-{{- $warnings = append $warnings "You are currently using the legacy runMigrations setting in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-migration-job-configuration" -}}
-{{- end -}}
-
 {{ if (hasKey .Values "proxy.ingress.hosts") -}}
 {{/* Legacy proxy ingress */}}
 {{- $warnings = append $warnings "You are currently using legacy proxy Ingress configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress" -}}

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -13,9 +13,4 @@ Kong: https://bit.ly/k4k8s-get-started
 
 {{ $warnings := list -}}
 
-{{ if (hasKey .Values "proxy.ingress.hosts") -}}
-{{/* Legacy proxy ingress */}}
-{{- $warnings = append $warnings "You are currently using legacy proxy Ingress configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress" -}}
-{{- end -}}
-
 {{- include "kong.deprecation-warnings" $warnings -}}

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -13,11 +13,6 @@ Kong: https://bit.ly/k4k8s-get-started
 
 {{ $warnings := list -}}
 
-{{- if .Values.admin.containerPort -}}
-{{/* Legacy admin API listen */}}
-{{- $warnings = append $warnings "You are currently using legacy admin API configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration" -}}
-{{- end -}}
-
 {{ if (hasKey .Values "proxy.ingress.hosts") -}}
 {{/* Legacy proxy ingress */}}
 {{- $warnings = append $warnings "You are currently using legacy proxy Ingress configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress" -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -276,20 +276,12 @@ Create a single listen (IP+port+parameter combo)
 Return the local admin API URL, preferring HTTPS if available
 */}}
 {{- define "kong.adminLocalURL" -}}
-  {{- if .Values.admin.containerPort -}} {{/* TODO: Remove legacy admin behavior */}}
-    {{- if .Values.admin.useTLS -}}
-https://localhost:{{ .Values.admin.containerPort }}
-    {{- else -}}
-http://localhost:{{ .Values.admin.containerPort }}
-    {{- end -}}
-  {{- else -}}
-    {{- if .Values.admin.tls.enabled -}}
+  {{- if .Values.admin.tls.enabled -}}
 https://localhost:{{ .Values.admin.tls.containerPort }}
-    {{- else if .Values.admin.http.enabled -}}
+  {{- else if .Values.admin.http.enabled -}}
 http://localhost:{{ .Values.admin.http.containerPort }}
-    {{- else -}}
+  {{- else -}}
 http://localhost:9999 # You have no admin listens! The controller will not work unless you set .Values.admin.http.enabled=true or .Values.admin.tls.enabled=true!
-    {{- end -}}
   {{- end -}}
 {{- end -}}
 
@@ -580,27 +572,15 @@ the template that it itself is using form the above sections.
   {{- $_ := set $autoEnv "KONG_KIC" "on" -}}
 {{- end -}}
 
-{{/*
-TODO: remove legacy admin listen behavior at a future date
-*/}}
-
 {{- with .Values.admin -}}
   {{- $address := "0.0.0.0" -}}
   {{- if (not .enabled) -}}
     {{- $address = "127.0.0.1" -}}
   {{- end -}}
-  {{- if .containerPort -}} {{/* Legacy admin listener */}}
-    {{- if .useTLS -}}
-      {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "%s:%d ssl" $address (int64 .containerPort)) -}}
-    {{- else -}}
-      {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "%s:%d" $address (int64 .containerPort)) -}}
-    {{- end -}}
-  {{- else -}} {{/* Modern admin listener */}}
-    {{- $listenConfig := dict -}}
-    {{- $listenConfig := merge $listenConfig . -}}
-    {{- $_ := set $listenConfig "address" $address -}}
-    {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (include "kong.listen" $listenConfig) -}}
-  {{- end -}}
+  {{- $listenConfig := dict -}}
+  {{- $listenConfig := merge $listenConfig . -}}
+  {{- $_ := set $listenConfig "address" $address -}}
+  {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (include "kong.listen" $listenConfig) -}}
 {{- end -}}
 
 {{- if .Values.admin.ingress.enabled }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -647,12 +647,6 @@ TODO: remove legacy admin listen behavior at a future date
     {{- if .Values.portalapi.ingress.enabled }}
       {{- $_ := set $autoEnv "KONG_PORTAL_API_URL" (include "kong.ingress.serviceUrl" .Values.portalapi.ingress) -}}
     {{- end }}
-
-    {{- if .Values.enterprise.portal.portal_auth }} {{/* TODO: deprecated, remove in a future version */}}
-      {{- $_ := set $autoEnv "KONG_PORTAL_AUTH" .Values.enterprise.portal.portal_auth -}}
-      {{- $portalSession := include "secretkeyref" (dict "name" .Values.enterprise.portal.session_conf_secret "key" "portal_session_conf") -}}
-      {{- $_ := set $autoEnv "KONG_PORTAL_SESSION_CONF" $portalSession -}}
-    {{- end }}
   {{- end }}
 
   {{- if .Values.enterprise.rbac.enabled }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -77,15 +77,6 @@ spec:
         lifecycle:
           {{- toYaml .Values.lifecycle | nindent 10 }}
         ports:
-        {{/* TODO: remove legacy admin port template */}}
-        {{- if (and .Values.admin.containerPort .Values.admin.enabled) }}
-        - name: admin
-          containerPort: {{ .Values.admin.containerPort }}
-          {{- if .Values.admin.hostPort }}
-          hostPort: {{ .Values.admin.hostPort }}
-          {{- end}}
-          protocol: TCP
-        {{- end }}
         {{- if (and .Values.admin.http.enabled .Values.admin.enabled) }}
         - name: admin
           containerPort: {{ .Values.admin.http.containerPort }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.kong.enabled }}
-{{- if (and (or (.Values.runMigrations) (.Values.migrations.postUpgrade)) (not (eq .Values.env.database "off"))) }}
+{{- if (and .Values.migrations.postUpgrade (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.kong.enabled }}
-{{- if (and (or (.Values.runMigrations) (.Values.migrations.preUpgrade)) (not (eq .Values.env.database "off"))) }}
+{{- if (and .Values.migrations.preUpgrade (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -9,8 +9,6 @@
 {{- $runInit := true -}}
 {{- if (hasKey .Values.migrations "init") -}}
   {{- $runInit = .Values.migrations.init -}}
-{{- else if (hasKey .Values "runMigrations") -}}
-  {{- $runInit = .Values.runMigrations -}}
 {{- end -}}
 
 {{- if (and ($runInit) (not (eq .Values.env.database "off"))) }}

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -1,83 +1,3 @@
-{{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
-{{- if .Values.deployment.kong.enabled }}
-{{- if .Values.admin.enabled -}}
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "kong.fullname" . }}-admin
-  namespace: {{ template "kong.namespace" . }}
-  {{- if .Values.admin.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.admin.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-spec:
-  type: {{ .Values.admin.type }}
-  {{- if eq .Values.admin.type "LoadBalancer" }}
-  {{- if .Values.admin.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
-  {{- end }}
-  {{- if .Values.admin.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.admin.loadBalancerSourceRanges }}
-  - {{ $cidr }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  ports:
-  - name: kong-admin
-    port: {{ .Values.admin.servicePort }}
-    targetPort: {{ .Values.admin.containerPort }}
-  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.nodePort))) }}
-    nodePort: {{ .Values.admin.nodePort }}
-  {{- end }}
-    protocol: TCP
-  selector:
-    {{- include "kong.selectorLabels" . | nindent 4 }}
-{{- end -}}
-{{- end }}
----
-{{ if .Values.admin.ingress.enabled -}}
-{{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := .Values.admin.servicePort -}}
-{{- $path := .Values.admin.ingress.path -}}
-{{- $tls := .Values.admin.ingress.tls -}}
-{{- $hostname := .Values.admin.ingress.hostname -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ template "kong.fullname" . }}-admin
-  namespace: {{ template "kong.namespace" . }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-  {{- if .Values.admin.ingress.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.admin.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-spec:
-  rules:
-  - host: {{ $hostname }}
-    http:
-      paths:
-        - path: {{ $path }}
-          backend:
-            serviceName: {{ $serviceName }}-admin
-            servicePort: {{ $servicePort }}
-  {{- if $tls }}
-  tls:
-  - hosts:
-    - {{ $hostname }}
-    secretName: {{ $tls }}
-  {{- end -}}
-{{- end -}}
-
-{{- else -}} {{/* Modern admin handler */}}
-
 {{- if .Values.deployment.kong.enabled }}
 {{- if and .Values.admin.enabled (or .Values.admin.http.enabled .Values.admin.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
@@ -91,7 +11,6 @@ spec:
 {{ if .Values.admin.ingress.enabled }}
 ---
 {{ include "kong.ingress" $serviceConfig }}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -10,41 +10,7 @@
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.proxy.ingress.enabled }}
 ---
-{{ if (not (hasKey .Values.proxy.ingress "hosts"))  -}}
 {{ include "kong.ingress" $serviceConfig }}
-{{ else -}} {{/* TODO remove legacy proxy ingress handling */}}
-{{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
-{{- $path := .Values.proxy.ingress.path -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ template "kong.fullname" . }}-proxy
-  namespace: {{ template "kong.namespace" . }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-  {{- if .Values.proxy.ingress.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.proxy.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-spec:
-  rules:
-    {{- range $host := .Values.proxy.ingress.hosts }}
-    - host: {{ $host | quote }}
-      http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-proxy
-              servicePort: {{ $servicePort }}
-    {{- end -}}
-  {{- if .Values.proxy.ingress.tls }}
-  tls:
-{{ toYaml .Values.proxy.ingress.tls | indent 2 }}
-  {{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Clears out previously-deprecated template code scheduled for removal in 2.x. See individual commits/issues for details.

#### Which issue this PR fixes
Closes #286, #287, #288, and #289 

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
