### PR TITLE
[repo] keep master in sync with main

### DIFF
--- a/.github/workflows/master-mirrors-main.yaml
+++ b/.github/workflows/master-mirrors-main.yaml
@@ -1,0 +1,19 @@
+name: 'sync master with main'
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  push-master:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Push HEAD to master
+      # Deliberately not force-pushing: designed to fail if this would mean rewriting history
+      run: |
+        git push origin HEAD:master


### PR DESCRIPTION
#### What this PR does / why we need it:
This repo didn't get a sync job when we did the master/main switch. While there shouldn't be any actual use of master still, it may persist in user bookmarks or similar, so we may as well keep it updated.

#### Special notes for your reviewer:
Copied from the controller repo workflow: https://github.com/Kong/kubernetes-ingress-controller/blob/main/.github/workflows/master-mirrors-main.yaml