### PR TITLE
[kong] update readme compatibility information

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -68,7 +68,11 @@ $ helm install kong/kong --generate-name
 
 ## Prerequisites
 
-- Kubernetes 1.12+
+- Kubernetes 1.17+. Older chart releases support older Kubernetes versions.
+  Refer to the [supported version matrix](https://docs.konghq.com/kubernetes-ingress-controller/latest/references/version-compatibility/#kubernetes)
+  and the [chart changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md)
+  for information about the default chart controller versions and Kubernetes
+  versions supported by controller releases.
 - PV provisioner support in the underlying infrastructure if persistence
   is needed for Kong datastore.
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Revises the compatibility information to reflect the current default controller and provide information about historical compatibility.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #423 

#### Special notes for your reviewer:
I kept the version relevant to the current chart release instead of just providing the compat matrix link, as you generally can't just change the controller version to make the chart compatible--the chart includes resources independent of the controller and those will remain the same no matter what you set the controller tag to (e.g. 2.4.0 will install `apiextensions.k8s.io/v1 CustomResourceDefinition` resources regardless of the controller version).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
