### PR TITLE
[kong] release 1.15.3/update Docker repos and tags

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.15.3
+
+* Kong Enterprise image now pulled from Docker Hub. Updated tags to latest
+  versions.
+
 ## 1.15.2
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 1.15.2
-appVersion: 2.3
+version: 1.15.3
+appVersion: "2.4"

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -461,7 +461,7 @@ directory.
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
-| image.tag                          | Kong image version                                                                    | `2.0`               |
+| image.tag                          | Kong image version                                                                    | `2.4`               |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true         | `1`                 |
@@ -560,8 +560,8 @@ section of `values.yaml` file:
 | Parameter                          | Description                                                                           | Default                                                                      |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | enabled                            | Deploy the ingress controller, rbac and crd                                           | true                                                                         |
-| image.repository                   | Docker image with the ingress controller                                              | kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller |
-| image.tag                          | Version of the ingress controller                                                     | 0.9.1                                                                        |
+| image.repository                   | Docker image with the ingress controller                                              | kong/kubernetes-ingress-controller |
+| image.tag                          | Version of the ingress controller                                                     | 1.2.0 |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
 | installCRDs                        | Create CRDs. **FOR HELM3, MAKE SURE THIS VALUE IS SET TO `false`.**  Regardless of value of this, Helm v3+ will install the CRDs if those are not present already. Use `--skip-crds` with `helm install` if you want to skip CRD creation.                 | true                                                                         |

--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -12,5 +12,5 @@ ingressController:
   env:
     anonymous_reports: "false"
   image:
-    unifiedRepoTag: kong-docker-kubernetes-ingress-controller.bintray.io/kong-ingress-controller:1.1.1
+    unifiedRepoTag: kong/kubernetes-ingress-controller:1.2.0
   installCRDs: false

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -11,8 +11,8 @@
 #   the Portal and Portal API.
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -8,8 +8,8 @@
 # kubectl port-forward deploy/your-deployment-kong 8001:8001 8002:8002
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -3,8 +3,8 @@
 # Secrets. These Secrets must be created before installation.
 
 image:
-  repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  tag: "2.3.2.0-alpine"
+  repository: kong/kong-gateway
+  tag: "2.3.3.2-alpine"
 
 enterprise:
   enabled: true

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -57,10 +57,10 @@ env:
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "2.3"
+  tag: "2.4"
   # Kong Enterprise
-  # repository: kong-docker-kong-gateway-docker.bintray.io/kong-enterprise-edition
-  # tag: "2.3.2.0-alpine"
+  # repository: kong/kong-gateway
+  # tag: "2.3.3.2-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -321,7 +321,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "1.1"
+    tag: "1.2"
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables


### PR DESCRIPTION
#### What this PR does / why we need it:
1.x series companion to https://github.com/Kong/charts/pull/349

#### Special notes for your reviewer:
As there are no known or expected incompatibilities between the latest image versions and 1.x, this just cherry-picks the mainline commit for the repos/versions and adds a release commit.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
