### PR TITLE
[kong] add toggle for test resources

### DIFF
--- a/charts/kong/templates/tests/test-jobs.yaml
+++ b/charts/kong/templates/tests/test-jobs.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-ingress"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: "{{ .Release.Name }}-curl"
+      image: curlimages/curl
+      command:
+        - curl
+        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-ingress-v1beta1"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: "{{ .Release.Name }}-curl"
+      image: curlimages/curl
+      command:
+        - curl
+        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin-v1beta1"
+

--- a/charts/kong/templates/tests/test-resources.yaml
+++ b/charts/kong/templates/tests/test-resources.yaml
@@ -1,3 +1,4 @@
+{{- if  .Values.deployment.test.enabled }}
 ---
 apiVersion: v1
 kind: Pod
@@ -61,33 +62,4 @@ spec:
         backend:
           serviceName: "{{ .Release.Name }}-httpbin"
           servicePort: 80
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ .Release.Name }}-test-ingress"
-  annotations:
-    "helm.sh/hook": test
-spec:
-  restartPolicy: OnFailure
-  containers:
-    - name: "{{ .Release.Name }}-curl"
-      image: curlimages/curl
-      command:
-        - curl
-        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin"
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "{{ .Release.Name }}-test-ingress-v1beta1"
-  annotations:
-    "helm.sh/hook": test
-spec:
-  restartPolicy: OnFailure
-  containers:
-    - name: "{{ .Release.Name }}-curl"
-      image: curlimages/curl
-      command:
-        - curl
-        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin-v1beta1"
+{{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -40,6 +40,9 @@ deployment:
   # userDefinedVolumeMounts:
   # - name: "volumeName"
   #   mountPath: "/opt/user/dir/mount"
+  test:
+    # Enable creation of test resources for use with "helm test"
+    enabled: false
 
 # Override namepsace for Kong chart resources. By default, the chart creates resources in the release namespace.
 # This may not be desirable when using this chart as a dependency.

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -63,11 +63,12 @@ cd charts/kong/
 if [[ "${TAG}" == "default" ]]
 then
     echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
-    helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" ./
+    helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
+	--set deployment.test.enabled=true ./
 else
     echo "INFO: installing chart as release ${RELEASE_NAME} with controller tag ${TAG} to namespace ${RELEASE_NAMESPACE}"
     helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" \
-        --set ingressController.image.tag="${TAG}" "${RELEASE_NAME}" ./
+        --set ingressController.image.tag="${TAG}" "${RELEASE_NAME}" --set deployment.test.enabled=true ./
 fi
 
 # ------------------------------------------------------------------------------

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -52,7 +52,8 @@ trap cleanup SIGINT
 
 cd charts/kong/
 echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
-helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" ./
+helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
+    --set deployment.test.enabled=true ./
 
 # ------------------------------------------------------------------------------
 # Test Chart - Kubernetes Ingress Controller
@@ -66,7 +67,8 @@ helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
 # ------------------------------------------------------------------------------
 
 echo "INFO: upgrading the helm chart to image tag ${TAG}"
-helm upgrade --namespace "${RELEASE_NAMESPACE}" --set ingressController.image.tag="${TAG}" "${RELEASE_NAME}" ./
+helm upgrade --namespace "${RELEASE_NAMESPACE}" --set ingressController.image.tag="${TAG}" "${RELEASE_NAME}" \
+    --set deployment.test.enabled=true ./
 
 # ------------------------------------------------------------------------------
 # Test Upgraded Chart


### PR DESCRIPTION
#### What this PR does / why we need it:
Add a new "deployment.test.enabled" setting which controls whether test
resources are created. This should only be enabled for releases where
you wish to run "helm test".

Rearrange test templates to split jobs and test resources.

Enable test resources in test script releases.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- ~[ ] New or modified sections of values.yaml are documented in the README.md~ intentionally omitted
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
