### PR TITLE
[kong] Remove maxUnavailable PDB default

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -560,6 +560,9 @@ autoscaling:
 # Kong Pod Disruption Budget
 podDisruptionBudget:
   enabled: false
+  # Uncomment only one of the following when enabled is set to true
+  # maxUnavailable: "50%"
+  # minUnavailable: "50%"
 
 podSecurityPolicy:
   enabled: false

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -560,7 +560,6 @@ autoscaling:
 # Kong Pod Disruption Budget
 podDisruptionBudget:
   enabled: false
-  maxUnavailable: "50%"
 
 podSecurityPolicy:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Helm's handling of default values means you cannot unset this from your values.yaml. The default values.yaml will repopulate empty values. This setting is mutually exclusive with minUnavailable, so the default prevents you from using minUnavailable at all.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
