### PR TITLE
[kong] clear stale PIDs from prefix

### DIFF
--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -70,15 +70,23 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-      {{- if (or (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) .Values.deployment.initContainers) }}
       initContainers:
+      - name: clear-stale-pid
+        image: {{ include "kong.getRepoTag" .Values.image }}
+        command:
+        - "rm"
+        - "-vrf"
+        - "$KONG_PREFIX/pids"
+        env:
+        {{- include "kong.env" . | nindent 8 }}
+        volumeMounts:
+        {{- include "kong.volumeMounts" . | nindent 8 }}
         {{- if .Values.deployment.initContainers }}
         {{- toYaml .Values.deployment.initContainers | nindent 6 }}
         {{- end }}
         {{- if (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) }}
         {{- include "kong.wait-for-db" . | nindent 6 }}
         {{- end }}
-      {{- end }}
       {{- if .Values.deployment.hostAliases }}
       hostAliases:
         {{- toYaml .Values.deployment.hostAliases | nindent 6 }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Add an init container to delete the "pids/" directory from the prefix. This allows Kong to start in the event that the Kong container crashed abruptly (leaving its PIDfile behind in the prefix emptyDir) and restarted in the same Pod.

#### Which issue this PR fixes

Fix #466

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
