### PR TITLE
[kong] rework chart-testing CI config

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -7,8 +7,6 @@ on:
 
 jobs:
   lint-test:
-    env:
-      COMMON_CT_ARGS: "--chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch main"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,10 +24,11 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.1.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
+        working-directory: charts
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
@@ -37,11 +36,13 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint $COMMON_CT_ARGS
+        run: ct lint
+        working-directory: charts
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install $COMMON_CT_ARGS
+        run: ct install
+        working-directory: charts

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -24,16 +24,18 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.1.0
 
       - name: Run chart-testing (lint)
         run: ct lint
+        working-directory: charts
 
       - name: setup testing environment (kind-cluster)
         run: ./scripts/test-env.sh
 
       - name: run chart-testing (install)
         run: ct install
+        working-directory: charts
 
       - name: run integration tests (integration)
         run: ./scripts/test-run.sh

--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint-test:
     env:
-      COMMON_CT_ARGS: "--chart-repos bitnami=https://charts.bitnami.com/bitnami --remote origin --target-branch next"
+      CT_TARGET_BRANCH: next
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -33,6 +33,7 @@ jobs:
 
       - name: Run chart-testing (list-changed)
         id: list-changed
+        working-directory: charts
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
@@ -40,14 +41,17 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint $COMMON_CT_ARGS --check-version-increment=false
+        run: ct lint --check-version-increment=false
+        working-directory: charts
 
       - name: setup testing environment (kind-cluster)
         run: ./scripts/test-env.sh
-        if: steps.list-changed.outputs.changed == 'true'
+        # currently broken. list-changed refuses to list changed charts for some reason
+        #if: steps.list-changed.outputs.changed == 'true'
 
       - name: run chart-testing (install)
-        run: ct install $COMMON_CT_ARGS
+        run: ct install
+        working-directory: charts
 
       - name: cleanup integration tests (cleanup)
         run: ./scripts/test-env.sh cleanup

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,3 +1,5 @@
 # See https://github.com/helm/chart-testing#configuration
+remote: origin
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
+target-branch: main


### PR DESCRIPTION
#### What this PR does / why we need it:
Continuation of https://github.com/Kong/charts/pull/471, sorta.

This now just adds additional config that we should have for `ct` runs to the config YAML, and bumps the action version for good measure.

Removes the condition for the test environment from other branches also, though it leaves a comment about what's broken instead of pruning it entirely.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
