### PR TITLE
[kong] merge staged 2.x changes into next

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,28 +11,38 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
 
       - name: Run chart-testing (lint)
-        id: lint
-        uses: helm/chart-testing-action@v1.0.0
-        with:
-          command: lint
-          config: ct-main.yaml
+        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
-        with:
-          install_local_path_provisioner: true
-        if: steps.lint.outputs.changed == 'true'
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0
-        with:
-          command: install
-          config: ct-main.yaml
+        run: ct install
   release:
     needs: lint-test
     runs-on: ubuntu-latest
@@ -49,18 +59,16 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       # See https://github.com/helm/chart-releaser-action/issues/6
-      - name: Install Helm
-        run: |
-          curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
-          chmod 700 get_helm.sh
-          ./get_helm.sh
-          helm init --client-only
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-alpha.2
+        uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.0
+          version: v3.2.4
 
       - uses: actions/setup-python@v2
         with:
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.0
+          version: v3.2.4
 
       - name: Add dependency chart repos
         run: |

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.0
+          version: v3.2.4
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
     - 'main'
+    - 'kong-1.x'
   pull_request:
     branches:
     - '**'
@@ -14,23 +15,35 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
 
       - name: Run chart-testing (lint)
-        id: lint
-        uses: helm/chart-testing-action@v1.0.0
-        with:
-          command: lint
+        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --check-version-increment false --remote origin
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
-        with:
-          install_local_path_provisioner: true
-        if: steps.lint.outputs.changed == 'true'
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0
-        with:
-          command: install
+        run: ct install

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -1,20 +1,10 @@
 # CI test for testing dbless deployment without ingress controllers using legacy admin listen and stream listens
-# TODO: remove legacy admin listen behavior at a future date
 # - disable ingress controller
 ingressController:
   enabled: false
   installCRDs: false
   env:
     anonymous_reports: "false"
-# - use legacy admin listen config
-admin:
-  enabled: true
-  useTLS: true
-  servicePort: 8444
-  containerPort: 8444
-  ingress:
-    enabled: true
-    hostname: admin.kong.example
 
 # - disable DB for kong
 env:

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -42,6 +42,3 @@ proxy:
     - ssl
   ingress:
     enabled: true
-    hosts:
-    - foo.kong.example
-    - bar.kong.example

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -13,11 +13,6 @@ Kong: https://bit.ly/k4k8s-get-started
 
 {{ $warnings := list -}}
 
-{{- if and (.Values.enterprise.portal.enabled) (or (.Values.enterprise.portal.portal_auth) (.Values.enterprise.portal.session_conf_secret)) -}}
-{{/* Legacy Portal auth handling */}}
-{{- $warnings = append $warnings "You are currently using legacy Portal authentication configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-dedicated-portal-authentication-configuration-parameters" -}}
-{{- end -}}
-
 {{- if .Values.admin.containerPort -}}
 {{/* Legacy admin API listen */}}
 {{- $warnings = append $warnings "You are currently using legacy admin API configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration" -}}

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -18,11 +18,6 @@ Kong: https://bit.ly/k4k8s-get-started
 {{- $warnings = append $warnings "You are currently using legacy admin API configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration" -}}
 {{- end -}}
 
-{{- if .Values.runMigrations -}}
-{{/* Legacy migration toggle */}}
-{{- $warnings = append $warnings "You are currently using the legacy runMigrations setting in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-migration-job-configuration" -}}
-{{- end -}}
-
 {{ if (hasKey .Values "proxy.ingress.hosts") -}}
 {{/* Legacy proxy ingress */}}
 {{- $warnings = append $warnings "You are currently using legacy proxy Ingress configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress" -}}

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -13,9 +13,4 @@ Kong: https://bit.ly/k4k8s-get-started
 
 {{ $warnings := list -}}
 
-{{ if (hasKey .Values "proxy.ingress.hosts") -}}
-{{/* Legacy proxy ingress */}}
-{{- $warnings = append $warnings "You are currently using legacy proxy Ingress configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress" -}}
-{{- end -}}
-
 {{- include "kong.deprecation-warnings" $warnings -}}

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -13,11 +13,6 @@ Kong: https://bit.ly/k4k8s-get-started
 
 {{ $warnings := list -}}
 
-{{- if .Values.admin.containerPort -}}
-{{/* Legacy admin API listen */}}
-{{- $warnings = append $warnings "You are currently using legacy admin API configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changes-to-kong-service-configuration" -}}
-{{- end -}}
-
 {{ if (hasKey .Values "proxy.ingress.hosts") -}}
 {{/* Legacy proxy ingress */}}
 {{- $warnings = append $warnings "You are currently using legacy proxy Ingress configuration in values.yaml. Support for this will be removed in a future release. Please see the upgrade guide for instructions to update your configuration: https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#removal-of-multi-host-proxy-ingress" -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -276,20 +276,12 @@ Create a single listen (IP+port+parameter combo)
 Return the local admin API URL, preferring HTTPS if available
 */}}
 {{- define "kong.adminLocalURL" -}}
