### PR TITLE
[repo] bump CI KIND to 1.1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,7 @@ jobs:
         run: ct lint $COMMON_CT_ARGS
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.1.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -44,7 +44,7 @@ jobs:
         run: ct lint $COMMON_CT_ARGS --check-version-increment=false
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.1.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
#### What this PR does / why we need it:
Bumps the CI KIND version. 1.0 uses something that doesn't support Ingress v1, and this makes controller 2.x unhappy.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
