### PR TITLE
[kong] remove default controller binary arg and add debug no-probe setting for controller

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -598,10 +598,17 @@ Note that this is a string, not a boolean, because templates vov
 {{- include "kong.ingressController.env" .  | indent 2 }}
   image: {{ include "kong.getRepoTag" .Values.ingressController.image }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
+{{/* disableReadiness is a hidden setting to drop this block entirely for use with a debugger
+     Helm value interpretation doesn't let you replac the default HTTP checks with any other
+	 check type, and all HTTP checks freeze when a debugger pauses operation.
+	 Setting disableReadiness to ANY value disables the probes.
+*/}}
+{{- if (not (hasKey .Values.ingressController "disableProbes")) }}
   readinessProbe:
 {{ toYaml .Values.ingressController.readinessProbe | indent 4 }}
   livenessProbe:
 {{ toYaml .Values.ingressController.livenessProbe | indent 4 }}
+{{- end }}
   resources:
 {{ toYaml .Values.ingressController.resources | indent 4 }}
 {{- if .Values.ingressController.admissionWebhook.enabled }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -599,7 +599,7 @@ Note that this is a string, not a boolean, because templates vov
   image: {{ include "kong.getRepoTag" .Values.ingressController.image }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{/* disableReadiness is a hidden setting to drop this block entirely for use with a debugger
-     Helm value interpretation doesn't let you replac the default HTTP checks with any other
+     Helm value interpretation doesn't let you replace the default HTTP checks with any other
 	 check type, and all HTTP checks freeze when a debugger pauses operation.
 	 Setting disableReadiness to ANY value disables the probes.
 */}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -568,7 +568,6 @@ Note that this is a string, not a boolean, because templates vov
   securityContext:
 {{ toYaml .Values.containerSecurityContext | nindent 4 }}  
   args:
-  - /kong-ingress-controller
   {{ if .Values.ingressController.args}}
   {{- range $val := .Values.ingressController.args }}
   - {{ $val }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Two changes to allow running the controller via Delve without local chart modifications:

1. Remove the hard-coded `/kong-ingress-controller` arg from the controller. It's currently wrong and should never have been necessary due to our images' entrypoints.
2. Add a hidden `.ingressController.disableProbes` value to disable readiness and liveness probes entirely. Debugger pauses break the probes and force a restart, and they can't be configured away because Helm will always add in the default HTTP probe unless you set your own HTTP probe (and no HTTP probes work, since they're all paused). While enabling this does allow you to use a debugger, it also causes all hell to break loose because the controller becomes ready immediately, even if it fails to start and exits. It usually fails to start because Kong takes a bit to come online. Don't know of any way around that other than manually killing PID 1 to restart the container (we have no admin API retry config), so it's quite janky and really should not be exposed to users.

#### Special notes for your reviewer:
AFAIK we no longer test anything with CLI args since the chart uses envvars for everything. They do work as expected, however (testing on 2.0):

```
14:46:31-0700 esenin $ helm upgrade trk /tmp/symkong --set ingressController.args={"--help"}          
Release "trk" has been upgraded. Happy Helming!
...

14:47:23-0700 esenin $ kubectl logs trk-kong-5b6bfbc98f-4dbtd -c ingress-controller | head
Usage:
   [flags]

Flags:
      --admission-webhook-cert string                 admission server PEM certificate value
      --admission-webhook-cert-file string            admission server PEM certificate file path; if both this and the cert value is unset, defaults to /admission-webhook/tls.crt
...
```

I'm fairly sure no older versions would actually require this arg given the entrypoint, but worst case you can add it back via user-configured args.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
