### PR TITLE
[kong] use latest available Ingress version

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -566,6 +566,7 @@ or `ingress` sections, as it is used only for stream listens.
 | SVC.externalIPs                    | IPs for which nodes in the cluster will also accept traffic for the servic            | `[]`                |
 | SVC.externalTrafficPolicy          | k8s service's externalTrafficPolicy. Options: Cluster, Local                          |                     |
 | SVC.ingress.enabled                | Enable ingress resource creation (works with SVC.type=ClusterIP)                      | `false`             |
+| SVC.ingress.ingressClassName       | Set the ingressClassName to associate this Ingress with an IngressClass               |                     |
 | SVC.ingress.tls                    | Name of secret resource, containing TLS secret                                        |                     |
 | SVC.ingress.hostname               | Ingress hostname                                                                      | `""`                |
 | SVC.ingress.path                   | Ingress path.                                                                         | `/`                 |
@@ -605,7 +606,8 @@ section of `values.yaml` file:
 | serviceAccount.name                | Use existing Service Account, specify its name                                        | ""
 | serviceAccount.annotations         | Annotations for Service Account                                                       | {}
 | env                                | Specify Kong Ingress Controller configuration via environment variables               |                                                                              |
-| ingressClass                       | The ingress-class value for controller                                                | kong                                                                         |
+| ingressClass                       | The name of this controller's ingressClass                                                | kong                                                                         |
+| ingressClassAnnotations            | The ingress-class value for controller                                                | kong                                                                         |
 | args                               | List of ingress-controller cli arguments                                              | []                                                                           |
 | watchNamespaces                    | List of namespaces to watch. Watches all namespaces if empty                          | []                                                                           |
 | admissionWebhook.enabled           | Whether to enable the validating admission webhook                                    | false                                                                        |

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -88,7 +88,7 @@ spec:
     http:
       paths:
         - backend:
-          {{- if (and (not (eq .ingressVersion "networking.k8s.io/v1")) .ingress.ingressClassName) }}
+          {{- if (not (eq .ingressVersion "networking.k8s.io/v1")) }}
             serviceName: {{ .fullName }}-{{ .serviceName }}
             servicePort: {{ $servicePort }}
           {{- else }}
@@ -99,7 +99,7 @@ spec:
             {{- end }}
           {{- if $path }}
           path: {{ $path }}
