### PR TITLE
[kong] release 2.1.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2.1.0
+
+### Improvements
+
+* Added support for user-defined volumes, volume mounts, and init containers.
+  ([#317](https://github.com/Kong/charts/pull/317))
+* Tolerations are now applied to migration Job Pods also.
+  ([#341](https://github.com/Kong/charts/pull/341))
+* Added support for using a DaemonSet instead of Deployment.
+  ([#347](https://github.com/Kong/charts/pull/347))
+* Updated default image versions and completed migration off Bintray
+  repositories.
+  ([#349](https://github.com/Kong/charts/pull/349))
+* PDB ignores migration Job Pods.
+  ([#352](https://github.com/Kong/charts/pull/352))
+
+### Documentation
+
+* Clarified service monitor usage information.
+  ([#345](https://github.com/Kong/charts/pull/345))
+
 ## 2.0.0
 
 ### Breaking changes

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.0.0
-appVersion: "2.3"
+version: 2.1.0
+appVersion: "2.4"

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -66,10 +66,10 @@ Bintray, the Docker registry previously used for several images used by this
 chart, is [sunsetting May 1,
 2021](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).
 
-The chart default values.yaml now uses the new Docker Hub repositories for all
-affected images. You should check your release values.yamls to confirm that
+The chart default `values.yaml` now uses the new Docker Hub repositories for all
+affected images. You should check your release `values.yaml` files to confirm that
 they do not still reference Bintray repositories. If they do, update them to
-use the Docker Hub repositories now in the default values.yaml.
+use the Docker Hub repositories now in the default `values.yaml`.
 
 ## 2.0.0
 

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -17,6 +17,7 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [2.1.0](#210)
 - [2.0.0](#200)
 - [1.14.0](#1140)
 - [1.11.0](#1110)
@@ -56,6 +57,19 @@ text ending with `field is immutable`. This is typically due to a bug with the
 `init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+## 2.1.0
+
+### Migration off Bintray
+
+Bintray, the Docker registry previously used for several images used by this
+chart, is [sunsetting May 1,
+2021](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).
+
+The chart default values.yaml now uses the new Docker Hub repositories for all
+affected images. You should check your release values.yamls to confirm that
+they do not still reference Bintray repositories. If they do, update them to
+use the Docker Hub repositories now in the default values.yaml.
 
 ## 2.0.0
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases 2.1.0.

#### Special notes for your reviewer:
Contingent on https://github.com/Kong/charts/pull/349. Do not merge until that is complete.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
