### PR TITLE
[kong] fix: support helm test on k8s v1.22+

### DIFF
--- a/charts/kong/templates/tests/test-resources.yaml
+++ b/charts/kong/templates/tests/test-resources.yaml
@@ -45,21 +45,4 @@ spec:
             name: "{{ .Release.Name }}-httpbin"
             port:
               number: 80
----
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: "{{ .Release.Name }}-httpbin-v1beta1"
-  annotations:
-    httpbin.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: "kong"
-    konghq.com/strip-path: "true"
-spec:
-  rules:
-  - http:
-      paths:
-      - path: /httpbin-v1beta1
-        backend:
-          serviceName: "{{ .Release.Name }}-httpbin"
-          servicePort: 80
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Going forward in order to support Kubernetes
release v1.22.x+ (wherein v1beta1.Ingress was
removed) this patch removes testing those
legacy types when testing the KIC.

The KIC itself still supports (and tests) the
legacy types independently upstream.

#### Which issue this PR fixes

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1683

#### Checklist

- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