-          {{- if (and (not (eq .ingressVersion "extensions/v1beta1")) .ingress.ingressClassName) }}
+          {{- if (not (eq .ingressVersion "extensions/v1beta1")) }}
           pathType: ImplementationSpecific
           {{- end }}
           {{- end -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -88,10 +88,20 @@ spec:
     http:
       paths:
         - backend:
+          {{- if (and (not (eq .ingressVersion "networking.k8s.io/v1")) .ingress.ingressClassName) }}
             serviceName: {{ .fullName }}-{{ .serviceName }}
             servicePort: {{ $servicePort }}
+          {{- else }}
+            service:
+              name: {{ .fullName }}-{{ .serviceName }}
+              port:
+                number: {{ $servicePort }}
+            {{- end }}
           {{- if $path }}
           path: {{ $path }}
+          {{- if (and (not (eq .ingressVersion "extensions/v1beta1")) .ingress.ingressClassName) }}
+          pathType: ImplementationSpecific
+          {{- end }}
           {{- end -}}
   {{- if (hasKey .ingress "tls") }}
   tls:

--- a/charts/kong/templates/ingress-class.yaml
+++ b/charts/kong/templates/ingress-class.yaml
@@ -1,0 +1,16 @@
+{{- if (and .Values.ingressController.enabled (not (eq (include "kong.ingressVersion" .) "extensions/v1beta1"))) -}}
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: {{ .Values.ingressController.ingressClass }}
+  {{- if .Values.ingressController.ingressClassAnnotations }}
+  annotations:
+  {{- range $key, $value := .Values.ingressController.ingressClassAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  labels:
+  {{- include "kong.metaLabels" . | nindent 4 }}
+spec:
+  controller: konghq.com/ingress-controller
+{{- end -}}

--- a/charts/kong/templates/ingress-class.yaml
+++ b/charts/kong/templates/ingress-class.yaml
@@ -1,3 +1,6 @@
+{{/* Create a "kong" IngressClass if none exists already */}}
+{{- $existingKongIngressClass := (lookup "networking.k8s.io/v1" "IngressClass" "" "kong") -}}
+{{- if $existingKongIngressClass -}}
 {{- if (and .Values.ingressController.enabled (not (eq (include "kong.ingressVersion" .) "extensions/v1beta1"))) -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
@@ -13,4 +16,5 @@ metadata:
   {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
   controller: konghq.com/ingress-controller
+{{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -2,6 +2,7 @@
 {{- if and .Values.admin.enabled (or .Values.admin.http.enabled .Values.admin.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.admin -}}
+{{- $_ := set $serviceConfig "ingressVersion" (include "kong.ingressVersion" .) -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}

--- a/charts/kong/templates/service-kong-cluster-telemetry.yaml
+++ b/charts/kong/templates/service-kong-cluster-telemetry.yaml
@@ -2,6 +2,7 @@
 {{- if and .Values.clustertelemetry.enabled .Values.clustertelemetry.tls.enabled -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.clustertelemetry -}}
+{{- $_ := set $serviceConfig "ingressVersion" (include "kong.ingressVersion" .) -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}

--- a/charts/kong/templates/service-kong-cluster.yaml
+++ b/charts/kong/templates/service-kong-cluster.yaml
@@ -2,6 +2,7 @@
 {{- if and .Values.cluster.enabled .Values.cluster.tls.enabled -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.cluster -}}
+{{- $_ := set $serviceConfig "ingressVersion" (include "kong.ingressVersion" .) -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}

--- a/charts/kong/templates/service-kong-manager.yaml
+++ b/charts/kong/templates/service-kong-manager.yaml
@@ -3,6 +3,7 @@
 {{- if and .Values.manager.enabled (or .Values.manager.http.enabled .Values.manager.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.manager -}}
+{{- $_ := set $serviceConfig "ingressVersion" (include "kong.ingressVersion" .) -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}

--- a/charts/kong/templates/service-kong-portal-api.yaml
+++ b/charts/kong/templates/service-kong-portal-api.yaml
@@ -3,6 +3,7 @@
 {{- if and .Values.portalapi.enabled (or .Values.portalapi.http.enabled .Values.portalapi.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.portalapi -}}
+{{- $_ := set $serviceConfig "ingressVersion" (include "kong.ingressVersion" .) -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}

--- a/charts/kong/templates/service-kong-portal.yaml
+++ b/charts/kong/templates/service-kong-portal.yaml
@@ -3,6 +3,7 @@
 {{- if and .Values.portal.enabled (or .Values.portal.http.enabled .Values.portal.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.portal -}}
+{{- $_ := set $serviceConfig "ingressVersion" (include "kong.ingressVersion" .) -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -2,6 +2,7 @@
 {{- if and .Values.proxy.enabled (or .Values.proxy.http.enabled .Values.proxy.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.proxy -}}
+{{- $_ := set $serviceConfig "ingressVersion" (include "kong.ingressVersion" .) -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}

--- a/charts/kong/templates/service-kong-udp-proxy.yaml
+++ b/charts/kong/templates/service-kong-udp-proxy.yaml
@@ -2,6 +2,7 @@
 {{- if and .Values.udpProxy.enabled -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.udpProxy -}}
+{{- $_ := set $serviceConfig "ingressVersion" (include "kong.ingressVersion" .) -}}
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -136,6 +136,7 @@ admin:
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
+    ingressClassName:
     # TLS secret name.
     # tls: kong-admin.example.com-tls
     # Ingress hostname
@@ -256,6 +257,7 @@ proxy:
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
+    ingressClassName:
     # Ingress hostname
     # TLS secret name.
     # tls: kong-admin.example.com-tls
@@ -434,6 +436,8 @@ ingressController:
     #   | Add the CA bundle content here.
 
   ingressClass: kong
+  # annotations for IngressClass resource (Kubernetes 1.18+)
+  ingressClassAnnotations: {}
 
   rbac:
     # Specifies whether RBAC resources should be created
@@ -780,6 +784,7 @@ manager:
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
+    ingressClassName:
     # TLS secret name.
     # tls: kong-proxy.example.com-tls
     # Ingress hostname
@@ -823,6 +828,7 @@ portal:
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
+    ingressClassName:
     # TLS secret name.
     # tls: kong-proxy.example.com-tls
     # Ingress hostname
@@ -866,6 +872,7 @@ portalapi:
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
+    ingressClassName:
     # TLS secret name.
     # tls: kong-proxy.example.com-tls
     # Ingress hostname

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -48,3 +48,8 @@ fi
 
 echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
 helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
+
+# ------------------------------------------------------------------------------
+# Cleanup
+# ------------------------------------------------------------------------------
+helm delete --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -56,3 +56,9 @@ helm upgrade --namespace "${RELEASE_NAMESPACE}" --set ingressController.image.ta
 
 echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
 helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
+
+
+# ------------------------------------------------------------------------------
+# Cleanup
+# ------------------------------------------------------------------------------
+helm delete --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"


### PR DESCRIPTION
#### What this PR does / why we need it:
Add support for networking.k8s.io/v1beta1 and networking.k8s.io/v1
Ingress resources. Generate Ingress resources with the newest available
version on the cluster.

Add support for the ingressClassName field and IngressClass resource.

We need Ingress v1 support for 1.22. These are fairly recent, however, so instead of blanket changes to v1, this auto-detects the latest available version and creates resources according.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #444 

#### Special notes for your reviewer:
Does anyone know of a local K8S environment <1.18 that still works? KIND and Minikube are both failing to start for me on 1.17 and 1.16 images, and I can't find related issues with a fix in those projects.

I can force the extensions content to render with invalid versions:
```
diff --git a/charts/kong/templates/_helpers.tpl b/charts/kong/templates/_helpers.tpl
index 268182f45..386ade324 100644
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1076,9 +1076,9 @@ Kubernetes resources it uses to build Kong configuration.
 {{- end -}}
 
 {{- define "kong.ingressVersion" -}}
-{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1") -}}
+{{- if (.Capabilities.APIVersions.Has "anetworking.k8s.io/v1") -}}
 networking.k8s.io/v1
-{{- else if (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") -}}
+{{- else if (.Capabilities.APIVersions.Has "anetworking.k8s.io/v1beta1") -}}
 networking.k8s.io/v1beta1
 {{- else -}}
 extensions/v1beta1
```
Which makes `helm template trk /tmp/symkong -f ~/src/charts/charts/kong/example-values/minimal-kong-controller.yaml --set admin.enabled=true --set admin.ingress.enabled=true > /tmp/fakeold.yaml` render [fakeold.yaml.txt](https://github.com/Kong/charts/files/7017969/fakeold.yaml.txt)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
