### PR TITLE
[kong] ServiceAccount can't be created if not using ingressController (#418)

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -629,6 +629,9 @@ For a complete list of all configuration values you can set in the
 | deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |
 | deployment.userDefinedVolumes      | Create volumes. Please go to Kubernetes doc for the spec of the volumes               |                     |
 | deployment.userDefinedVolumeMounts | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts     |                     |
+| deployment.serviceAccount.create   | Create Service Account for the Deployment / Daemonset and the migrations              | `false`             |
+| deployment.serviceAccount.name     | Name of the Service Account, a default one will be generated if left blank            | ""                  |
+| deployment.serviceAccount.annotations | Annotations for the Service Account                                                | {}                  |
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |
 | autoscaling.minReplicas            | Set minimum number of replicas                                                        | `2`                 |
 | autoscaling.maxReplicas            | Set maximum number of replicas                                                        | `5`                 |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -630,7 +630,7 @@ For a complete list of all configuration values you can set in the
 | deployment.userDefinedVolumes      | Create volumes. Please go to Kubernetes doc for the spec of the volumes               |                     |
 | deployment.userDefinedVolumeMounts | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts     |                     |
 | deployment.serviceAccount.create   | Create Service Account for the Deployment / Daemonset and the migrations              | `false`             |
-| deployment.serviceAccount.name     | Name of the Service Account, a default one will be generated if left blank            | ""                  |
+| deployment.serviceAccount.name     | Name of the Service Account, a default one will be generated if left blank. If the ingressController.serviceAccount.create is set to true then the name will be taken from the ingressController.serviceAccount.name | ""                  |
 | deployment.serviceAccount.annotations | Annotations for the Service Account                                                | {}                  |
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |
 | autoscaling.minReplicas            | Set minimum number of replicas                                                        | `2`                 |

--- a/charts/kong/ci/service-account.yaml
+++ b/charts/kong/ci/service-account.yaml
@@ -6,3 +6,6 @@ deployment:
     name: my-kong-sa
     annotations: {}
 
+ingressController:
+  serviceAccount:
+    create: false

--- a/charts/kong/ci/service-account.yaml
+++ b/charts/kong/ci/service-account.yaml
@@ -1,7 +1,7 @@
 
-# install chart with a servie account
-
-serviceAccount:
+# install chart with a service account
+deployment:
+  serviceAccount:
     create: true
     name: my-kong-sa
     annotations: {}

--- a/charts/kong/ci/service-account.yaml
+++ b/charts/kong/ci/service-account.yaml
@@ -1,0 +1,8 @@
+
+# install chart with a servie account
+
+serviceAccount:
+    create: true
+    name: my-kong-sa
+    annotations: {}
+

--- a/charts/kong/ci/service-account.yaml
+++ b/charts/kong/ci/service-account.yaml
@@ -3,7 +3,7 @@
 deployment:
   serviceAccount:
     create: true
-    name: my-kong-sa
+    name: "my-kong-sa"
     annotations: {}
 
 ingressController:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -52,12 +52,21 @@ app.kubernetes.io/instance: "{{ .Release.Name }}"
 Create the name of the service account to use
 */}}
 {{- define "kong.serviceAccountName" -}}
+{{- if .Values.ingressController.serviceAccount.name -}}
 {{- if .Values.ingressController.serviceAccount.create -}}
     {{ default (include "kong.fullname" .) .Values.ingressController.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.ingressController.serviceAccount.name }}
 {{- end -}}
+{{- else -}}
+{{- if .Values.deployment.serviceAccount.create -}}
+    {{ default (include "kong.fullname" .) .Values.deployment.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.deployment.serviceAccount.name }}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
 
 {{/*
 Create Ingress resource for a Kong service

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -58,7 +58,7 @@ Create the name of the service account to use
 {{- if .Values.deployment.serviceAccount.create -}}
     {{ default (include "kong.fullname" .) .Values.deployment.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" Values.ingressController.serviceAccount.name }}
+    {{ default "default" .Values.ingressController.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -52,17 +52,13 @@ app.kubernetes.io/instance: "{{ .Release.Name }}"
 Create the name of the service account to use
 */}}
 {{- define "kong.serviceAccountName" -}}
-{{- if .Values.ingressController.serviceAccount.name -}}
 {{- if .Values.ingressController.serviceAccount.create -}}
     {{ default (include "kong.fullname" .) .Values.ingressController.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.ingressController.serviceAccount.name }}
-{{- end -}}
 {{- else -}}
 {{- if .Values.deployment.serviceAccount.create -}}
     {{ default (include "kong.fullname" .) .Values.deployment.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.deployment.serviceAccount.name }}
+    {{ default "default" Values.ingressController.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}
-      {{- if or .Values.ingressController.enabled .Values.podSecurityPolicy.enabled }}
+      {{- if or .Values.ingressController.enabled .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
       {{ end }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
-      {{- if and .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
+      {{- if or .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
-      {{- if .Values.podSecurityPolicy.enabled }}
+      {{- if and .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
-      {{- if and .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
+      {{- if or .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
-      {{- if .Values.podSecurityPolicy.enabled }}
+      {{- if and .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
-      {{- if .Values.podSecurityPolicy.enabled }}
+      {{- if and .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
-      {{- if and .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
+      {{- if or .Values.podSecurityPolicy.enabled .Values.deployment.serviceAccount.create }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.image.pullSecrets }}

--- a/charts/kong/templates/service-account.yaml
+++ b/charts/kong/templates/service-account.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.deployment.kong.enabled .Values.deployment.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "kong.serviceAccountName" . }}
+  namespace: {{ template "kong.namespace" . }}
+  {{- if .Values.deployment.serviceAccount.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.deployment.serviceAccount.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -22,8 +22,8 @@ deployment:
   ## Specify the service account to create and to be assigned to the deployment / daemonset and for th migrations
   serviceAccount:
     create: false
-  ## Optionally specify the name of the service account to create and the annotations to add.  
-  #  name: 
+  ## Optionally specify the name of the service account to create and the annotations to add.
+  #  name:
   #  annotations: {}
 
   ## Optionally specify any extra sidecar containers to be included in the deployment

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -21,9 +21,11 @@ deployment:
     enabled: true
   ## Specify the service account to create and to be assigned to the deployment / daemonset and for th migrations
   serviceAccount:
-     create: false
-     name: 
-     annotations: {}      
+    create: false
+  ## Optionally specify the name of the service account to create and the annotations to add.  
+  #  name: 
+  #  annotations: {}
+
   ## Optionally specify any extra sidecar containers to be included in the deployment
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
   # sidecarContainers:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -19,6 +19,11 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+  ## Specify the service account to create and to be assigned to the deployment / daemonset and for th migrations
+  serviceAccount:
+     create: false
+     name: 
+     annotations: {}      
   ## Optionally specify any extra sidecar containers to be included in the deployment
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
   # sidecarContainers:


### PR DESCRIPTION
[kong] ServiceAccount can't be created if not using ingressController (#418)

Add the feature to create a service account for the deployment and the migrations

#### What this PR does / why we need it:

#### Which issue this PR fixes
 - fixes #418 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [X] New or modified sections of values.yaml are documented in the README.md
- [X] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
