### PR TITLE
[kong] fix daemonset values key

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -19,8 +19,6 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
-    # Use a DaemonSet controller instead of a Deployment controller
-    daemonset: false
   ## Optionally specify any extra sidecar containers to be included in the deployment
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
   # sidecarContainers:
@@ -43,6 +41,8 @@ deployment:
   test:
     # Enable creation of test resources for use with "helm test"
     enabled: false
+  # Use a DaemonSet controller instead of a Deployment controller
+  daemonset: false
 
 # Override namepsace for Kong chart resources. By default, the chart creates resources in the release namespace.
 # This may not be desirable when using this chart as a dependency.


### PR DESCRIPTION
#### What this PR does / why we need it:
The daemonset toggle was previously at `deployment.kong.daemonset`. The templates expected `deployment.daemonset`, and placing this toggle directly under `deployment` is semantically correct (it affects the entire deployment, not just the Kong container).

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #409

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
