### PR TITLE
[repo] update workflow branch criteria

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -1,0 +1,47 @@
+name: Release Charts
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-test:
+    env:
+      COMMON_CT_ARGS: "--chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.2.4
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint $COMMON_CT_ARGS
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.2.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install $COMMON_CT_ARGS

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   lint-test:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   lint-test:

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -6,8 +6,8 @@ on:
     - 'main'
     - 'kong-1.x'
   pull_request:
-    branches:
-    - '**'
+    branches-ignore:
+    - 'main'
 
 jobs:
   lint-test:


### PR DESCRIPTION
#### What this PR does / why we need it:
- Run the main workflow on PRs to main.
- Exclude PRs to main from the non-main workflow.

Ensures that the default lint behavior (do not skip the version increment check) runs on PRs to main.

Fix #400 

#### Checklist
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
