### PR TITLE
[kong] fix: https://github.com/Kong/charts/issues/438

### DIFF
--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
           protocol: {{ .protocol }}
         {{- end }}
         {{- range .Values.udpProxy.stream }}
-        - name: stream-udp-{{ .containerPort }}
+        - name: streamudp-{{ .containerPort }}
           containerPort: {{ .containerPort }}
           {{- if .hostPort }}
           hostPort: {{ .hostPort }}


### PR DESCRIPTION
Limit generated UDPproxy stream port name to 15 characters.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Fix bug
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #438 

#### Special notes for your reviewer:
![image](https://user-images.githubusercontent.com/38505557/129948822-ec207209-8180-48b0-9742-e39832b3fe4d.png)
Once more, thank you.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
