### PR TITLE
Added support for servicePortName

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -135,7 +135,7 @@ spec:
   ports:
   {{- if .http }}
   {{- if .http.enabled }}
-  - name: kong-{{ .serviceName }}
+  - name: {{ .http.servicePortName }}
     port: {{ .http.servicePort }}
     targetPort: {{ .http.containerPort }}
   {{- if (and (or (eq .type "LoadBalancer") (eq .type "NodePort")) (not (empty .http.nodePort))) }}
@@ -145,7 +145,7 @@ spec:
   {{- end }}
   {{- end }}
   {{- if .tls.enabled }}
-  - name: kong-{{ .serviceName }}-tls
+  - name: {{ .tls.servicePortName }}
     port: {{ .tls.servicePort }}
     targetPort: {{ .tls.overrideServiceTargetPort | default .tls.containerPort }}
   {{- if (and (or (eq .type "LoadBalancer") (eq .type "NodePort")) (not (empty .tls.nodePort))) }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -89,6 +89,7 @@ admin:
     # Disabling this and using a TLS listen only is recommended for most configuration
     enabled: false
     servicePort: 8001
+    servicePortName: http-kongadmin
     containerPort: 8001
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
@@ -99,6 +100,7 @@ admin:
     # Enable HTTPS listen for the admin API
     enabled: true
     servicePort: 8444
+    servicePortName: https-kongadmin
     containerPort: 8444
     # Set a target port for the TLS port in the admin API service, useful when using TLS
     # termination on an ELB.
@@ -183,6 +185,7 @@ proxy:
     # Enable plaintext HTTP listen for the proxy
     enabled: true
     servicePort: 80
+    servicePortName: http-kongproxy
     containerPort: 8000
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
@@ -193,6 +196,7 @@ proxy:
     # Enable HTTPS listen for the proxy
     enabled: true
     servicePort: 443
+    servicePortName: https-kongproxy
     containerPort: 8443
     # Set a target port for the TLS port in proxy service, useful when using TLS
     # termination on an ELB.


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
This PR is raised based on feedback at :https://github.com/Kong/kong-operator/pull/61

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #
  This PR provide user flexibility to provide servicePortName .
  Currently we are having validation hook which restrict servicePortName in particular format .
  As with current kong operator , no option to provide servicePortName .
  I added this PR.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
