### PR TITLE
[kong] add an image compat test for pre-releases

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,20 @@
+name: Lint Scripts
+
+on:
+  push:
+    branches:
+    - 'next'
+  pull_request:
+    branches:
+    - 'next'
+
+jobs:
+  lint-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: shellcheck scripts
+        run: make lint

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -52,5 +52,14 @@ jobs:
       - name: run integration tests (integration)
         run: ./scripts/test-run.sh
 
+      # NOTE: these are specifically in place in the interim between v1.x
+      #       and the upcoming v2.x release to add some extra checking to
+      #       ensure our chart and our pre-releases are compatible, once
+      #       v2.0 has released and become a standard part of the chart we
+      #       can remove this or change the upgrade tests in whatever way
+      #       seems to fit.
+      - name: run prerelease compatibility tests (integration-prerelease)
+        run: ./scripts/test-kic-2.x-upgrade.sh
+
       - name: cleanup integration tests (cleanup)
         run: ./scripts/test-env.sh cleanup

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -52,13 +52,17 @@ jobs:
       - name: run integration tests (integration)
         run: ./scripts/test-run.sh
 
-      # NOTE: these are specifically in place in the interim between v1.x
+      - name: run upgrade integration tests (integration-upgrade)
+        run: ./scripts/test-upgrade.sh
+
+      # TODO: these are specifically in place in the interim between v1.x
       #       and the upcoming v2.x release to add some extra checking to
-      #       ensure our chart and our pre-releases are compatible, once
-      #       v2.0 has released and become a standard part of the chart we
-      #       can remove this or change the upgrade tests in whatever way
+      #       ensure our chart and our pre-releases are compatible, and there
+      #       are no regressions with our charts in between pre-releases.
+      #       Once v2.0 has released and become a standard part of the chart
+      #       we can remove this or change the upgrade tests in whatever way
       #       seems to fit.
-      - name: run prerelease compatibility tests (integration-prerelease)
+      - name: run prerelease upgrade compatibility tests (integration-prerelease)
         run: ./scripts/test-kic-2.x-upgrade.sh
 
       - name: cleanup integration tests (cleanup)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: lint
