### PR TITLE
[kong] bump versions

### DIFF
--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -12,5 +12,5 @@ ingressController:
   env:
     anonymous_reports: "false"
   image:
-    unifiedRepoTag: kong/kubernetes-ingress-controller:1.2.0
+    unifiedRepoTag: kong/kubernetes-ingress-controller:1.3.1
   installCRDs: false

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.3.3.2-alpine"
+  tag: "2.4.1.1-alpine"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.3.3.2-alpine"
+  tag: "2.4.1.1-alpine"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.3.3.2-alpine"
+  tag: "2.4.1.1-alpine"
 
 enterprise:
   enabled: true

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -79,7 +79,7 @@ image:
   tag: "2.4"
   # Kong Enterprise
   # repository: kong/kong-gateway
-  # tag: "2.3.3.2-alpine"
+  # tag: "2.4.1.1-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -340,7 +340,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "1.2"
+    tag: "1.3"
   args: []
 
   # Specify Kong Ingress Controller configuration via environment variables


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump the default versions for Kong Gateway and KIC to latest releases.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
