### PR TITLE
[kong] update Docker repos and tags

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -471,7 +471,7 @@ directory.
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
-| image.tag                          | Kong image version                                                                    | `2.0`               |
+| image.tag                          | Kong image version                                                                    | `2.4`               |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true         | `1`                 |
@@ -570,8 +570,8 @@ section of `values.yaml` file:
 | Parameter                          | Description                                                                           | Default                                                                      |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | enabled                            | Deploy the ingress controller, rbac and crd                                           | true                                                                         |
-| image.repository                   | Docker image with the ingress controller                                              | kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller |
-| image.tag                          | Version of the ingress controller                                                     | 0.9.1                                                                        |
+| image.repository                   | Docker image with the ingress controller                                              | kong/kubernetes-ingress-controller |
+| image.tag                          | Version of the ingress controller                                                     | 1.2.0 |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
 | installCRDs                        | Creates managed CRDs.                                                                 | false

--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -2,7 +2,7 @@
 # use single image strings instead of repository/tag
 
 image:
-  unifiedRepoTag: kong:2.3
+  unifiedRepoTag: kong:2.4
 proxy:
   type: NodePort
 
@@ -12,5 +12,5 @@ ingressController:
   env:
     anonymous_reports: "false"
   image:
-    unifiedRepoTag: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1.1
+    unifiedRepoTag: kong/kubernetes-ingress-controller:1.2.0
   installCRDs: false

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -11,8 +11,8 @@
 #   the Portal and Portal API.
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -8,8 +8,8 @@
 # kubectl port-forward deploy/your-deployment-kong 8001:8001 8002:8002
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -3,8 +3,8 @@
 # Secrets. These Secrets must be created before installation.
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 enterprise:
   enabled: true

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -68,10 +68,10 @@ env:
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "2.3"
+  tag: "2.4"
   # Kong Enterprise
-  # repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  # tag: "2.3.2.0-alpine"
+  # repository: kong/kong-gateway
+  # tag: "2.3.3.2-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -332,7 +332,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "1.1"
+    tag: "1.2"
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables


### PR DESCRIPTION
#### What this PR does / why we need it:
Clears out remaining Bintray repo defaults/examples and updates tags to latest versions.

#### Special notes for your reviewer:
As of just recently, Enterprise/Kong Gateway tags after the switch to the no-credential Bintray repo are now available on Docker Hub.

Prior versions in the private repo are still not migrated to their new home. As such, Bintray credential instructions still in place. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
