### PR TITLE
[kong] release 2.0.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,22 +1,6 @@
 # Changelog
 
-## 2.0.0-rc.3
-
-### Fixed
-
-* Kong Ingress Controller image now pulled from Docker Hub (due to Bintray being
-  discontinued). Changed the default Docker image repository for the ingress
-  controller.
-
-## 2.0.0-rc.2
-
-### Fixed
-
-* The legacy CRD lookup now functions on Kubernetes versions that do not
-  support `apiextensions.k8s.io/v1/CustomResourceDefinition` (versions prior to
-  1.16).
-
-## 2.0.0-rc.1
+## 2.0.0
 
 ### Breaking changes
 
@@ -50,6 +34,9 @@ equivalents of these settings and can proceed with upgrading to 2.0.0-rc1.
   ([#305](https://github.com/Kong/charts/pull/305))
 * Added support for Pod `topologySpreadConstraints`.
   ([#308](https://github.com/Kong/charts/pull/308))
+* Kong Ingress Controller image now pulled from Docker Hub (due to Bintray being
+  discontinued). Changed the default Docker image repository for the ingress
+  controller.
 
 ### Fixed
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.0.0-rc.3
+version: 2.0.0
 appVersion: 2.3

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -17,7 +17,7 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
-- [2.0.0-rc.1](#200-rc1)
+- [2.0.0](#200)
 - [1.14.0](#1140)
 - [1.11.0](#1110)
 - [1.10.0](#1100)
@@ -57,7 +57,7 @@ text ending with `field is immutable`. This is typically due to a bug with the
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
 
-## 2.0.0-rc1
+## 2.0.0
 
 ### Support for Helm 2 dropped
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases 2.0.0 and condenses RC changelog/upgrade into a single 2.0.0 section

#### Which issue this PR fixes
  - fixes #309 

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