-  {{- if .Values.admin.containerPort -}} {{/* TODO: Remove legacy admin behavior */}}
-    {{- if .Values.admin.useTLS -}}
-https://localhost:{{ .Values.admin.containerPort }}
-    {{- else -}}
-http://localhost:{{ .Values.admin.containerPort }}
-    {{- end -}}
-  {{- else -}}
-    {{- if .Values.admin.tls.enabled -}}
+  {{- if .Values.admin.tls.enabled -}}
 https://localhost:{{ .Values.admin.tls.containerPort }}
-    {{- else if .Values.admin.http.enabled -}}
+  {{- else if .Values.admin.http.enabled -}}
 http://localhost:{{ .Values.admin.http.containerPort }}
-    {{- else -}}
+  {{- else -}}
 http://localhost:9999 # You have no admin listens! The controller will not work unless you set .Values.admin.http.enabled=true or .Values.admin.tls.enabled=true!
-    {{- end -}}
   {{- end -}}
 {{- end -}}
 
@@ -580,27 +572,15 @@ the template that it itself is using form the above sections.
   {{- $_ := set $autoEnv "KONG_KIC" "on" -}}
 {{- end -}}
 
-{{/*
-TODO: remove legacy admin listen behavior at a future date
-*/}}
-
 {{- with .Values.admin -}}
   {{- $address := "0.0.0.0" -}}
   {{- if (not .enabled) -}}
     {{- $address = "127.0.0.1" -}}
   {{- end -}}
