### PR TITLE
[kong] Release Kong chart 2.4.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 2.4.0
+
+* KIC now defaults to version 2.0. If you use a database, you must first
+  perform a temporary intermediate upgrade to disable KIC before upgrading it
+  to 2.0 and re-enabling it. See the [upgrade guide](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#disable-ingress-controller-prior-to-2x-upgrade-when-using-postgresql)
+  for detailed instructions.
+* ServiceAccount are now always created by default unless explicitly disabled.
+  ServiceAccount customization has [moved under the `deployment` section of
+  configuration](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#changed-serviceaccount-configuration-location)
+  to reflect this. This accomodates configurations that need a ServiceAccount
+  but that do not use the ingress controller.
+  ([#455](https://github.com/Kong/charts/pull/455))
+
+### Breaking Changes
+
+### Improvements
+
+* Migration jobs support a configurable backoffLimit.
+  ([#442](https://github.com/Kong/charts/pull/442))
+* Generated Ingresses now use `networking.k8s.io/v1` when available.
+  ([#446](https://github.com/Kong/charts/pull/446))
+
+### Fixed
+
+* 5-digit UDP ports now work properly.
+  ([#443](https://github.com/Kong/charts/pull/443))
+* Fixed port name used for NLB annotation example.
+  ([#458](https://github.com/Kong/charts/pull/458))
+* Fixed a compatibility issue with Helm's `--set-file` feature and
+  user-provided DB-less configuration ConfigMaps.
+  ([#465](https://github.com/Kong/charts/pull/465))
+
 ## 2.3.0
 
 ### Breaking Changes

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.3.0
+version: 2.4.0
 appVersion: "2.5"

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -603,7 +603,7 @@ section of `values.yaml` file:
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | enabled                            | Deploy the ingress controller, rbac and crd                                           | true                                                                         |
 | image.repository                   | Docker image with the ingress controller                                              | kong/kubernetes-ingress-controller |
-| image.tag                          | Version of the ingress controller                                                     | 1.2.0 |
+| image.tag                          | Version of the ingress controller                                                     | 2.0 |
 | image.effectiveSemver              | Version of the ingress controller used for version-specific features when image.tag is not a valid semantic version | |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -109,6 +109,17 @@ $ helm upgrade \
   <YOUR_RELEASE_NAME> kong/kong
 ```
 
+### Changed ServiceAccount configuration location
+
+2.4.0 moved ServiceAccount configuration from
+`ingressController.serviceAccount` to `deployment.serviceAccount` to accomodate
+configurations that required a ServiceAccount but did not use the controller.
+If you disable ServiceAccount or override its name, you must move your
+configuration under `deployment.serviceAccount`. The chart will warn you if it
+detects non-default configuration in the original location when you upgrade.
+You can use `helm upgrade --dry-run` to see if you are affected before actually
+upgrading.
+
 ## 2.3.0
 
 ### Updated CRDs and CRD API version

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -397,7 +397,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "1.3"
+    tag: "2.0"
     # Optionally set a semantic version for version-gated features. This can normally
     # be left unset. You only need to set this if your tag is not a semver string,
     # such as when you are using a "next" tag. Set this to the effective semantic


### PR DESCRIPTION
#### What this PR does / why we need it:
- Updates metadata and docs for 2.4.0
- Bumps KIC version to 2.0

#### Special notes for your reviewer:
Hold until https://github.com/Kong/kubernetes-ingress-controller/pull/1902 is merged and images have successfully pushed to Docker Hub.

No Kong version bump yet. 2.6 is still in beta for Enterprise.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
