### PR TITLE
test(ct): fix the release pipeline: remove the list-changed condition, move args to ct.yaml

### DIFF
--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   lint-test:
-    env:
-      COMMON_CT_ARGS: "--chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,23 +26,14 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1
 
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
-          fi
-
       - name: Run chart-testing (lint)
-        run: ct lint $COMMON_CT_ARGS
+        run: ct lint
 
       - name: setup testing environment (kind-cluster)
         run: ./scripts/test-env.sh
-        if: steps.list-changed.outputs.changed == 'true'
 
       - name: run chart-testing (install)
-        run: ct install $COMMON_CT_ARGS
+        run: ct install
 
       - name: run integration tests (integration)
         run: ./scripts/test-run.sh

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,3 @@
+# See https://github.com/helm/chart-testing#configuration
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami


### PR DESCRIPTION
This PR attempts to fix the CI failure that prevented the 2.4.0 release from happening.

The identified root cause of the 2.4.0 release failure ([logs](https://github.com/Kong/charts/actions/runs/1317477468)):
- `ct list-changed` indicated that there was no diff between `origin/main` and HEAD (where HEAD was the tip of `main` so it was effectively the same commit!)
- the CI pipeline suppressed creation of a `kind` cluster because the aforementioned `ct list-changes` reported no changes
- a later step of the CI pipeline tried to use the `kind` cluster (the creation of which was suppressed as written above) and failed.

This PR does the following:
- removes the `ct list-changed` test because it compares `origin/main` to `origin/main` which is nonsensical (and will never say anything but "they're equal") if I understand it right
- makes `kind` cluster creation unconditional, streamlining the test and removing the "optional" path which was meant to be "run the test only if the chart has changed" but didn't work this way
- moves `ct` params to `ct.yaml` (copycat from #471)

Merging this PR to main _should_ result in:
- the CI test pipeline not failing anymore,
- the release pipeline releasing 2.4.0 from the tip of `main`.

Obsoletes #471 