### PR TITLE
[kong] remove built-in DB from data plane example

### DIFF
--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -28,13 +28,6 @@ admin:
 secretVolumes:
 - kong-cluster-cert
 
-postgresql:
-  enabled: true
-  postgresqlUsername: kong
-  postgresqlDatabase: kong
-  service:
-    port: 5432
-
 ingressController:
   enabled: false
   installCRDs: false


### PR DESCRIPTION
#### What this PR does / why we need it:
The hybrid data plane example spawned Postgres. It shouldn't; this fixes that.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [z] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
