### PR TITLE
[kong] add hostAliases for deployment

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -434,6 +434,11 @@ event you need to recover from unintended CRD deletion.
 
 The chart able to deploy initcontainers along with Kong. This can be very useful when require to setup additional custom initialization. The `deployment.initcontainers` field in values.yaml takes an array of objects that get appended as-is to the existing `spec.template.initContainers` array in the kong deployment resource. 
 
+### HostAliases
+
+The chart able to inject host aliases into containers. This can be very useful when require to resolve additional domain name which can't
+be looked-up directly from dns server. The `deployment.hostAliases` field in values.yaml takes an array of objects that set to `spec.template.hostAliases` field in the kong deployment resource.
+
 ### Sidecar Containers
 
 The chart can deploy additional containers along with the Kong and Ingress

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -76,6 +76,10 @@ spec:
         {{- include "kong.wait-for-db" . | nindent 6 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.deployment.hostAliases }}
+      hostAliases:
+        {{- toYaml .Values.deployment.hostAliases | nindent 6 }}
+      {{- end}}
       containers:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -29,6 +29,11 @@ deployment:
   # initContainers:
   # - name: initcon
   #   image: initcon:latest
+  # hostAliases:
+  # - ip: "127.0.0.1"
+  #   hostnames:
+  #   - "foo.local"
+  #   - "bar.local"
   # userDefinedVolumes:
   # - name: "volumeName"
   #   emptyDir: {}


### PR DESCRIPTION
expose hostAliases to values.yaml to be able to inject host aliases
into containers, so that we can resolve additional domain name which
can't be looked-up directly from dns server.

#### What this PR does / why we need it:

What:
expose hostAliases to values.yaml to be able to inject host aliases into containers.

Why:
In some case we need resolve custom domain which can't be looked-up from dns server


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
