### PR TITLE
[kong] use migration commands directly in args

### DIFF
--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -57,7 +57,7 @@ spec:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }} 
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
-        args: [ "/bin/sh", "-c", "kong migrations finish" ]
+        args: [ "kong", "migrations", "finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
         {{- include "kong.userDefinedVolumeMounts" . | nindent 8 }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -57,7 +57,7 @@ spec:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }} 
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
-        args: [ "/bin/sh", "-c", "kong migrations up" ]
+        args: [ "kong", "migrations", "up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
         {{- include "kong.userDefinedVolumeMounts" . | nindent 8 }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -65,7 +65,7 @@ spec:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }} 
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
-        args: [ "/bin/sh", "-c", "kong migrations bootstrap" ]
+        args: [ "kong", "migrations", "bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
         {{- include "kong.userDefinedVolumeMounts" . | nindent 8 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Call `kong` commands directly from migration pods. This allows them to take advantage of special entrypoint script features that require a `kong` command in args.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
Related to https://github.com/Kong/charts/issues/386#issuecomment-891859681

Note that the functionality in question doesn't yet exist in the entrypoint for the `KONG_PASSWORD` variable. This is preparation assuming that will be implemented.

#### Special notes for your reviewer:
Holding pending CI confirmation that Postgres tests complete successfully.

IIRC there may have been some reason we used the `sh` arg originally--typically we did that specifically to _avoid_ the entrypoint script because of some incompatibility between its behavior and the chart (usually related to daemonization). Not sure if that ever actually existed though and/or if it's something that affected older versions of, but not the current entrypoint script.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
