### PR TITLE
[kong] Fix disabling KongClusterPlugin controller environment variable.

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -361,7 +361,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- if (not (eq (len .Values.ingressController.watchNamespaces) 0)) }}
   {{- $_ := set $autoEnv "CONTROLLER_WATCH_NAMESPACE" (.Values.ingressController.watchNamespaces | join ",") -}}
-  {{- $_ := set $autoEnv "CONTROLLER_ENABLE_CONTROLLER_KONGCLUSTERPLUGIN" "disabled" -}}
+  {{- $_ := set $autoEnv "CONTROLLER_ENABLE_CONTROLLER_KONGCLUSTERPLUGIN" false -}}
 {{- end }}
 
 {{/*

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -361,7 +361,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- if (not (eq (len .Values.ingressController.watchNamespaces) 0)) }}
   {{- $_ := set $autoEnv "CONTROLLER_WATCH_NAMESPACE" (.Values.ingressController.watchNamespaces | join ",") -}}
-  {{- $_ := set $autoEnv "CONTROLLER_CONTROLLER_KONGCLUSTERPLUGIN" "disabled" -}}
+  {{- $_ := set $autoEnv "CONTROLLER_ENABLE_CONTROLLER_KONGCLUSTERPLUGIN" "disabled" -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION

Signed-off-by: John Harris <john.harris@konghq.com>

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
 When deploying KIC with `watchNamespaces` set, the chart sets an incorrect environment variable so the KongClusterPlugin controller is not disabled, causing a CrashLoopBackOff.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
