### PR TITLE
[kong] look up the CRD version that's available in the cluster

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.0-rc.2
+
+### Fixed
+
+* The legacy CRD lookup now functions on Kubernetes versions that do not
+  support `apiextensions.k8s.io/v1/CustomResourceDefinition` (versions prior to
+  1.16).
+
 ## 2.0.0-rc.1
 
 ### Breaking changes

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.0.0-rc.1
+version: 2.0.0-rc.2
 appVersion: 2.3

--- a/charts/kong/templates/custom-resource-definitions.yaml
+++ b/charts/kong/templates/custom-resource-definitions.yaml
@@ -22,6 +22,7 @@
   {{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" -}}
     {{- $kongPluginCRD = (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "kongplugins.configuration.konghq.com") -}}
   {{- else -}}
+    {{/* TODO: remove the v1beta1 path when we no longer support k8s <1.16 */}}
     {{- $kongPluginCRD = (lookup "apiextensions.k8s.io/v1beta1" "CustomResourceDefinition" "" "kongplugins.configuration.konghq.com") -}}
   {{- end -}}
   {{- if $kongPluginCRD -}}

--- a/charts/kong/templates/custom-resource-definitions.yaml
+++ b/charts/kong/templates/custom-resource-definitions.yaml
@@ -18,7 +18,12 @@
        so this clause pretends the default didn't change if you have an existing release that relied
        on it
   */}}
-  {{- $kongPluginCRD := (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "kongplugins.configuration.konghq.com") -}}
+  {{- $kongPluginCRD := false -}}
+  {{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1/CustomResourceDefinition" -}}
+    {{- $kongPluginCRD = (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "kongplugins.configuration.konghq.com") -}}
+  {{- else -}}
+    {{- $kongPluginCRD = (lookup "apiextensions.k8s.io/v1beta1" "CustomResourceDefinition" "" "kongplugins.configuration.konghq.com") -}}
+  {{- end -}}
   {{- if $kongPluginCRD -}}
     {{- if (hasKey $kongPluginCRD.metadata "annotations") -}}
       {{- if (eq .Release.Name (get $kongPluginCRD.metadata.annotations "meta.helm.sh/release-name")) -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
The original implementation of this lookup in #305 assumed that the CRD API version was `apiextensions.k8s.io/v1`. This is the case on 1.16+, but earlier versions still use `apiextensions.k8s.io/v1beta1`, and the attempt to look up the newer version failed.

#### Which issue this PR fixes
  - fixes #322 

#### Special notes for your reviewer:
Comparison of behavior between K8S versions in my test KIND environments is available in [15_16_behavior.txt](https://github.com/Kong/charts/files/6208323/15_16_behavior.txt)

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
