### PR TITLE
[kong] only include license if provided

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -677,9 +677,12 @@ configuration can be placed under the `.env` key.
 
 #### Kong Enterprise License
 
-All Kong Enterprise deployments require a license. If you do not have a copy
-of yours, please contact Kong Support. Once you have it, you will need to
-store it in a Secret:
+Kong Enterprise 2.3+ can run with or without a license. If you wish to run 2.3+
+without a license, you can skip this step and leave `enterprise.license_secret`
+unset. Earlier versions require a license.
+
+If you have paid for a license, but you do not have a copy of yours, please
+contact Kong Support. Once you have it, you will need to store it in a Secret:
 
 ```bash
 $ kubectl create secret generic kong-enterprise-license --from-file=license=./license.json

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -663,8 +663,10 @@ the template that it itself is using form the above sections.
     {{- $_ := set $autoEnv "KONG_SMTP_MOCK" "on" -}}
   {{- end }}
 
-  {{- $lic := include "secretkeyref" (dict "name" .Values.enterprise.license_secret "key" "license") -}}
-  {{- $_ := set $autoEnv "KONG_LICENSE_DATA" $lic -}}
+  {{- if .Values.enterprise.license_secret -}}
+    {{- $lic := include "secretkeyref" (dict "name" .Values.enterprise.license_secret "key" "license") -}}
+    {{- $_ := set $autoEnv "KONG_LICENSE_DATA" $lic -}}
+  {{- end }}
 
 {{- end }} {{/* End of the Enterprise settings block */}}
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -595,8 +595,9 @@ enterprise:
   enabled: false
   # Kong Enterprise license secret name
   # This secret must contain a single 'license' key, containing your base64-encoded license data
-  # The license secret is required for all Kong Enterprise deployments
-  license_secret: kong-enterprise-license
+  # The license secret is required to unlock all Enterprise features. If you omit it,
+  # Kong will run in free mode, with some Enterprise features disabled.
+  # license_secret: kong-enterprise-license
   vitals:
     enabled: true
   portal:


### PR DESCRIPTION
#### What this PR does / why we need it:
Omits license in Enterprise mode if no license is provided, for compatibility with free mode.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
