### PR TITLE
[repo] bump KIND action version

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,7 @@ jobs:
         run: ct lint $COMMON_CT_ARGS
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -44,7 +44,7 @@ jobs:
         run: ct lint $COMMON_CT_ARGS --check-version-increment=false
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
#### What this PR does / why we need it:
Bump the KIND action version to 1.2.0, which bumps KIND to 0.11.1 and kubectl to 1.20.8.

Older versions of KIND are apparently :sadcomputer: now.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
