### PR TITLE
[kong] update CRDs

### DIFF
--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -1,11 +1,7 @@
-# generated using: kubectl kustomize github.com/kong/kubernetes-ingress-controller/railgun/config/crd?ref=main
----
+# generated using: kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/crd?ref=main
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -13,55 +9,49 @@ spec:
     kind: KongClusterPlugin
     listKind: KongClusterPluginList
     plural: kongclusterplugins
+    shortNames:
+    - kcp
     singular: kongclusterplugin
   preserveUnknownFields: false
   scope: Cluster
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: KongClusterPlugin is the Schema for the kongclusterplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
+            type: object
             x-kubernetes-preserve-unknown-fields: true
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: NamespacedSecretValueFromSource represents the source
                   of a secret value specifying the secret namespace
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
@@ -69,6 +59,10 @@ spec:
                   namespace:
                     description: The namespace containing the secret
                     type: string
+                required:
+                - key
+                - name
+                - namespace
                 type: object
             type: object
           consumerRef:
@@ -77,13 +71,6 @@ spec:
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -92,12 +79,26 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:
             description: RunOn configures the plugin to run on the first or the second
               or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
             type: string
+        required:
+        - plugin
         type: object
     served: true
     storage: true
@@ -113,9 +114,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -123,20 +121,26 @@ spec:
     kind: KongConsumer
     listKind: KongConsumerList
     plural: kongconsumers
+    shortNames:
+    - kc
     singular: kongconsumer
   preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Username of a Kong Consumer
+      jsonPath: .username
+      name: Username
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: KongConsumer is the Schema for the kongconsumers API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           credentials:
             description: Credentials are references to secrets containing a credential
               to be provisioned in Kong.
@@ -147,13 +151,6 @@ spec:
             description: CustomID existing unique ID for the consumer - useful for
               mapping Kong with users in your existing database
             type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           username:
             description: Username unique username of the consumer.
             type: string
@@ -172,9 +169,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -182,6 +176,8 @@ spec:
     kind: KongIngress
     listKind: KongIngressList
     plural: kongingresses
+    shortNames:
+    - ki
     singular: kongingress
   preserveUnknownFields: false
   scope: Namespaced
@@ -191,126 +187,64 @@ spec:
       openAPIV3Schema:
         description: KongIngress is the Schema for the kongingresses API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           proxy:
             description: Service represents a Service in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Service-object
             properties:
-              ca_certificates:
-                items:
-                  type: string
-                type: array
-              client_certificate:
-                description: Certificate represents a Certificate in Kong. Read https://getkong.org/docs/0.14.x/admin-api/#certificate-object
-                properties:
-                  cert:
-                    type: string
-                  created_at:
-                    format: int64
-                    type: integer
-                  id:
-                    type: string
-                  key:
-                    type: string
-                  snis:
-                    items:
-                      type: string
-                    type: array
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                type: object
               connect_timeout:
-                type: integer
-              created_at:
-                type: integer
-              host:
-                type: string
-              id:
-                type: string
-              name:
-                type: string
-              path:
-                type: string
-              port:
+                minimum: 0
                 type: integer
               protocol:
+                enum:
+                - http
+                - https
+                - grpc
+                - grpcs
+                - tcp
+                - tls
+                - udp
                 type: string
               read_timeout:
+                minimum: 0
                 type: integer
               retries:
+                minimum: 0
                 type: integer
-              tags:
-                items:
-                  type: string
-                type: array
-              tls_verify:
-                type: boolean
-              tls_verify_depth:
-                type: integer
-              updated_at:
-                type: integer
-              url:
-                type: string
               write_timeout:
+                minimum: 0
                 type: integer
             type: object
           route:
             description: Route represents a Route in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Route-object
             properties:
-              created_at:
-                type: integer
-              destinations:
-                items:
-                  description: CIDRPort represents a set of CIDR and a port.
-                  properties:
-                    ip:
-                      type: string
-                    port:
-                      type: integer
-                  type: object
-                type: array
               headers:
                 additionalProperties:
                   items:
                     type: string
                   type: array
                 type: object
-              hosts:
-                items:
-                  type: string
-                type: array
               https_redirect_status_code:
                 type: integer
