### PR TITLE
[kong] add missing root object type to CRD OpenAPI v3 schema

### DIFF
--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -33,6 +33,7 @@ spec:
     priority: 1
   validation:
     openAPIV3Schema:
+      type: object
       required:
       - plugin
       properties:
@@ -110,6 +111,7 @@ spec:
     priority: 1
   validation:
     openAPIV3Schema:
+      type: object
       required:
       - plugin
       properties:
@@ -180,6 +182,7 @@ spec:
     JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         username:
           type: string
@@ -208,8 +211,10 @@ spec:
     - ki
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         route:
+          type: object
           properties:
             methods:
               type: array
@@ -377,6 +382,7 @@ spec:
     JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      type: object
       properties:
         apiVersion:
           type: string


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Currently all installed CRDs are throwing violations warnings due to missing root type values.

```
kubectl describe crd kongconsumers.configuration.konghq.com
...
Status:
  Accepted Names:
    Kind:       KongConsumer
    List Kind:  KongConsumerList
    Plural:     kongconsumers
    Short Names:
      kc
    Singular:  kongconsumer
  Conditions:
    Last Transition Time:  2021-01-20T14:41:12Z
    Message:               spec.versions[0].schema.openAPIV3Schema.type: Required value: must not be empty at the root
``` 

See the following for more information on this topic:

* https://github.com/kubernetes/kubernetes/issues/81445
* https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

OpenAPI will not be published to `kubectl explain` unless we also set `preserveUnknownFields: false` or set the `apiVersion: apiextensions.k8s.io/v1` (it is `v1beta1` today).

```
kubectl explain kongingress
KIND:     KongIngress
VERSION:  configuration.konghq.com/v1

DESCRIPTION:
     <empty>
```

See https://github.com/kubernetes/kubernetes/issues/95702 for more info on this topic.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