-  {{- if .containerPort -}} {{/* Legacy admin listener */}}
-    {{- if .useTLS -}}
-      {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "%s:%d ssl" $address (int64 .containerPort)) -}}
-    {{- else -}}
-      {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (printf "%s:%d" $address (int64 .containerPort)) -}}
-    {{- end -}}
-  {{- else -}} {{/* Modern admin listener */}}
-    {{- $listenConfig := dict -}}
-    {{- $listenConfig := merge $listenConfig . -}}
-    {{- $_ := set $listenConfig "address" $address -}}
-    {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (include "kong.listen" $listenConfig) -}}
-  {{- end -}}
+  {{- $listenConfig := dict -}}
+  {{- $listenConfig := merge $listenConfig . -}}
+  {{- $_ := set $listenConfig "address" $address -}}
+  {{- $_ := set $autoEnv "KONG_ADMIN_LISTEN" (include "kong.listen" $listenConfig) -}}
 {{- end -}}
 
 {{- if .Values.admin.ingress.enabled }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -647,12 +647,6 @@ TODO: remove legacy admin listen behavior at a future date
     {{- if .Values.portalapi.ingress.enabled }}
       {{- $_ := set $autoEnv "KONG_PORTAL_API_URL" (include "kong.ingress.serviceUrl" .Values.portalapi.ingress) -}}
     {{- end }}
-
-    {{- if .Values.enterprise.portal.portal_auth }} {{/* TODO: deprecated, remove in a future version */}}
-      {{- $_ := set $autoEnv "KONG_PORTAL_AUTH" .Values.enterprise.portal.portal_auth -}}
-      {{- $portalSession := include "secretkeyref" (dict "name" .Values.enterprise.portal.session_conf_secret "key" "portal_session_conf") -}}
-      {{- $_ := set $autoEnv "KONG_PORTAL_SESSION_CONF" $portalSession -}}
-    {{- end }}
   {{- end }}
 
   {{- if .Values.enterprise.rbac.enabled }}

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -1,7 +1,20 @@
-{{- if .Values.ingressController.admissionWebhook.enabled }}
-{{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) }}
+{{- if .Values.ingressController.admissionWebhook.enabled -}}
+{{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) -}}
 {{- $ca := genCA "kong-admission-ca" 3650 -}}
 {{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+{{- $certCert := $cert.Cert -}}
+{{- $certKey := $cert.Key -}}
+{{- $caCert := $ca.Cert -}}
+{{- $caKey := $ca.Key -}}
+
+{{- $caSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-ca-keypair" (include "kong.fullname" .))) -}}
+{{- $certSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-keypair" (include "kong.fullname" .))) -}}
+{{- if $certSecret -}}
+{{- $certCert = (b64dec (get $certSecret.data "tls.crt")) -}}
+{{- $certKey = (b64dec (get $certSecret.data "tls.key")) -}}
+{{- $caCert = (b64dec (get $caSecret.data "tls.crt")) -}}
+{{- $caKey = (b64dec (get $caSecret.data "tls.key")) -}}
+{{- end -}}
 kind: ValidatingWebhookConfiguration
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
@@ -30,7 +43,7 @@ webhooks:
     - kongconsumers
     - kongplugins
   clientConfig:
-    caBundle: {{ b64enc $ca.Cert }}
+    caBundle: {{ b64enc $caCert }}
     service:
       name: {{ template "kong.service.validationWebhook" . }}
       namespace: {{ template "kong.namespace" . }}
@@ -55,12 +68,24 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ template "kong.fullname" . }}-validation-webhook-ca-keypair
+  namespace:  {{ template "kong.namespace" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+    tls.crt: {{ b64enc $caCert  }}
+    tls.key: {{ b64enc $caKey  }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
   name: {{ template "kong.fullname" . }}-validation-webhook-keypair
   namespace:  {{ template "kong.namespace" . }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ b64enc $cert.Cert }}
-  tls.key: {{ b64enc $cert.Key }}
+  tls.crt: {{ b64enc $certCert }}
+  tls.key: {{ b64enc $certKey }}
 {{ end }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -77,15 +77,6 @@ spec:
         lifecycle:
           {{- toYaml .Values.lifecycle | nindent 10 }}
         ports:
-        {{/* TODO: remove legacy admin port template */}}
-        {{- if (and .Values.admin.containerPort .Values.admin.enabled) }}
-        - name: admin
-          containerPort: {{ .Values.admin.containerPort }}
-          {{- if .Values.admin.hostPort }}
-          hostPort: {{ .Values.admin.hostPort }}
-          {{- end}}
-          protocol: TCP
-        {{- end }}
         {{- if (and .Values.admin.http.enabled .Values.admin.enabled) }}
         - name: admin
           containerPort: {{ .Values.admin.http.containerPort }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -29,7 +29,9 @@ spec:
     metadata:
       annotations:
         {{- if .Values.ingressController.admissionWebhook.enabled }}
-        checksum/admission-webhook.yaml: {{ include (print $.Template.BasePath "/admission-webhook.yaml") . | sha256sum }}
+        {{/* Generating a checksum from the entire template causes the checksum to change depending on whether you install or upgrade
+             even though the resources do not actually change. Not sure why. Extracting the certificates only works around this. */}}
+        checksum/admission-webhook.yaml: {{ (regexFindAll "tls.crt: .*$" (include (print $.Template.BasePath "/admission-webhook.yaml") .) -1 | join ",") | sha256sum }}
         {{- end }}
         {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
         {{- if .Values.dblessConfig.config }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -28,11 +28,6 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.ingressController.admissionWebhook.enabled }}
-        {{/* Generating a checksum from the entire template causes the checksum to change depending on whether you install or upgrade
-             even though the resources do not actually change. Not sure why. Extracting the certificates only works around this. */}}
-        checksum/admission-webhook.yaml: {{ (regexFindAll "tls.crt: .*$" (include (print $.Template.BasePath "/admission-webhook.yaml") .) -1 | join ",") | sha256sum }}
-        {{- end }}
         {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
         {{- if .Values.dblessConfig.config }}
         checksum/dbless.config: {{ toYaml .Values.dblessConfig.config | sha256sum }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.kong.enabled }}
-{{- if (and (or (.Values.runMigrations) (.Values.migrations.postUpgrade)) (not (eq .Values.env.database "off"))) }}
+{{- if (and .Values.migrations.postUpgrade (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.kong.enabled }}
-{{- if (and (or (.Values.runMigrations) (.Values.migrations.preUpgrade)) (not (eq .Values.env.database "off"))) }}
+{{- if (and .Values.migrations.preUpgrade (not (eq .Values.env.database "off"))) }}
 # Why is this Job duplicated and not using only helm hooks?
 # See: https://github.com/helm/charts/pull/7362
 apiVersion: batch/v1

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -9,8 +9,6 @@
 {{- $runInit := true -}}
 {{- if (hasKey .Values.migrations "init") -}}
   {{- $runInit = .Values.migrations.init -}}
-{{- else if (hasKey .Values "runMigrations") -}}
-  {{- $runInit = .Values.runMigrations -}}
 {{- end -}}
 
 {{- if (and ($runInit) (not (eq .Values.env.database "off"))) }}

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -1,83 +1,3 @@
-{{- if .Values.admin.containerPort -}} {{/* TODO: remove legacy admin handling */}}
-{{- if .Values.deployment.kong.enabled }}
-{{- if .Values.admin.enabled -}}
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ template "kong.fullname" . }}-admin
-  namespace: {{ template "kong.namespace" . }}
-  {{- if .Values.admin.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.admin.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-spec:
-  type: {{ .Values.admin.type }}
-  {{- if eq .Values.admin.type "LoadBalancer" }}
-  {{- if .Values.admin.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.admin.loadBalancerIP }}
-  {{- end }}
-  {{- if .Values.admin.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-  {{- range $cidr := .Values.admin.loadBalancerSourceRanges }}
-  - {{ $cidr }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-  ports:
-  - name: kong-admin
-    port: {{ .Values.admin.servicePort }}
-    targetPort: {{ .Values.admin.containerPort }}
-  {{- if (and (eq .Values.admin.type "NodePort") (not (empty .Values.admin.nodePort))) }}
-    nodePort: {{ .Values.admin.nodePort }}
-  {{- end }}
-    protocol: TCP
-  selector:
-    {{- include "kong.selectorLabels" . | nindent 4 }}
-{{- end -}}
-{{- end }}
----
-{{ if .Values.admin.ingress.enabled -}}
-{{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := .Values.admin.servicePort -}}
-{{- $path := .Values.admin.ingress.path -}}
-{{- $tls := .Values.admin.ingress.tls -}}
-{{- $hostname := .Values.admin.ingress.hostname -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ template "kong.fullname" . }}-admin
-  namespace: {{ template "kong.namespace" . }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-  {{- if .Values.admin.ingress.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.admin.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-spec:
-  rules:
-  - host: {{ $hostname }}
-    http:
-      paths:
-        - path: {{ $path }}
-          backend:
-            serviceName: {{ $serviceName }}-admin
-            servicePort: {{ $servicePort }}
-  {{- if $tls }}
-  tls:
-  - hosts:
-    - {{ $hostname }}
-    secretName: {{ $tls }}
-  {{- end -}}
-{{- end -}}
-
-{{- else -}} {{/* Modern admin handler */}}
-
 {{- if .Values.deployment.kong.enabled }}
 {{- if and .Values.admin.enabled (or .Values.admin.http.enabled .Values.admin.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
@@ -91,7 +11,6 @@ spec:
 {{ if .Values.admin.ingress.enabled }}
 ---
 {{ include "kong.ingress" $serviceConfig }}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -10,41 +10,7 @@
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.proxy.ingress.enabled }}
 ---
-{{ if (not (hasKey .Values.proxy.ingress "hosts"))  -}}
 {{ include "kong.ingress" $serviceConfig }}
-{{ else -}} {{/* TODO remove legacy proxy ingress handling */}}
-{{- $serviceName := include "kong.fullname" . -}}
-{{- $servicePort := include "kong.ingress.servicePort" .Values.proxy -}}
-{{- $path := .Values.proxy.ingress.path -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ template "kong.fullname" . }}-proxy
-  namespace: {{ template "kong.namespace" . }}
-  labels:
-    {{- include "kong.metaLabels" . | nindent 4 }}
-  {{- if .Values.proxy.ingress.annotations }}
-  annotations:
-  {{- range $key, $value := .Values.proxy.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
-  {{- end }}
-spec:
-  rules:
-    {{- range $host := .Values.proxy.ingress.hosts }}
-    - host: {{ $host | quote }}
-      http:
-        paths:
-          - path: {{ $path }}
-            backend:
-              serviceName: {{ $serviceName }}-proxy
-              servicePort: {{ $servicePort }}
-    {{- end -}}
-  {{- if .Values.proxy.ingress.tls }}
-  tls:
-{{ toYaml .Values.proxy.ingress.tls | indent 2 }}
-  {{- end -}}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/ct-main.yaml
+++ b/ct-main.yaml
@@ -1,8 +1,0 @@
-# See https://github.com/helm/chart-testing#configuration
-remote: origin
-chart-dirs:
-  - charts
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
-helm-extra-args: --timeout 200s
-check-version-increment: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,8 +1,0 @@
-# See https://github.com/helm/chart-testing#configuration
-remote: origin
-chart-dirs:
-  - charts
-chart-repos:
-  - bitnami=https://charts.bitnami.com/bitnami
-helm-extra-args: --timeout 200s
-check-version-increment: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Merges Helm 3-based CI and 2.x changes from `stage/2.x` into `next`

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #301 

#### Special notes for your reviewer:
New branch since I messed up next merges in `stage/2.x` and created duplicate commits. This branch cherry-picks the actual new commits.

Previous PRs for non-CI features:
https://github.com/Kong/charts/pull/256 (preserving generated admission webhook certificate across upgrades)
https://github.com/Kong/charts/pull/303 (removing deprecated features)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
