### PR TITLE
[kong] change installCRDs default while handling installations with the old default

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -31,7 +31,7 @@ $ helm install kong/kong --generate-name
   - [Separate admin and proxy nodes](#separate-admin-and-proxy-nodes)
   - [Standalone controller nodes](#standalone-controller-nodes)
   - [Hybrid mode](#hybrid-mode)
-  - [CRDs only](#crds-only)
+  - [CRD management](#crd-management)
   - [Sidecar containers](#sidecar-containers)
   - [Example configurations](#example-configurations)
 - [Configuration](#configuration)
@@ -394,16 +394,16 @@ documentation on Service
 DNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/)
 for more detail.
 
-### CRDs only
+### CRD management
 
-Earlier iterations of this chart (<2.0) created CRDs associated with the
-ingress controller as part of the release. This raised two challenges:
+Earlier versions of this chart (<2.0) created CRDs associated with the ingress
+controller as part of the release. This raised two challenges:
 
-- Multiple installations of the chart would conflict with one another, as each
-  would attempt to create its own set of CRDs.
+- Multiple release of the chart would conflict with one another, as each would
+  attempt to create its own set of CRDs.
 - Because deleting a CRD also deletes any custom resources associated with it,
-  uninstalling the chart could destroy user configuration without providing any
-  means to restore it.
+  deleting a release of the chart could destroy user configuration without
+  providing any means to restore it.
 
 Helm 3 introduced a simplified CRD management method that was safer, but
 requires some manual work when a chart added or modified CRDs: CRDs are created
@@ -414,15 +414,17 @@ recommended for most users.
 
 Some users may wish to manage their CRDs automatically. If you manage your CRDs
 this way, we _strongly_ recommend that you back up all associated custom
-resources in the event you need to recover from unintended CRD deletion. To
-manage CRDs via a Helm release, you can either:
+resources in the event you need to recover from unintended CRD deletion.
 
-- Set `ingressController.enabled=true` and
-  `ingressController.installCRDs=true`. These CRDs will be managed along with
-  your Kong release.
-- Set `ingressController.enabled=false`, `deployment.kong.enabled=false`, and
-  `ingressController.installCRDs=true`. This creates a CRD-only release that
-  you can upgrade independent of your Kong release(s).
+While Helm 3's CRD management system is recommended, there is no simple means
+of migrating away from release-managed CRDs if you previously installed your
+release with the old system (you would need to back up your existing custom
+resources, delete your release, reinstall, and restore your custom resources
+after). As such, the chart detects if you currently use release-managed CRDs
+and continues to use the old CRD templates when using chart version 2.0+. If
+you do (your resources will have a `meta.helm.sh/release-name` annotation), we
+_strongly_ recommend that you back up all associated custom resources in the
+event you need to recover from unintended CRD deletion.
 
 ### Sidecar Containers
 

--- a/charts/kong/templates/custom-resource-definitions.yaml
+++ b/charts/kong/templates/custom-resource-definitions.yaml
@@ -1,9 +1,34 @@
-{{/*
-This handles two cases where we should render this template. These map to the two top-level or clauses:
-- This is a controller-managed Helm 2 install. The controller is enabled and installCRDs is enabled.
-- This is a CRD-only install. Neither the controller nor Kong are enabled (the "not or") and installCRDs is enabled.
-*/}}
-{{- if (or (and .Values.ingressController.enabled .Values.ingressController.installCRDs) (and (not (or .Values.deployment.kong.enabled .Values.ingressController.enabled )) .Values.ingressController.installCRDs)) -}}
+{{- $installCRDs := false -}}
+{{- if .Values.ingressController.installCRDs -}}
+  {{- if .Values.ingressController.enabled -}}
+    {{/* Managed CRD installation is enabled, and the controller is enabled.
+    */}}
+    {{- $installCRDs = true -}}
+  {{- else if (not .Values.deployment.kong.enabled) -}}
+    {{/* Managed CRD installation is enabled, and neither the controller nor Kong or enabled.
+         This is a CRD-only release.
+    */}}
+    {{- $installCRDs = true -}}
+  {{- end -}}
+{{- else -}}
+  {{/* Legacy default handling. CRD installation is _not_ enabled, but CRDs are already present
+       and are managed by this release. This release previously relied on the <2.0 default
+       .Values.ingressController.installCRDs=true. The default change would delete CRDs on upgrade,
+       which would cascade delete all associated CRs. This unexpected loss of configuration is bad,
+       so this clause pretends the default didn't change if you have an existing release that relied
+       on it
+  */}}
+  {{- $kongPluginCRD := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "kongplugins.configuration.konghq.com") -}}
+  {{- if $kongPluginCRD -}}
+    {{- if (hasKey $kongPluginCRD.metadata "annotations") -}}
+      {{- if (eq .Release.Name (get $kongPluginCRD.metadata.annotations "meta.helm.sh/release-name")) -}}
+        {{- $installCRDs = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $installCRDs -}}
 {{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
 {{ $.Files.Get $path }}
 ---

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -358,8 +358,6 @@ ingressController:
     # The annotations for service account
     annotations: {}
 
-  installCRDs: false
-
   # general properties
   livenessProbe:
     httpGet:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -358,7 +358,7 @@ ingressController:
     # The annotations for service account
     annotations: {}
 
-  installCRDs: true
+  installCRDs: false
 
   # general properties
   livenessProbe:


### PR DESCRIPTION
#### What this PR does / why we need it:
- Changes the values.yaml default `ingressController.installCRDs=true` to `ingressController.installCRDs=false`
- Adds lookup logic to make this change have no effect on existing installations that used the old default. If you created a release with `installCRDs=true` in the past, changing that setting, either intentionally or because the default changed, has no effect.

This seeks to address two goals:
- The current default conflicts with Helm 3's default behavior, which creates all CRDs under the `crds/` directory during install, but does not make them part of the release. Attempting to use that behavior with `installCRDs=true` attempts to create the same set of CRDs twice, which fails and prevents the installation from completing. As such, we [instruct Helm 3 users to override the default or use `--skip-crds`](https://github.com/Kong/charts/blob/main/charts/kong/README.md#helm-3). We don't want this: the default values.yaml should be valid without overrides or non-default install flags.
- Changing the default without the fallback logic is dangerous. If an installation is already using managed CRDs and does not explicitly set `installCRDs=true` in their values.yaml, upgrading to a version with the new default would normally delete all the managed CRDs and their associated custom resources, without any way to recover those custom resources. This is destructive enough that I'm not comfortable with upgrade instructions alone.

#### Which issue this PR fixes
  - fixes #304 

#### Special notes for your reviewer:
Realized that this would be quite annoying when I started the last pass of documentation/changelog/etc. updates for 2.0 in preparation to PR this branch to next. Keeping this staging branch for now since the proposed workaround here requires Helm 3.

We either need something like this that infers the correct behavior for existing installs or need to preserve the existing instructions (i.e. you must set `installCRDs=false` before you install). https://gist.github.com/rainest/1a80e8d97be23605d34824ae86f217e8 shows install/upgrade flows for various configurations.

I'd originally wanted a path for users to transition from managed to unmanaged CRDs that would block 2.0 upgrades, but it [doesn't appear that this is possible](https://github.com/Kong/charts/issues/304#issuecomment-790059522) without manual edits to Helm release Secrets, which isn't really supported.

https://github.com/helm/community/pull/138/files (still a draft, but mostly complete) provides background on the underlying CRD management issues.

#### Checklist
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
