### PR TITLE
[kong] remove status RBAC guidance

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -537,7 +537,6 @@ resources: {}
   #  memory: 256Mi
 
 # readinessProbe for Kong pods
-# If using Kong Enterprise with RBAC, you must add a Kong-Admin-Token header
 readinessProbe:
   httpGet:
     path: "/status"


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove instructions to use RBAC headers with the status endpoint. It hasn't needed that since it was moved to the status listen.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
