### PR TITLE
[kong] release 2.3.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.3.0 (not yet released)
+## 2.3.0
 
 ### Breaking Changes
 
@@ -19,6 +19,43 @@
   CRDs so when upgrading from a previous release you will need
   to apply the new V1 versions of the CRDs (in `crds/`) manually.
   [hip-0011](https://github.com/helm/community/blob/main/hips/hip-0011.md)
+  ([#415](https://github.com/Kong/charts/pull/415))
+* Added support for controller metrics to the Prometheus resources. This
+  requires KIC 2.x. The chart automatically detects if your controller image is
+  compatible, but only if your tag is semver-compliant. If you are using an
+  image without a semver-compliant tag (such as `next`) you _must_ set the
+  `ingressController.image.effectiveSemver` value to a semver string
+  appropriate for your image (for example, if your image is 2.0.0-based, you
+  would set it to `2.0.0`.
+  ([#430](https://github.com/Kong/charts/pull/430))
+
+### Improvements
+
+* Updated default Kong versions to 2.5 (OSS) and 2.5.0.0 (Enterprise).
+* Added user-configured initContainer support to Jobs.
+  ([#408](https://github.com/Kong/charts/pull/408))
+* Upgraded RBAC resources to v1 from v1beta1 for compatibility with Kubernetes
+  1.22 and newer. This breaks compatibility with Kubernetes 1.7 and older, but
+  these Kubernetes versions were never supported, so this change is not
+  breaking. Added additional permissions to support KIC 2.x.
+  ([#420](https://github.com/Kong/charts/pull/420))
+  ([#419](https://github.com/Kong/charts/pull/419))
+* Added `ingressController.watchNamespaces[]` to values.yaml. When set, the
+  controller will only watch the listed namespaces (instead of all namespaces,
+  the default), and will create Roles for each namespace (instead of a
+  ClusterRole). This feature requires KIC 2.x.
+  ([#420](https://github.com/Kong/charts/pull/420))
+* Added support for [dnsPolicy and
+  dnsConfig](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/).
+  ([#425](https://github.com/Kong/charts/pull/425))
+* Use migration commands directly in upgrade/install Jobs instead of invoking
+  them via a shell. This adds support for some additional features in Kong
+  images that only apply when the container command starts with `kong`.
+  ([#429](https://github.com/Kong/charts/pull/429))
+
+### Fixed
+* Fixed an incorrect template for DaemonSet releases.
+  ([#426](https://github.com/Kong/charts/pull/426))
 
 ## 2.2.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 name: kong
 sources:
 version: 2.2.0
-appVersion: "2.4"
+appVersion: "2.5"

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.2.0
+version: 2.3.0
 appVersion: "2.5"

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -489,7 +489,7 @@ directory.
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
-| image.tag                          | Kong image version                                                                    | `2.4`               |
+| image.tag                          | Kong image version                                                                    | `2.5`               |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true         | `1`                 |

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -17,6 +17,7 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [2.3.0](#230)
 - [2.2.0](#220)
 - [2.1.0](#210)
 - [2.0.0](#200)
@@ -58,6 +59,51 @@ text ending with `field is immutable`. This is typically due to a bug with the
 `init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+## 2.3.0
+
+### Updated CRDs and CRD API version
+
+2.3.0 adds new and updated CRDs for KIC 2.x. These CRDs are compatible with
+KIC 1.x also. The CRD API version is now v1, replacing the deprecated v1beta1,
+to support Kubernetes 1.22 and onward. API version v1 requires Kubernetes 1.16
+and newer.
+
+Helm 2-style CRD management will upgrade CRDs automatically. You can check to
+see if you are using Helm 2-style management by running:
+
+```
+kubectl get crd kongconsumers.configuration.konghq.com -o yaml | grep "meta.helm.sh/release-name"
+```
+
+If you see output, you are using Helm 2-style CRD management.
+
+Helm 3-style CRD management (the default) does not upgrade CRDs automatically.
+You must apply the changes manually by running:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/Kong/charts/kong-2.2.0/charts/kong/crds/custom-resource-definitions.yaml
+```
+
+Although not recommended, you can remain on an older Kubernetes version and not
+upgrade your CRDs if you are using Helm 3-style CRD management. However, you
+will not be able to run KIC 2.x, and these configurations are considered
+unsupported.
+
+### Ingress controller feature detection
+
+2.3.0 includes some features that are enabled by default, but require KIC 2.x.
+KIC 2.x is not yet the default ingress controller version because there are
+currently only preview releases for it. To maintain compatibility with KIC 1.x,
+the chart automatically detects the KIC image version and disables incompatible
+features. This feature detection requires a semver image tag, and the chart
+cannot render successfully if the image tag is not semver-compliant.
+
+Standard KIC images do use semver-compliant tags, and you do not need to make
+any configuration changes if you use one. If you use a non-semver tag, such as
+`next`, you must set the new `ingressController.image.effectiveSemver` field to
+your approximate semver version. For example, if your `next` tag is for an
+unreleased `2.1.0` KIC version, you should set `effectiveSemver: 2.1.0`.
 
 ## 2.2.0
 

--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -2,7 +2,7 @@
 # use single image strings instead of repository/tag
 
 image:
-  unifiedRepoTag: kong:2.4
+  unifiedRepoTag: kong:2.5
 proxy:
   type: NodePort
 

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.4.1.1-alpine"
+  tag: "2.5.0.0-alpine"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.4.1.1-alpine"
+  tag: "2.5.0.0-alpine"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.4.1.1-alpine"
+  tag: "2.5.0.0-alpine"
 
 enterprise:
   enabled: true

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -79,10 +79,10 @@ extraLabels: {}
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "2.4"
+  tag: "2.5"
   # Kong Enterprise
   # repository: kong/kong-gateway
-  # tag: "2.4.1.1-alpine"
+  # tag: "2.5.0.0-alpine"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
#### What this PR does / why we need it:
* Bumps default Kong versions to 2.5.
* Updates changelog and upgrade guide for chart 2.3.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
