### PR TITLE
[kong] use args instead of command

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -508,8 +508,9 @@ The name of the service used for the ingress controller's validation webhook
   env:
   {{- include "kong.env" . | nindent 2 }}
 {{/* TODO: the rm command here is a workaround for https://github.com/Kong/charts/issues/295
-     It should be removed once that's fixed */}}
-  command: [ "/bin/sh", "-c", "until kong start; do echo 'waiting for db'; sleep 1; done; kong stop; rm -fv {{ $sockFile | squote }}"]
+     It should be removed once that's fixed.
+     Note that we use args instead of command here to /not/ override the standard image entrypoint. */}}
+  args: [ "/bin/sh", "-c", "export KONG_NGINX_DAEMON=on; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop; rm -fv {{ $sockFile | squote }}"]
   volumeMounts:
   {{- include "kong.volumeMounts" . | nindent 4 }}
   {{- include "kong.userDefinedVolumeMounts" . | nindent 4 }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -49,7 +49,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
-        command: [ "/bin/sh", "-c", "kong migrations finish" ]
+        args: [ "/bin/sh", "-c", "kong migrations finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
         resources:

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -49,7 +49,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
-        command: [ "/bin/sh", "-c", "kong migrations up" ]
+        args: [ "/bin/sh", "-c", "kong migrations up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
         resources:

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -57,7 +57,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
-        command: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
+        args: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
         resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
Uses `args` instead of `command` to invoke non-standard commands for Kong containers. This allows the standard image entrypoint to run [rather than replacing it](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#notes).

Inject the no daemonize environment variable directly into the wait-for-db command. There's currently a limitation in the entrypoint that overrides the container environment. https://github.com/Kong/docker-kong/pull/474 intends to fix it but we'll need this for backwards compatibility.

See the commit message for a bit more detail on why we need this.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/Kong/charts/issues/371

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
