### PR TITLE
[kong] fix appVersion type and CI issues

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin
+        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --check-version-increment=false --remote origin
+        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --check-version-increment=false --remote origin --target-branch next
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --check-version-increment false --remote origin
+        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --check-version-increment=false --remote origin
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 name: kong
 sources:
 version: 2.0.0
-appVersion: 2.3
+appVersion: "2.3"


### PR DESCRIPTION
#### What this PR does / why we need it:
- Forces YAML to treat the appVersion as a string.
- Fixes an issue with the lint arguments in CI.
- Sets target branches in CI.

#### Which issue this PR fixes
Recent versions of Helm introduced a lint check for this. Doesn't appear that it causes issues beyond that (the chart still installs), but may as well fix it. Prior to this change:

```
$ helm version
version.BuildInfo{Version:"v3.5.3", GitCommit:"041ce5a2c17a58be0fcd5f5e16fb3e7e95fea622", GitTreeState:"dirty", GoVersion:"go1.16.2"}
13:33:43-0700 yagody $ helm lint
==> Linting .
[ERROR] Chart.yaml: appVersion should be of type string but it's of type float64
```
Reported elsewhere: https://github.com/Kong/kong-operator/pull/58

#### Special notes for your reviewer:
Also wanted to create a small PR to check whether an unrelated linter failure was due to weirdness handling changes in a PR base or something else after both https://github.com/Kong/charts/actions/runs/742365097 (a PR accidentally targeted at main initially) AND https://github.com/Kong/charts/actions/runs/746000964 (merger to next) failed. Turns out that was failing even on the branch push and PR runs even when the PR target was set to next.

This happened because the argument was never correct to begin with, which didn't matter until #327 because all comparisons were against the (previously very outdated) master branch. After adding that sync, comparisons were against the actual current version and began to fail.

I don't think `ct lint` uses the target branch for anything other than the version increment (its other checks are against the branch itself, not the target), but figured it was prudent to indicate the branches we actually care about.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)