+lint: ./scripts/*
+	@for script in $^ ; do \
+		shellcheck $${script} ; \
+	done

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -19,11 +19,11 @@
 TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
 KIND_VERSION="${KIND_VERSION:-v0.11.1}"
 
-if [[ ! -z $1 ]]
+if [[ -n $1 ]]
 then
     if [[ "$1" == "cleanup" ]]
     then
-        ktf environments delete --name ${TEST_ENV_NAME}
+        ktf environments delete --name "${TEST_ENV_NAME}"
         exit $?
     fi
 fi
@@ -55,7 +55,7 @@ docker info 1>/dev/null
 # ensure kind command is accessible
 if ! command -v kind &> /dev/null
 then
-    go get -v sigs.k8s.io/kind@${KIND_VERSION}
+    go get -v sigs.k8s.io/kind@"${KIND_VERSION}"
 fi
 
 # ensure kind is functional
@@ -68,7 +68,7 @@ kind version 1>/dev/null
 # ensure ktf command is accessible
 if ! command -v ktf 1>/dev/null
 then
-    mkdir -p ${HOME}/.local/bin
+    mkdir -p "${HOME}"/.local/bin
     curl --proto '=https' -sSf https://kong.github.io/kubernetes-testing-framework/install.sh | bash
     export PATH="${HOME}/.local/bin:$PATH"
 fi
@@ -81,7 +81,7 @@ ktf 1>/dev/null
 # ------------------------------------------------------------------------------
 
 function cleanup() {
-    ktf environments delete --name ${TEST_ENV_NAME}
+    ktf environments delete --name "${TEST_ENV_NAME}"
     exit 1
 }
 
@@ -91,4 +91,4 @@ trap cleanup SIGTERM SIGINT
 # Create Testing Environment
 # ------------------------------------------------------------------------------
 
-ktf environments create --name ${TEST_ENV_NAME} --addon metallb
+ktf environments create --name "${TEST_ENV_NAME}" --addon metallb

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -16,15 +16,8 @@
 # Environment Variables
 # ------------------------------------------------------------------------------
 
-if [[ -z $TEST_ENV_NAME ]]
-then
-    TEST_ENV_NAME="kong-charts-tests"
-fi
-
-if [[ -z $KIND_VERSION ]]
-then
-    KIND_VERSION="v0.11.1"
-fi
+TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
+KIND_VERSION="${KIND_VERSION:-v0.11.1}"
 
 if [[ ! -z $1 ]]
 then

--- a/scripts/test-kic-2.x-upgrade.sh
+++ b/scripts/test-kic-2.x-upgrade.sh
@@ -14,10 +14,7 @@
 # Environment Variables
 # ------------------------------------------------------------------------------
 
-if [[ -z $TEST_ENV_NAME ]]
-then
-    TEST_ENV_NAME="kong-charts-tests"
-fi
+TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
 
 # ------------------------------------------------------------------------------
 # Shell Configuration

--- a/scripts/test-kic-2.x-upgrade.sh
+++ b/scripts/test-kic-2.x-upgrade.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # ------------------------------------------------------------------------------
-# test-kick-2.x-upgrade.sh
+# test-kic-2.x-upgrade.sh
 #
 # This script is temporary: in the timeframe between 1.x and 2.x KIC
 # releases this script was made to validate that upgrading to the

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 # Kubernetes Cluster Setup
 # ------------------------------------------------------------------------------
 
-kubectl cluster-info --context kind-${TEST_ENV_NAME} 1>/dev/null
+kubectl cluster-info --context kind-"${TEST_ENV_NAME}" 1>/dev/null
 KUBERNETES_VERSION="$(kubectl version -o json | jq -r '.serverVersion.gitVersion')"
 
 # ------------------------------------------------------------------------------
@@ -39,13 +39,13 @@ RELEASE_NAMESPACE="$(uuidgen)"
 
 function cleanup() {
     echo "INFO: cleaning up helm release ${RELEASE_NAME}"
-    helm delete --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}
-    kubectl delete namespace ${RELEASE_NAMESPACE}
-    kubectl delete clusterrole ${RELEASE_NAME}-kong
+    helm delete --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
+    kubectl delete namespace "${RELEASE_NAMESPACE}"
+    kubectl delete clusterrole "${RELEASE_NAME}"-kong
     exit 1
 }
 
-trap cleanup SIGINT SIGKILL
+trap cleanup SIGINT
 
 # ------------------------------------------------------------------------------
 # Deploy Chart - Kubernetes Ingress Controller
@@ -53,11 +53,11 @@ trap cleanup SIGINT SIGKILL
 
 cd charts/kong/
 echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
-helm install --create-namespace --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME} ./
+helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" ./
 
 # ------------------------------------------------------------------------------
 # Test Chart - Kubernetes Ingress Controller
 # ------------------------------------------------------------------------------
 
 echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
-helm test --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}
+helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -15,10 +15,7 @@
 # Environment Variables
 # ------------------------------------------------------------------------------
 
-if [[ -z $TEST_ENV_NAME ]]
-then
-    TEST_ENV_NAME="kong-charts-tests"
-fi
+TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
 
 # ------------------------------------------------------------------------------
 # Shell Configuration

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 # Kubernetes Cluster Setup
 # ------------------------------------------------------------------------------
 
-kubectl cluster-info --context kind-${TEST_ENV_NAME} 1>/dev/null
+kubectl cluster-info --context kind-"${TEST_ENV_NAME}" 1>/dev/null
 KUBERNETES_VERSION="$(kubectl version -o json | jq -r '.serverVersion.gitVersion')"
 
 # ------------------------------------------------------------------------------
@@ -38,13 +38,13 @@ KUBERNETES_VERSION="$(kubectl version -o json | jq -r '.serverVersion.gitVersion
 
 function cleanup() {
     echo "INFO: cleaning up helm release ${RELEASE_NAME}"
-    helm delete --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}
-    kubectl delete namespace ${RELEASE_NAMESPACE}
-    kubectl delete clusterrole ${RELEASE_NAME}-kong
+    helm delete --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
+    kubectl delete namespace "${RELEASE_NAMESPACE}"
+    kubectl delete clusterrole "${RELEASE_NAME}"-kong
     exit 1
 }
 
-trap cleanup SIGINT SIGKILL
+trap cleanup SIGINT
 
 # ------------------------------------------------------------------------------
 # Deploy Chart - Kubernetes Ingress Controller
@@ -52,25 +52,25 @@ trap cleanup SIGINT SIGKILL
 
 cd charts/kong/
 echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
-helm install --create-namespace --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME} ./
+helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" ./
 
 # ------------------------------------------------------------------------------
 # Test Chart - Kubernetes Ingress Controller
 # ------------------------------------------------------------------------------
 
 echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
-helm test --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}
+helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
 
 # ------------------------------------------------------------------------------
 # Upgrade Chart Image
 # ------------------------------------------------------------------------------
 
 echo "INFO: upgrading the helm chart to image tag ${TAG}"
-helm upgrade --namespace ${RELEASE_NAMESPACE} --set ingressController.image.tag=${TAG} ${RELEASE_NAME} ./
+helm upgrade --namespace "${RELEASE_NAMESPACE}" --set ingressController.image.tag="${TAG}" "${RELEASE_NAME}" ./
 
 # ------------------------------------------------------------------------------
 # Test Upgraded Chart
 # ------------------------------------------------------------------------------
 
 echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
-helm test --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}
+helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# TAG=<OPTIONAL TAG> ./test-upgrade.sh
+#
+# This script (by default) tests against the `next` branch of the KIC to ensure
+# that chart upgrades work against the latest work being done there.
+#
+# Optionally, the script can be flagged to test upgrades from the current default
+# tag (provided by the chart and values.yaml) to any tag specified.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+
+if [[ -z $TEST_ENV_NAME ]]
+then
+    TEST_ENV_NAME="kong-charts-tests"
+fi
+
+if [[ -z $TAG ]]
+then
+    TAG="next-railgun"
+fi
+
+if [[ -z $RELEASE_NAME ]]
+then
+    RELEASE_NAME="chart-tests-upgrade-compat"
+fi
+
+if [[ -z $RELEASE_NAMESPACE ]]
+then
+    RELEASE_NAMESPACE="$(uuidgen)"
+fi
+
+# ------------------------------------------------------------------------------
+# Shell Configuration
+# ------------------------------------------------------------------------------
+
+set -euo pipefail
+
+# ------------------------------------------------------------------------------
+# Kubernetes Cluster Setup
+# ------------------------------------------------------------------------------
+
+kubectl cluster-info --context kind-${TEST_ENV_NAME} 1>/dev/null
+KUBERNETES_VERSION="$(kubectl version -o json | jq -r '.serverVersion.gitVersion')"
+
+# ------------------------------------------------------------------------------
+# Setup Chart Cleanup - Kubernetes Ingress Controller
+# ------------------------------------------------------------------------------
+
+function cleanup() {
+    echo "INFO: cleaning up helm release ${RELEASE_NAME}"
+    helm delete --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}
+    kubectl delete namespace ${RELEASE_NAMESPACE}
+    kubectl delete clusterrole ${RELEASE_NAME}-kong
+    exit 1
+}
+
+trap cleanup SIGINT SIGKILL
+
+# ------------------------------------------------------------------------------
+# Deploy Chart - Kubernetes Ingress Controller
+# ------------------------------------------------------------------------------
+
+cd charts/kong/
+echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
+helm install --create-namespace --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME} ./
+
+# ------------------------------------------------------------------------------
+# Test Chart - Kubernetes Ingress Controller
+# ------------------------------------------------------------------------------
+
+echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
+helm test --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}
+
+# ------------------------------------------------------------------------------
+# Upgrade Chart Image
+# ------------------------------------------------------------------------------
+
+echo "INFO: upgrading the helm chart to image tag ${TAG}"
+helm upgrade --namespace ${RELEASE_NAMESPACE} --set ingressController.image.tag=${TAG} ${RELEASE_NAME} ./
+
+# ------------------------------------------------------------------------------
+# Test Upgraded Chart
+# ------------------------------------------------------------------------------
+
+echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
+helm test --namespace ${RELEASE_NAMESPACE} ${RELEASE_NAME}

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -14,25 +14,10 @@
 # Environment Variables
 # ------------------------------------------------------------------------------
 
-if [[ -z $TEST_ENV_NAME ]]
-then
-    TEST_ENV_NAME="kong-charts-tests"
-fi
-
-if [[ -z $TAG ]]
-then
-    TAG="next-railgun"
-fi
-
-if [[ -z $RELEASE_NAME ]]
-then
-    RELEASE_NAME="chart-tests-upgrade-compat"
-fi
-
-if [[ -z $RELEASE_NAMESPACE ]]
-then
-    RELEASE_NAMESPACE="$(uuidgen)"
-fi
+TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
+TAG="${TAG:-next-railgun}"
+RELEASE_NAME="${RELEASE_NAME:-chart-tests-upgrade-compat}"
+RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-$(uuidgen)}"
 
 # ------------------------------------------------------------------------------
 # Shell Configuration


### PR DESCRIPTION
#### What this PR does / why we need it:

This patch adds a test intended to help catch regressions
that would make the upcoming KIC 2.0 releases incompatible
with the chart (or visa versa) by ensuring a minimal upgrade
test of the image is performed and the helm tests pass.

#### Which issue this PR fixes

Partially resolves https://github.com/Kong/charts/issues/391

#### Special notes for your reviewer:

#### Checklist

- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
