### PR TITLE
docs: add a note to serviceMonitor

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -573,11 +573,8 @@ securityContext: {}
 
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created
-  # NOTE: setting `enabled: true` here enables the ServiceMonitor resource, but
-  #       by itself doesn't enable the label for all components that can be monitored.
-  #       For instance, if you want to turn metrics on for the Admin API you must add
-  #       a `metrics-enabled: true` label in the admin.labels above.
-  #       For more context see: https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
+  # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:
+  # https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
   enabled: false
   # interval: 10s
   # Specifies namespace, where ServiceMonitor should be installed

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -573,6 +573,11 @@ securityContext: {}
 
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created
+  # NOTE: setting `enabled: true` here enables the ServiceMonitor resource, but
+  #       by itself doesn't enable the label for all components that can be monitored.
+  #       For instance, if you want to turn metrics on for the Admin API you must add
+  #       a `metrics-enabled: true` label in the admin.labels above.
+  #       For more context see: https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
   enabled: false
   # interval: 10s
   # Specifies namespace, where ServiceMonitor should be installed


### PR DESCRIPTION
Sometimes `values.yaml` fields can be slightly misleading, in
this case setting `serviceMonitor.enabled=true` doesn't inherently
place the label for all components (such as the admin api) and it
may not be intuitive that several other configurations must be updated
in order to achieve that. As such this commit adds some helper text
and a link to the README to provide some hints, and more context.

Resolves #311 