### PR TITLE
[kong] Add possibility to configure  dnsConfig and dnsPolicy

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -472,6 +472,10 @@ controller](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/
 instead of a Deployment controller. This runs a Kong Pod on every kubelet in
 the Kubernetes cluster.
 
+### Using dnsPolicy and dnsConfig
+
+The chart able to inject custom DNS configuration into containers. This can be useful when you have EKS cluster with [NodeLocal DNSCache](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/) configured and attach AWS security groups directly to pod using [security groups for pods feature](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html).
+
 ### Example configurations
 
 Several example values.yaml are available in the
@@ -619,8 +623,8 @@ For a complete list of all configuration values you can set in the
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
+| deployment.kong.daemonset          | Use a DaemonSet instead of a Deployment                                               | `false`             |
 | deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |
-| deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |
 | deployment.userDefinedVolumes      | Create volumes. Please go to Kubernetes doc for the spec of the volumes               |                     |
 | deployment.userDefinedVolumeMounts | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts     |                     |
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |
@@ -641,6 +645,8 @@ For a complete list of all configuration values you can set in the
 | podLabels                          | Labels to add to each pod                                                             | `{}`                |
 | resources                          | Pod resource requests & limits                                                        | `{}`                |
 | tolerations                        | List of node taints to tolerate                                                       | `[]`                |
+| dnsPolicy                          | Pod dnsPolicy                                                                         |                     |
+| dnsConfig                          | Pod dnsConfig                                                                         |                     |
 | podDisruptionBudget.enabled        | Enable PodDisruptionBudget for Kong                                                   | `false`             |
 | podDisruptionBudget.maxUnavailable | Represents the minimum number of Pods that can be unavailable (integer or percentage) | `50%`               |
 | podDisruptionBudget.minAvailable   | Represents the number of Pods that must be available (integer or percentage)          |                     |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -623,8 +623,8 @@ For a complete list of all configuration values you can set in the
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
-| deployment.kong.daemonset          | Use a DaemonSet instead of a Deployment                                               | `false`             |
 | deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |
+| deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |
 | deployment.userDefinedVolumes      | Create volumes. Please go to Kubernetes doc for the spec of the volumes               |                     |
 | deployment.userDefinedVolumeMounts | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts     |                     |
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if or .Values.deployment.kong.enabled .Values.ingressController.enabled }}
 apiVersion: apps/v1
-{{- if .Values.deployment.daemonset }}
+{{- if .Values.deployment.kong.daemonset }}
 kind: DaemonSet
 {{- else }}
 kind: Deployment
@@ -81,6 +81,13 @@ spec:
       hostAliases:
         {{- toYaml .Values.deployment.hostAliases | nindent 6 }}
       {{- end}}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
       containers:
       {{- if .Values.ingressController.enabled }}
       {{- include "kong.controller-container" . | nindent 6 }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- if or .Values.deployment.kong.enabled .Values.ingressController.enabled }}
 apiVersion: apps/v1
-{{- if .Values.deployment.kong.daemonset }}
+{{- if .Values.deployment.daemonset }}
 kind: DaemonSet
 {{- else }}
 kind: Deployment

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -658,6 +658,20 @@ securityContext: {}
 # securityContext for containers.
 containerSecurityContext: {}
 
+## Optional DNS configuration for Kong pods
+# dnsPolicy: ClusterFirst
+# dnsConfig:
+#   nameservers:
+#   - "10.100.0.10"
+#   options:
+#   - name: ndots
+#     value: "5"
+#   searches:
+#   - default.svc.cluster.local
+#   - svc.cluster.local
+#   - cluster.local
+#   - us-east-1.compute.internal
+
 serviceMonitor:
   # Specifies whether ServiceMonitor for Prometheus operator should be created
   # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Ability to configure dnsPolicy and dnsConfig is required when you have EKS cluster with Nodelocal DNSCache configured and try to attach AWS security group directly to Kong pods. Some details you can find in [this](https://discuss.konghq.com/t/kong-ingress-readiness-liveness-probes-failed-when-use-aws-security-group-for-kong-pods/7869) discussion on Kong Nation, the solution for this case described [here](https://github.com/aws/amazon-vpc-cni-k8s/issues/1384#issuecomment-856932376).

This MR also contains a tiny fix for using DaemonSet instead of Deployment



#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #409

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
