### PR TITLE
 [kong] release 2.0.0-rc.3; change repo from bintray to dockerhub

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.0-rc.3
+
+### Fixed
+
+* Kong Ingress Controller image now pulled from Docker Hub (due to Bintray being
+  discontinued). Changed the default Docker image repository for the ingress
+  controller.
+
 ## 2.0.0-rc.2
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.0.0-rc.2
+version: 2.0.0-rc.3
 appVersion: 2.3

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -320,7 +320,7 @@ dblessConfig:
 ingressController:
   enabled: true
   image:
-    repository: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller
+    repository: kong/kubernetes-ingress-controller
     tag: "1.1"
   args: []
 


### PR DESCRIPTION
Same as https://github.com/Kong/charts/pull/338 but for the 2.0 line.