### PR TITLE
[kong] add controller to service monitor

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -596,6 +596,7 @@ section of `values.yaml` file:
 | enabled                            | Deploy the ingress controller, rbac and crd                                           | true                                                                         |
 | image.repository                   | Docker image with the ingress controller                                              | kong/kubernetes-ingress-controller |
 | image.tag                          | Version of the ingress controller                                                     | 1.2.0 |
+| image.effectiveSemver              | Version of the ingress controller used for version-specific features when image.tag is not a valid semantic version | |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
 | installCRDs                        | Creates managed CRDs.                                                                 | false

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -535,7 +535,17 @@ The name of the service used for the ingress controller's validation webhook
   {{- toYaml .Values.resources | nindent 4 }}
 {{- end -}}
 
+{{/*
+kong.controller2xplus returns "true" if the controller image tag major version is >= 2
+Note that this is a string, not a boolean, because templates vov
+*/}}
+{{- define "kong.controller2xplus" -}}
+{{- $version := semver .Values.ingressController.image.tag -}}
+{{- ge $version.Major 2 -}}
+{{- end -}}
+
 {{- define "kong.controller-container" -}}
+{{- $controllerIs2xPlus := include "kong.controller2xplus" . -}}
 - name: ingress-controller
   securityContext:
 {{ toYaml .Values.containerSecurityContext | nindent 4 }}  
@@ -550,6 +560,11 @@ The name of the service used for the ingress controller's validation webhook
   {{- if .Values.ingressController.admissionWebhook.enabled }}
   - name: webhook
     containerPort: {{ .Values.ingressController.admissionWebhook.port }}
+    protocol: TCP
+  {{- end }}
+  {{ if (eq $controllerIs2xPlus "true") -}}
+  - name: cmetrics
+    containerPort: 10255
     protocol: TCP
   {{- end }}
   env:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -540,7 +540,12 @@ kong.controller2xplus returns "true" if the controller image tag major version i
 Note that this is a string, not a boolean, because templates vov
 */}}
 {{- define "kong.controller2xplus" -}}
-{{- $version := semver .Values.ingressController.image.tag -}}
+{{- $version := "" -}}
+{{- if .Values.ingressController.image.effectiveSemver -}}
+  {{- $version = semver .Values.ingressController.image.effectiveSemver -}}
+{{- else -}}
+  {{- $version = semver .Values.ingressController.image.tag -}}
+{{- end -}}
 {{- ge $version.Major 2 -}}
 {{- end -}}
 

--- a/charts/kong/templates/servicemonitor.yaml
+++ b/charts/kong/templates/servicemonitor.yaml
@@ -1,4 +1,5 @@
 {{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+{{- $controllerIs2xPlus := include "kong.controller2xplus" . -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -24,6 +25,19 @@ spec:
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
     {{- end }}
+  {{ if (eq $controllerIs2xPlus "true") -}}
+  - targetPort: cmetrics
+    scheme: http
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.honorLabels }}
+    honorLabels: true
+    {{- end }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+  {{- end }}
   jobLabel: {{ .Release.Name }}
   namespaceSelector:
     matchNames:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -387,6 +387,12 @@ ingressController:
   image:
     repository: kong/kubernetes-ingress-controller
     tag: "1.3"
+    # Optionally set a semantic version for version-gated features. This can normally
+    # be left unset. You only need to set this if your tag is not a semver string,
+    # such as when you are using a "next" tag. Set this to the effective semantic
+    # version of your tag: for example if using a "next" image for an unreleased 3.1.0
+    # version, set this to "3.1.0".
+    effectiveSemver:
   args: []
 
   # Specify individual namespaces to watch for ingress configuration. By default,

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -20,6 +20,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}/.."
 
 TAG="${TAG:-next-railgun}"
+EFFECTIVE_TAG="2.0.0"
 RELEASE_NAME="${RELEASE_NAME:-chart-tests-upgrade-compat}"
 RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-$(uuidgen)}"
 TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
@@ -47,7 +48,7 @@ helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
 
 echo "INFO: upgrading the helm chart to image tag ${TAG}"
 helm upgrade --namespace "${RELEASE_NAMESPACE}" --set ingressController.image.tag="${TAG}" "${RELEASE_NAME}" \
-    --set deployment.test.enabled=true charts/kong/
+    --set deployment.test.enabled=true --set ingressController.image.effectiveSemver="${EFFECTIVE_TAG}" charts/kong/
 
 # ------------------------------------------------------------------------------
 # Test Upgraded Chart


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the controller metrics port to the controller container template and Prometheus ServiceMonitor template. The port only appears if the controller's major version is >= 2.

#### Which issue this PR fixes
Part of https://github.com/Kong/kubernetes-ingress-controller/issues/1497

#### Special notes for your reviewer:
This change imposes new requirements on values. The controller image tag _must_ be semver-compliant. The template will completely fail to render if it is not.

This does not pose issues for our stock image tags, but may affect users who use custom controller images. If they do not currently use semver tags, they must make them semver compliant. IMO this is a reasonable ask: they can use the base image version and include any additional info relevant to their build using semver metadata.

The helper output is annoyingly considered a string, with no available function to convert it to a boolean. Go templates are cumbersome.

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
