### PR TITLE
[kong] fix: dbless configmap duplicate pipes

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -146,17 +146,18 @@ read the [env](#the-env-section) section.
 
 When deploying Kong in DB-less mode(`env.database: "off"`)
 and without the Ingress Controller(`ingressController.enabled: false`),
-you have to provide a [declarative configuration]https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format)
-for Kong to run. You can provide an existing ConfigMap
+you have to provide a [declarative configuration]https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format) for Kong to run.
+You can provide an existing ConfigMap
 (`dblessConfig.configMap`) or place the whole configuration into
 `values.yaml` (`dblessConfig.config`)
 parameter. See the example configuration in the default values.yaml
 for more details. You can use `--set-file dblessConfig.config=/path/to/declarative-config.yaml`
 in Helm commands to substitute in a complete declarative config file.    
     
-Note that ConfigMap updates will not restart Kong pods when using `dblessConfig.configMap`,
-and they will not recognize updated configuration until restarted. You should run
-`kubectl rollout restart deploy` after updating the configuration ConfigMap contents.    
+Note that externally supplied ConfigMaps are not hashed or tracked in deployment annotations.
+Subsequent ConfigMap updates will require user-initiated new deployment rollouts
+to apply the new configuration. You should run `kubectl rollout restart deploy`
+after updating externally supplied ConfigMap content.    
     
 #### Using the Postgres sub-chart
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -146,7 +146,7 @@ read the [env](#the-env-section) section.
 
 When deploying Kong in DB-less mode(`env.database: "off"`)
 and without the Ingress Controller(`ingressController.enabled: false`),
-you have to provide a [declarative configuration]https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format) for Kong to run.
+you have to provide a [declarative configuration](https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format) for Kong to run.
 You can provide an existing ConfigMap
 (`dblessConfig.configMap`) or place the whole configuration into
 `values.yaml` (`dblessConfig.config`)

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -146,21 +146,17 @@ read the [env](#the-env-section) section.
 
 When deploying Kong in DB-less mode(`env.database: "off"`)
 and without the Ingress Controller(`ingressController.enabled: false`),
-you have to provide a declarative configuration for Kong to run. [Declarative
-configuration](https://docs.konghq.com/gateway-oss/2.5.x/db-less-and-declarative-config/#the-declarative-configuration-format)
-is supplied via ConfigMap.    
+you have to provide a [declarative configuration]https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format)
+for Kong to run. You can provide an existing ConfigMap
+(`dblessConfig.configMap`) or place the whole configuration into
+`values.yaml` (`dblessConfig.config`)
+parameter. See the example configuration in the default values.yaml
+for more details. You can use `--set-file dblessConfig.config=/path/to/declarative-config.yaml`
+in Helm commands to substitute in a complete declarative config file.    
     
-Possible sources of the declarative configuration ConfigMap include configuration 
-supplied under the `dblessConfig.config` paramater of `values.yaml`, or with the
-helm flag `--set-file` parameter. See the example configuration in the default 
-[values.yaml](values.yaml#L371) or [example-values/dbless-config.yaml](example-values/dbless-config.yaml)
-for syntax and more details.    
-    
-Alternatively, the configuration can be provided separately using an existing
-ConfigMap name supplied to Kong in (`dblessConfig.configMap`). Note, externally
-supplied ConfigMaps are not hashed or tracked in deployment annotations.
-Subsequent ConfigMap updates will require user-initiated new deployment rollouts
-to apply the new configuration.    
+Note that ConfigMap updates will not restart Kong pods when using `dblessConfig.configMap`,
+and they will not recognize updated configuration until restarted. You should run
+`kubectl rollout restart deploy` after updating the configuration ConfigMap contents.    
     
 #### Using the Postgres sub-chart
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -146,13 +146,22 @@ read the [env](#the-env-section) section.
 
 When deploying Kong in DB-less mode(`env.database: "off"`)
 and without the Ingress Controller(`ingressController.enabled: false`),
-you have to provide a declarative configuration for Kong to run.
-The configuration can be provided using an existing ConfigMap
-(`dblessConfig.configMap`) or or the whole configuration can be put into the
-`values.yaml` file for deployment itself, under the `dblessConfig.config`
-parameter. See the example configuration in the default values.yaml
-for more details.
-
+you have to provide a declarative configuration for Kong to run. [Declarative
+configuration](https://docs.konghq.com/gateway-oss/2.5.x/db-less-and-declarative-config/#the-declarative-configuration-format)
+is supplied via ConfigMap.    
+    
+Possible sources of the declarative configuration ConfigMap include configuration 
+supplied under the `dblessConfig.config` paramater of `values.yaml`, or with the
+helm flag `--set-file` parameter. See the example configuration in the default 
+[values.yaml](values.yaml#L371) or [example-values/dbless-config.yaml](example-values/dbless-config.yaml)
+for syntax and more details.    
+    
+Alternatively, the configuration can be provided separately using an existing
+ConfigMap name supplied to Kong in (`dblessConfig.configMap`). Note, externally
+supplied ConfigMaps are not hashed or tracked in deployment annotations.
+Subsequent ConfigMap updates will require user-initiated new deployment rollouts
+to apply the new configuration.    
+    
 #### Using the Postgres sub-chart
 
 The chart can optionally spawn a Postgres instance using [Bitnami's Postgres

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -9,23 +9,6 @@ env:
   database: "off"
 postgresql:
   enabled: false
-# - supply DBless config for kong
-dblessConfig:
-  # Or the configuration is passed in full-text below
-  config:
-    _format_version: "1.1"
-    services:
-      - name: test-svc
-        url: http://example.com
-        routes:
-        - name: test
-          paths:
-          - /test
-        plugins:
-        - name: request-termination
-          config:
-            status_code: 200
-            message: "dbless-config"
 proxy:
   type: NodePort
 deployment:

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -12,23 +12,6 @@ env:
   database: "off"
 postgresql:
   enabled: false
-# - supply DBless config for kong
-dblessConfig:
-  # Or the configuration is passed in full-text below
-  config:
-    _format_version: "1.1"
-    services:
-      - name: test-svc
-        url: http://example.com
-        routes:
-        - name: test
-          paths:
-          - /test
-        plugins:
-        - name: request-termination
-          config:
-            status_code: 200
-            message: "dbless-config"
 proxy:
   type: NodePort
 # - add stream listens

--- a/charts/kong/example-values/dbless-config.yaml
+++ b/charts/kong/example-values/dbless-config.yaml
@@ -1,0 +1,9 @@
+_format_version: "1.1"
+services:
+  # Example configuration
+  - name: example.com
+    url: http://example.com
+    routes:
+    - name: example
+      paths:
+      - "/example"

--- a/charts/kong/example-values/dbless-config.yaml
+++ b/charts/kong/example-values/dbless-config.yaml
@@ -1,9 +1,0 @@
-_format_version: "1.1"
-services:
-  # Example configuration
-  - name: example.com
-    url: http://example.com
-    routes:
-    - name: example
-      paths:
-      - "/example"

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
 data:
-  kong.yml: |
+  kong.yml:
 {{ .Values.dblessConfig.config | toYaml | indent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -364,7 +364,7 @@ dblessConfig:
   # Either Kong's configuration is managed from an existing ConfigMap (with Key: kong.yml)
   configMap: ""
   # Or the configuration is passed in full-text below
-  config:
+  config: |
     _format_version: "1.1"
     services:
       # Example configuration


### PR DESCRIPTION
#### What this PR does / why we need it:
DB-less ConfigMap generates faulty ConfigMap with duplicate pipes on value when using helm `--set-file dblessConfig.config` or piping into `--set dblessConfig.config`

#### Which issue this PR fixes
  - fixes #463 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)

Signed-off-by: usrbinkat <usrbinkat@braincraft.io> 