### PR TITLE
[kong] fix(bug): APIVersion of v1 does not guarantee Ingress capability/resource definition exists

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1086,9 +1086,9 @@ Kubernetes resources it uses to build Kong configuration.
 {{- end -}}
 
 {{- define "kong.ingressVersion" -}}
-{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1") -}}
+{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") -}}
 networking.k8s.io/v1
-{{- else if (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") -}}
+{{- else if (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") -}}
 networking.k8s.io/v1beta1
 {{- else -}}
 extensions/v1beta1


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
There is a bug when installing this chart on Kubernetes 1.18 and lower, which is fixed here.

The existing check for the API namespace "networking.k8s.io/v1", when deciding on the Ingress object API, does not work on 1.18 and below. This is because the logic assumes that if "networking.k8s.io/v1" exists at all, then the Ingress object must also exist.

This isn't the case in some Kubernetes releases - the API namespace itself can still exist, but the Ingress object definition is still in the beta namespace.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)