### PR TITLE
[kong] Fix deployment sidecar path

### DIFF
--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -161,8 +161,6 @@ portalapi:
     konghq.com/protocol: "https"
 
   http:
-
-  http:
     enabled: true
     servicePort: 8004
     containerPort: 8004

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -80,8 +80,8 @@ spec:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}
       {{ end }}
-      {{- if .Values.deployment.sidecarContainers }}
-      {{- toYaml .Values.deployment.sidecarContainers | nindent 6 }}
+      {{- if .Values.deployment.kong.sidecarContainers }}
+      {{- toYaml .Values.deployment.kong.sidecarContainers | nindent 6 }}
       {{- end }}
       {{- if .Values.deployment.kong.enabled }}
       - name: "proxy"


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Which issue this PR fixes
- fixes the path for the kong deployment sidecar value

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
