### PR TITLE
[kong] fix service account inconsistency

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -55,7 +55,7 @@ Create the name of the service account to use
 {{- if .Values.deployment.serviceAccount.create -}}
     {{ default (include "kong.fullname" .) .Values.deployment.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.ingressController.serviceAccount.name }}
+    {{ default "default" .Values.deployment.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Make both clauses of the kong.serviceAccountName helper template use the
deployment.serviceAccount.name value. The else clause previously used
the deprecated ingressController.serviceAccount.name. Forgot to change
it when moving the value in #455.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #467 (not exactly--that issue was already fixed by #455, but this addresses issues with the fix mentioned there)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
