### PR TITLE
[repo] add CT arguments to install also

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main
   release:
     needs: lint-test
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   lint-test:
+    env:
+      COMMON_CT_ARGS: "--chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,14 +37,14 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main
+        run: ct lint $COMMON_CT_ARGS
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main
+        run: ct install $COMMON_CT_ARGS
   release:
     needs: lint-test
     runs-on: ubuntu-latest

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -46,4 +46,4 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch next

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   lint-test:
+    env:
+      COMMON_CT_ARGS: "--chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch next"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -39,11 +41,11 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-repos bitnami=https://charts.bitnami.com/bitnami --check-version-increment=false --remote origin --target-branch next
+        run: ct lint $COMMON_CT_ARGS --check-version-increment=false
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch next
+        run: ct install $COMMON_CT_ARGS


### PR DESCRIPTION
#### What this PR does / why we need it:
Copy the common arguments used in lint to the ct install command also. They shouldn't differ.

#### Which issue this PR fixes

Main issue is the lack of extra repo: https://github.com/Kong/charts/runs/2345521060?check_suite_focus=true

#### Special notes for your reviewer:

This weirdly doesn't always matter. https://github.com/Kong/charts/runs/2337522014 is the same workflow, but _doesn't_ care that we didn't indicate what bitnami was during install. Not sure why, but not too interested in investigating that in depth, since there's no good reason we shouldn't use the same set of common args for each of the ct steps.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