-              id:
-                type: string
               methods:
                 items:
                   type: string
                 type: array
-              name:
-                type: string
               path_handling:
+                enum:
+                - v0
+                - v1
                 type: string
-              paths:
-                items:
-                  type: string
-                type: array
               preserve_host:
                 type: boolean
               protocols:
                 items:
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
                   type: string
                 type: array
               regex_priority:
@@ -325,122 +259,22 @@ spec:
                 type: boolean
               response_buffering:
                 type: boolean
-              service:
-                description: Service represents a Service in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Service-object
-                properties:
-                  ca_certificates:
-                    items:
-                      type: string
-                    type: array
-                  client_certificate:
-                    description: Certificate represents a Certificate in Kong. Read
-                      https://getkong.org/docs/0.14.x/admin-api/#certificate-object
-                    properties:
-                      cert:
-                        type: string
-                      created_at:
-                        format: int64
-                        type: integer
-                      id:
-                        type: string
-                      key:
-                        type: string
-                      snis:
-                        items:
-                          type: string
-                        type: array
-                      tags:
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  connect_timeout:
-                    type: integer
-                  created_at:
-                    type: integer
-                  host:
-                    type: string
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  path:
-                    type: string
-                  port:
-                    type: integer
-                  protocol:
-                    type: string
-                  read_timeout:
-                    type: integer
-                  retries:
-                    type: integer
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                  tls_verify:
-                    type: boolean
-                  tls_verify_depth:
-                    type: integer
-                  updated_at:
-                    type: integer
-                  url:
-                    type: string
-                  write_timeout:
-                    type: integer
-                type: object
               snis:
                 items:
                   type: string
                 type: array
-              sources:
-                items:
-                  description: CIDRPort represents a set of CIDR and a port.
-                  properties:
-                    ip:
-                      type: string
-                    port:
-                      type: integer
-                  type: object
-                type: array
               strip_path:
                 type: boolean
-              tags:
-                items:
-                  type: string
-                type: array
-              updated_at:
-                type: integer
             type: object
           upstream:
             description: Upstream represents an Upstream in Kong.
             properties:
               algorithm:
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
                 type: string
-              client_certificate:
-                description: Certificate represents a Certificate in Kong. Read https://getkong.org/docs/0.14.x/admin-api/#certificate-object
-                properties:
-                  cert:
-                    type: string
-                  created_at:
-                    format: int64
-                    type: integer
-                  id:
-                    type: string
-                  key:
-                    type: string
-                  snis:
-                    items:
-                      type: string
-                    type: array
-                  tags:
-                    items:
-                      type: string
-                    type: array
-                type: object
-              created_at:
-                format: int64
-                type: integer
               hash_fallback:
                 type: string
               hash_fallback_header:
@@ -462,6 +296,7 @@ spec:
                       probing.
                     properties:
                       concurrency:
+                        minimum: 1
                         type: integer
                       healthy:
                         description: Healthy configures thresholds and HTTP status
@@ -472,17 +307,17 @@ spec:
                               type: integer
                             type: array
                           interval:
+                            minimum: 0
                             type: integer
                           successes:
+                            minimum: 0
                             type: integer
                         type: object
                       http_path:
+                        pattern: ^/.*$
                         type: string
-                      https_sni:
-                        type: string
-                      https_verify_certificate:
-                        type: boolean
                       timeout:
+                        minimum: 0
                         type: integer
                       type:
                         type: string
@@ -491,16 +326,20 @@ spec:
                           codes to mark targets unhealthy.
                         properties:
                           http_failures:
+                            minimum: 0
                             type: integer
                           http_statuses:
                             items:
                               type: integer
                             type: array
                           interval:
+                            minimum: 0
                             type: integer
                           tcp_failures:
+                            minimum: 0
                             type: integer
                           timeouts:
+                            minimum: 0
                             type: integer
                         type: object
                     type: object
@@ -517,45 +356,42 @@ spec:
                               type: integer
                             type: array
                           interval:
+                            minimum: 0
                             type: integer
                           successes:
+                            minimum: 0
                             type: integer
                         type: object
