### PR TITLE
[kong] release 1.15.2; change repo from bintray to dockerhub

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 1.15.0
+## 1.15.2
+
+### Fixed
+
+* Kong Ingress Controller image now pulled from Docker Hub (due to Bintray being
+  discontinued). Changed the default Docker image repository for the ingress
+  controller.
+
+## 1.15.1
 
 ### Fixed
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.15.1
+version: 1.15.2
 appVersion: 2.3

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -320,7 +320,7 @@ dblessConfig:
 ingressController:
   enabled: true
   image:
-    repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
+    repository: kong/kubernetes-ingress-controller
     tag: "1.1"
   args: []
 


### PR DESCRIPTION
Release v1.15.2 featuring one change: the default KIC image moving from Bintray to Docker Hub.