### PR TITLE
[kong] add support for UDP streams

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -505,6 +505,7 @@ individual services: see values.yaml for their individual default values.
 
 `SVC` below can be substituted with each of:
 * `proxy`
+* `udpProxy`
 * `admin`
 * `manager`
 * `portal`
@@ -524,6 +525,10 @@ only.
 authentication, which cannot pass through an ingress proxy). `clustertelemetry`
 is similar, and used when Vitals is enabled on Kong Enterprise control plane
 nodes.
+
+`udpProxy` is used for UDP stream listens (Kubernetes does not yet support
+mixed TCP/UDP LoadBalancer Services). It _does not_ support the `http`, `tls`,
+or `ingress` sections, as it is used only for stream listens.
 
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
@@ -558,10 +563,11 @@ nodes.
 #### Stream listens
 
 The proxy configuration additionally supports creating stream listens. These
-are configured using an array of objects under `proxy.stream`:
+are configured using an array of objects under `proxy.stream` and `udpProxy.stream`:
 
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
+| protocol                           | The listen protocol, either "TCP" or "UDP"                                            |                     |
 | containerPort                      | Container port to use for a stream listen                                             |                     |
 | servicePort                        | Service port to use for a stream listen                                               |                     |
 | nodePort                           | Node port to use for a stream listen                                                  |                     |

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -160,7 +160,7 @@ spec:
   {{- end }}
   {{- if (hasKey . "stream") }}
   {{- range .stream }}
-  - name: stream-{{ .containerPort }}
+  - name: stream-{{ if (eq .protocol "UDP") }}udp-{{ end }}{{ .containerPort }}
     port: {{ .servicePort }}
     targetPort: {{ .containerPort }}
     {{- if (and (or (eq $.type "LoadBalancer") (eq $.type "NodePort")) (not (empty .nodePort))) }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -255,10 +255,10 @@ Create KONG_STREAM_LISTEN string
     {{- $listenConfig := dict -}}
     {{- $listenConfig := merge $listenConfig . -}}
     {{- $_ := set $listenConfig "address" "0.0.0.0" -}}
-    {{/* You set NGINX stream listens to UDP using a parameter because reasons. Since our configuration
-         is dual-purpose for both the Service and listen string, we forcibly inject this parameter if
-         that's the Service protocol. The default handles configs that predate the addition of the
-         protocol field, where we only supported TCP. */}}
+    {{/* You set NGINX stream listens to UDP using a parameter due to historical reasons.
+         Our configuration is dual-purpose, for both the Service and listen string, so we
+         forcibly inject this parameter if that's the Service protocol. The default handles
+         configs that predate the addition of the protocol field, where we only supported TCP. */}}
     {{- if (eq (default .protocol "TCP") "UDP") -}}
       {{- $_ := set $listenConfig "parameters" (append .parameters "udp") -}}
     {{- end -}}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -134,7 +134,15 @@ spec:
           {{- if .hostPort }}
           hostPort: {{ .hostPort }}
           {{- end}}
-          protocol: TCP
+          protocol: {{ .protocol }}
+        {{- end }}
+        {{- range .Values.udpProxy.stream }}
+        - name: stream-udp-{{ .containerPort }}
+          containerPort: {{ .containerPort }}
+          {{- if .hostPort }}
+          hostPort: {{ .hostPort }}
+          {{- end}}
+          protocol: {{ .protocol }}
         {{- end }}
         {{- if (and .Values.status.http.enabled .Values.status.enabled)}}
         - name: status

--- a/charts/kong/templates/service-kong-udp-proxy.yaml
+++ b/charts/kong/templates/service-kong-udp-proxy.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.deployment.kong.enabled }}
+{{- if and .Values.udpProxy.enabled -}}
+{{- $serviceConfig := dict -}}
+{{- $serviceConfig := merge $serviceConfig .Values.udpProxy -}}
+{{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
+{{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
+{{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
+{{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- $_ := set $serviceConfig "serviceName" "udp-proxy" -}}
+{{- $_ := set $serviceConfig "tls" (dict "enabled" false) -}}
+{{- $_ := set $serviceConfig "http" (dict "enabled" false) -}}
+{{- include "kong.service" $serviceConfig }}
+{{- end -}}
+{{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -226,12 +226,17 @@ proxy:
   # To enable, remove "{}", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their servicePort,
   # e.g. "stream-9000" for the below.
+  # Note: although you can select the protocol here, you cannot set UDP if you
+  # use a LoadBalancer Service due to limitations in current Kubernetes versions.
+  # To proxy both TCP and UDP with LoadBalancers, you must enable the udpProxy Service
+  # in the next section and place all UDP stream listen configuration under it.
   stream: {}
     #   # Set the container (internal) and service (external) ports for this listen.
     #   # These values should normally be the same. If your environment requires they
     #   # differ, note that Kong will match routes based on the containerPort only.
     # - containerPort: 9000
     #   servicePort: 9000
+    #   protocol: TCP
     #   # Optionally set a static nodePort if the service type is NodePort
     #   # nodePort: 32080
     #   # Additional listen parameters, e.g. "ssl", "reuseport", "backlog=16384"
@@ -255,6 +260,40 @@ proxy:
 
   # Optionally specify a static load balancer IP.
   # loadBalancerIP:
+
+# Specify Kong UDP proxy service configuration
+# Currently, LoadBalancer type Services are generally limited to a single transport protocol
+# Multi-protocol Services are an alpha feature as of Kubernetes 1.20:
+# https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types
+# You should enable this Service if you proxy UDP traffic, and configure UDP stream listens under it
+udpProxy:
+  # Enable creating a Kubernetes service for UDP proxying
+  enabled: false
+  type: LoadBalancer
+  # To specify annotations or labels for the proxy service, add them to the respective
+  # "annotations" or "labels" dictionaries below.
+  annotations: {}
+  #  service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+  labels: {}
+  # Optionally specify a static load balancer IP.
+  # loadBalancerIP:
+
+  # Define stream (UDP) listen
+  # To enable, remove "{}", uncomment the section below, and select your desired
+  # ports and parameters. Listens are dynamically named after their servicePort,
+  # e.g. "stream-9000" for the below.
+  stream: {}
+    #   # Set the container (internal) and service (external) ports for this listen.
+    #   # These values should normally be the same. If your environment requires they
+    #   # differ, note that Kong will match routes based on the containerPort only.
+    # - containerPort: 9000
+    #   servicePort: 9000
+    #   protocol: UDP
+    #   # Optionally set a static nodePort if the service type is NodePort
+    #   # nodePort: 32080
+    #   # Additional listen parameters, e.g. "ssl", "reuseport", "backlog=16384"
+    #   # "ssl" is required for SNI-based routes. It is not supported on versions <2.0
+    #   parameters: []
 
 # Custom Kong plugins can be loaded into Kong by mounting the plugin code
 # into the file-system of Kong container.


### PR DESCRIPTION
#### What this PR does / why we need it:
- Adds a new UDP proxy Service. This needs to be separate from the standard proxy Service because of the [limitations on multi-protocol LoadBalancers](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types).
- Updates the stream listener generator and stream Service template handler to be protocol-aware.
- Adds protocol configuration to the TCP stream listen examples under the standard proxy.
- Includes UDP stream ports in the Deployment template.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #329 

#### Special notes for your reviewer:
TBD

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
