### PR TITLE
[kong] add helm chart tests

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,25 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'main'
+      - 'next'
+    tags:
+      - '*'
+
+jobs:
+  integration-test-dbless:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@v2
+    - name: setup testing environment
+      run: scripts/setup-test-cluster.sh
+      shell: bash
+    - name: run integration tests
+      run: scripts/run-tests.sh
+      shell: bash

--- a/charts/kong/templates/tests/test-ingress.yaml
+++ b/charts/kong/templates/tests/test-ingress.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-httpbin"
+  labels:
+    app: httpbin
+spec:
+  containers:
+    - name: httpbin
+      image: kennethreitz/httpbin
+      ports:
+      - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Release.Name }}-httpbin"
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: httpbin
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}-httpbin"
+  annotations:
+    httpbin.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "kong"
+    konghq.com/strip-path: "true"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /httpbin
+        pathType: Prefix
+        backend:
+          service:
+            name: "{{ .Release.Name }}-httpbin"
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}-httpbin-v1beta1"
+  annotations:
+    httpbin.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "kong"
+    konghq.com/strip-path: "true"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /httpbin-v1beta1
+        backend:
+          serviceName: "{{ .Release.Name }}-httpbin"
+          servicePort: 80
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-ingress"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: "{{ .Release.Name }}-curl"
+      image: curlimages/curl
+      command:
+        - curl
+        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-ingress-v1beta1"
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: "{{ .Release.Name }}-curl"
+      image: curlimages/curl
+      command:
+        - curl
+        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin-v1beta1"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+
+if [[ -z $TEST_ENV_NAME ]]
+then
+    TEST_ENV_NAME="kong-charts-tests"
+fi
+
+# ------------------------------------------------------------------------------
+# Shell Configuration
+# ------------------------------------------------------------------------------
+
+set -eu
+
+# ------------------------------------------------------------------------------
+# Kubernetes Cluster Setup
+# ------------------------------------------------------------------------------
+
+kubectl cluster-info --context kind-${TEST_ENV_NAME} 1>/dev/null
+KUBERNETES_VERSION="$(kubectl version -o json | jq -r '.serverVersion.gitVersion')"
+
+# ------------------------------------------------------------------------------
+# Setup Chart Cleanup - Kubernetes Ingress Controller
+# ------------------------------------------------------------------------------
+
+RELEASE_NAME="chart-tests"
+RELEASE_NAMESPACE="$(uuidgen)"
+
+function cleanup() {
+    echo "INFO: cleaning up helm release ${RELEASE_NAME}"
+    helm delete --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}
+    kubectl delete namespace ${RELEASE_NAMESPACE}
+    kubectl delete clusterrole ${RELEASE_NAME}-kong
+    exit 1
+}
+
+trap cleanup SIGINT SIGKILL EXIT
+
+# ------------------------------------------------------------------------------
+# Deploy Chart - Kubernetes Ingress Controller
+# ------------------------------------------------------------------------------
+
+cd charts/kong/
+echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
+helm install --create-namespace --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME} ./
+
+# ------------------------------------------------------------------------------
+# Test Chart - Kubernetes Ingress Controller
+# ------------------------------------------------------------------------------
+
+echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
+helm test --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}

--- a/scripts/setup-test-cluster.sh
+++ b/scripts/setup-test-cluster.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+
+if [[ -z $TEST_ENV_NAME ]]
+then
+    TEST_ENV_NAME="kong-charts-tests"
+fi
+
+if [[ -z $KIND_VERSION ]]
+then
+    KIND_VERSION="v0.11.1"
+fi
+
+# ------------------------------------------------------------------------------
+# Shell Configuration
+# ------------------------------------------------------------------------------
+
+set -eu
+
+# ------------------------------------------------------------------------------
+# Setup Tools - Docker
+# ------------------------------------------------------------------------------
+
+# ensure docker command is accessible
+if ! command -v docker &> /dev/null
+then
+    echo "ERROR: docker command not found"
+    exit 10
+fi
+
+# ensure docker is functional
+docker info 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Setup Tools - Kind
+# ------------------------------------------------------------------------------
+
+# ensure kind command is accessible
+if ! command -v kind &> /dev/null
+then
+    go get -v sigs.k8s.io/kind@${KIND_VERSION}
+fi
+
+# ensure kind is functional
+kind version 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Setup Tools - KTF
+# ------------------------------------------------------------------------------
+
+# ensure ktf command is accessible
+if ! command -v ktf 1>/dev/null
+then
+    mkdir -p ${HOME}/.local/bin
+    curl --proto '=https' -sSf https://kong.github.io/kubernetes-testing-framework/install.sh | sh
+    export PATH="${HOME}/.local/bin:$PATH"
+fi
+
+# ensure kind is functional
+ktf 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Configure Cleanup
+# ------------------------------------------------------------------------------
+
+function cleanup() {
+    ktf environments delete --name ${TEST_ENV_NAME}
+    exit 1
+}
+
+trap cleanup SIGTERM SIGINT EXIT
+
+# ------------------------------------------------------------------------------
+# Create Testing Environment
+# ------------------------------------------------------------------------------
+
+ktf environments create --name ${TEST_ENV_NAME} --addon metallb


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds [Chart Tests](https://helm.sh/docs/topics/chart_tests/) which can be used to validate the functionality of our Kong chart, and adds CI to run the tests on PRs and merges.

#### Which issue this PR fixes

Partially Resolves https://github.com/Kong/charts/issues/391

#### Special notes for your reviewer:

This is a minimal test set to get us started, I intend to have follow up PRs which add more tests and specifically test upgrades between chart versions.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
