### PR TITLE
[kong] add SAN to generated webhook certificate

### DIFF
--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingressController.admissionWebhook.enabled -}}
 {{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) -}}
 {{- $ca := genCA "kong-admission-ca" 3650 -}}
-{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 3650 $ca -}}
 {{- $certCert := $cert.Cert -}}
 {{- $certKey := $cert.Key -}}
 {{- $caCert := $ca.Cert -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add a SAN equal to the common name to the generated webhook certificate.
As of Go 1.15, certificates that contain a hostname CommonName and no
SubjectAlternativeName are considered invalid:
https://golang.org/cl/243221

Current versions of KIC use Go 1.15 and will complain without this.

#### Special notes for your reviewer:
Ref http://masterminds.github.io/sprig/crypto.html#gensignedcert for the syntax.

Once in next, we should cherry-pick into a 1.15.1 release also.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
