### PR TITLE
[kong] release 1.15.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.15.0
 
+### Fixed
+
+* Generated admission webhook certificates now include SANs for compatibility
+  with Go 1.15 controller builds.
+  ([#312](https://github.com/Kong/charts/pull/312)).
+
+## 1.15.0
+
 1.15.0 is an interim release before the planned release of 2.0.0. There were
 several feature changes we wanted to release prior to the removal of deprecated
 functionality for 2.0. The original planned deprecations covered in the [1.14.0

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.15.0
+version: 1.15.1
 appVersion: 2.3

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingressController.admissionWebhook.enabled }}
 {{- $cn := printf "%s.%s.svc" ( include "kong.service.validationWebhook" . ) ( include "kong.namespace" . ) }}
 {{- $ca := genCA "kong-admission-ca" 3650 -}}
-{{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 3650 $ca -}}
 kind: ValidatingWebhookConfiguration
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases 1.15.1, which cherry-picks the #312 fix into a 1.x release.

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
