### PR TITLE
[kong] add annotations for AWS ELB for Kong Proxy

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -194,7 +194,12 @@ proxy:
   # To specify annotations or labels for the proxy service, add them to the respective
   # "annotations" or "labels" dictionaries below.
   annotations: {}
-  #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  # If terminating TLS at the ELB, the following annotations can be used
+  # "service.beta.kubernetes.io/aws-load-balancer-backend-protocol": "*",
+  # "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
+  # "service.beta.kubernetes.io/aws-load-balancer-ssl-cert": "arn:aws:acm:REGION:ACCOUNT:certificate/XXXXXX-XXXXXXX-XXXXXXX-XXXXXXXX",
+  # "service.beta.kubernetes.io/aws-load-balancer-ssl-ports": "kong-tls-proxy",
+  # "service.beta.kubernetes.io/aws-load-balancer-type": "elb"
   labels:
     enable-metrics: "true"
 
@@ -213,8 +218,7 @@ proxy:
     enabled: true
     servicePort: 443
     containerPort: 8443
-    # Set a target port for the TLS port in proxy service, useful when using TLS
-    # termination on an ELB.
+    # Set a target port for the TLS port in proxy service
     # overrideServiceTargetPort: 8000
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32443


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

An override should not be used here. Annotations can be used by
the Kubernetes service for the Proxy to terminate TLS on the ELB
with a certificate from AWS ACM. Other annotations are available
but these are the minimum required for TLS termination and should
be "documented" as part of the chart comments.

AWS docs: https://aws.amazon.com/premiumsupport/knowledge-center/terminate-https-traffic-eks-acm/

#### Which issue this PR fixes
fixes #171


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
