### PR TITLE
[kong] fix example spacing and spelling typos

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -101,7 +101,7 @@ installing the chart:
 
 - Set `enterprise.enabled` to `true` in `values.yaml` file.
 - Update values.yaml to use a Kong Enterprise image.
-- Satisfy the two  prerequsisites below for
+- Satisfy the two prerequisites below for
   [Enterprise License](#kong-enterprise-license) and
   [Enterprise Docker Registry](#kong-enterprise-docker-registry-access).
 - (Optional) [set a `password` environment variable](#rbac) to create the
@@ -668,7 +668,7 @@ kong:
          secretKeyRef:
             key: kong
             name: postgres
-  nginx_worker_processes: "2"
+     nginx_worker_processes: "2"
 ```
 
 For complete list of Kong configurations please check the
@@ -697,7 +697,7 @@ you need to do the following:
 
 - Set `enterprise.enabled` to `true` in `values.yaml` file.
 - Update values.yaml to use a Kong Enterprise image.
-- Satisfy the two prerequsisites below for Enterprise License and
+- Satisfy the two prerequisites below for Enterprise License and
   Enterprise Docker Registry.
 - (Optional) [set a `password` environment variable](#rbac) to create the
   initial super-admin. Though not required, this is recommended for users that
@@ -815,7 +815,7 @@ as it contains an HMAC key.
 Kong Manager's session configuration must be configured via values.yaml,
 whereas this is optional for the Developer Portal on versions 0.36+. Providing
 Portal session configuration in values.yaml provides the default session
-configuration, which can be overriden on a per-workspace basis.
+configuration, which can be overridden on a per-workspace basis.
 
 ```
 $ cat admin_gui_session_conf


### PR DESCRIPTION
Fix the spelling of words 'prerequisites' and 'overridden' in the
README.md. Also, fix the example in the 'env' section to have proper
spacing for the nginx_worker_processes environment variable.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
The PR fixes documentation typos and is needed for clearer documentation.
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
