### PR TITLE
Firm up CI conditions

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   lint-test:
-    env:
-      COMMON_CT_ARGS: "--chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,6 +28,7 @@ jobs:
 
       - name: Run chart-testing (list-changed)
         id: list-changed
+        working-directory: charts
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
@@ -37,11 +36,13 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint $COMMON_CT_ARGS
+        run: ct lint
+        working-directory: charts
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install $COMMON_CT_ARGS
+        run: ct install
+        working-directory: charts

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -26,14 +26,25 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1
 
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        working-directory: charts
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
       - name: Run chart-testing (lint)
         run: ct lint
+        working-directory: charts
 
       - name: setup testing environment (kind-cluster)
         run: ./scripts/test-env.sh
 
       - name: run chart-testing (install)
         run: ct install
+        working-directory: charts
 
       - name: run integration tests (integration)
         run: ./scripts/test-run.sh

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -10,8 +10,6 @@ on:
 
 jobs:
   lint-test:
-    env:
-      COMMON_CT_ARGS: "--chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch next"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,6 +31,7 @@ jobs:
 
       - name: Run chart-testing (list-changed)
         id: list-changed
+        working-directory: charts
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
@@ -40,14 +39,16 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint $COMMON_CT_ARGS --check-version-increment=false
+        run: ct lint --check-version-increment=false
+        working-directory: charts
 
       - name: setup testing environment (kind-cluster)
         run: ./scripts/test-env.sh
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: run chart-testing (install)
-        run: ct install $COMMON_CT_ARGS
+        run: ct install
+        working-directory: charts
 
       - name: cleanup integration tests (cleanup)
         run: ./scripts/test-env.sh cleanup

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,5 @@
 # See https://github.com/helm/chart-testing#configuration
+remote: origin
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
+target-branch: main


### PR DESCRIPTION
#### What this PR does / why we need it:
The cause of the CI breakage in the 2.4.0 release job is unclear: https://github.com/Kong/charts/actions/runs/1317477468

Unfortunately, `ct list-changed` doesn't provide much anything in terms of output describing how it decides what did or didn't change. As we've had no CI changes since 2.3, however, whatever broke was hopefully a fluke that will be fixed by just bumping the version again :shrug: 

The only thing I can think of is that there's a race condition with the sync master job that causes this. We set main as the base branch for most commands, but didn't apply the default args to `list-changed`. Moving default args to a ct.yaml means that all ct invocations will use those settings by default, without explicitly adding them to the individual workflow step commands.