-                      type:
-                        type: string
                       unhealthy:
                         description: Unhealthy configures thresholds and HTTP status
                           codes to mark targets unhealthy.
                         properties:
                           http_failures:
+                            minimum: 0
                             type: integer
                           http_statuses:
                             items:
                               type: integer
                             type: array
                           interval:
+                            minimum: 0
                             type: integer
                           tcp_failures:
+                            minimum: 0
                             type: integer
                           timeouts:
+                            minimum: 0
                             type: integer
                         type: object
                     type: object
                   threshold:
-                    type: number
+                    type: integer
                 type: object
               host_header:
                 type: string
-              id:
-                type: string
-              name:
-                type: string
               slots:
+                minimum: 10
                 type: integer
-              tags:
-                items:
-                  type: string
-                type: array
             type: object
         type: object
     served: true
@@ -572,9 +408,6 @@ status:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -582,74 +415,61 @@ spec:
     kind: KongPlugin
     listKind: KongPluginList
     plural: kongplugins
+    shortNames:
+    - kp
     singular: kongplugin
   preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: KongPlugin is the Schema for the kongplugins API
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
           config:
             description: Config contains the plugin configuration.
+            type: object
             x-kubernetes-preserve-unknown-fields: true
           configFrom:
             description: ConfigFrom references a secret containing the plugin configuration.
             properties:
-              apiVersion:
-                description: 'APIVersion defines the versioned schema of this representation
-                  of an object. Servers should convert recognized schemas to the latest
-                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                type: string
-              kind:
-                description: 'Kind is a string value representing the REST resource
-                  this object represents. Servers may infer this from the endpoint
-                  the client submits requests to. Cannot be updated. In CamelCase.
-                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                type: string
               secretKeyRef:
                 description: SecretValueFromSource represents the source of a secret
                   value
                 properties:
-                  apiVersion:
-                    description: 'APIVersion defines the versioned schema of this
-                      representation of an object. Servers should convert recognized
-                      schemas to the latest internal value, and may reject unrecognized
-                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                    type: string
                   key:
                     description: the key containing the value
-                    type: string
-                  kind:
-                    description: 'Kind is a string value representing the REST resource
-                      this object represents. Servers may infer this from the endpoint
-                      the client submits requests to. Cannot be updated. In CamelCase.
-                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: the secret containing the key
                     type: string
+                required:
+                - key
+                - name
                 type: object
             type: object
-          consumerRef:
-            description: ConsumerRef is a reference to a particular consumer
-            type: string
           disabled:
             description: Disabled set if the plugin is disabled or not
             type: boolean
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -658,12 +478,26 @@ spec:
             description: Protocols configures plugin to run on requests received on
               specific protocols.
             items:
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
               type: string
             type: array
           run_on:
             description: RunOn configures the plugin to run on the first or the second
               or both nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
             type: string
+        required:
+        - plugin
         type: object
     served: true
     storage: true
@@ -680,7 +514,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: tcpingresses.configuration.konghq.com
 spec:
@@ -693,7 +527,16 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: TCPIngress is the Schema for the tcpingresses API
@@ -729,6 +572,9 @@ spec:
                           type: string
                         servicePort:
                           description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
                           type: integer
                       required:
                       - serviceName
@@ -745,6 +591,7 @@ spec:
                         over TCP sessions and route. It is a required field. If a
                         Host is not specified, the requested are routed based only
                         on Port.
+                      format: int32
                       maximum: 65535
                       minimum: 1
                       type: integer
@@ -854,7 +701,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: udpingresses.configuration.konghq.com
 spec:
@@ -867,7 +714,16 @@ spec:
   preserveUnknownFields: false
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: UDPIngress is the Schema for the udpingresses API
@@ -903,6 +759,9 @@ spec:
                           type: string
                         servicePort:
                           description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
                           type: integer
                       required:
                       - serviceName


### PR DESCRIPTION
#### What this PR does / why we need it:

Some patches to CRDs upstream recently changed some of the validation and other fields, this patch pulls those (by running the `kustomize` one liner from the comments) in for the upcoming 2.x release of the KIC.

#### Which issue this PR fixes

Resolves https://github.com/Kong/kubernetes-ingress-controller/issues/1762

#### Checklist

- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
