### PR TITLE
[kong] remove duplicate .portalapi.http keys resolves #359

### DIFF
--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -161,8 +161,6 @@ portalapi:
     konghq.com/protocol: "https"
 
   http:
-
-  http:
     enabled: true
     servicePort: 8004
     containerPort: 8004


### PR DESCRIPTION
#### What this PR does / why we need it:
remove dupe .portalapi.http keys in values file resolves #359

#### Which issue this PR fixes
  - fixes #359 

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md << N/A
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
