### PR TITLE
[kong] add migrations.backoffLimit

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -499,6 +499,7 @@ directory.
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
 | migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false" |
 | migrations.jobAnnotations          | Additional annotations for migration jobs                                             | `{}`                |
+| migrations.backoffLimit            | Override the system backoffLimit                                                      | `{}`                |
 | waitImage.enabled                  | Spawn init containers that wait for the database before starting Kong                 | `true`              |
 | waitImage.repository               | Image used to wait for database to become ready. Uses the Kong image if none set      |                     |
 | waitImage.tag                      | Tag for image used to wait for database to become ready                               |                     |

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -17,6 +17,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
   template:
     metadata:
       name: {{ template "kong.name" . }}-post-upgrade-migrations

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -17,6 +17,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
   template:
     metadata:
       name: {{ template "kong.name" . }}-pre-upgrade-migrations

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -25,6 +25,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
+  backoffLimit: {{ .Values.migrations.backoffLimit }}
   template:
     metadata:
       name: {{ template "kong.name" . }}-init-migrations

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -347,6 +347,7 @@ migrations:
   # This is helpful in certain non-Helm installation situations such as GitOps
   # where additional control is required around this job creation.
   jobAnnotations: {}
+  backoffLimit:
   resources: {}
   # Example reasonable setting for "resources":
   # resources:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -347,6 +347,7 @@ migrations:
   # This is helpful in certain non-Helm installation situations such as GitOps
   # where additional control is required around this job creation.
   jobAnnotations: {}
+  # Optionally set a backoffLimit. If none is set, Jobs will use the cluster default
   backoffLimit:
   resources: {}
   # Example reasonable setting for "resources":


### PR DESCRIPTION
#### What this PR does / why we need it:
Add migrations.backoffLimit to values, which sets the backoffLimit in
migration Jobs' specs.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #428 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
