### PR TITLE
[kong] fix IngressClass detection

### DIFF
--- a/.github/workflows/non-main.yaml
+++ b/.github/workflows/non-main.yaml
@@ -57,6 +57,8 @@ jobs:
         run: ./scripts/test-env.sh cleanup
 
   integration-test:
+    # Not a real requirement, but due to worker CPU contention, this can fail if it runs concurrent with lint-test
+    needs: lint-test
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/charts/kong/templates/ingress-class.yaml
+++ b/charts/kong/templates/ingress-class.yaml
@@ -1,6 +1,6 @@
 {{/* Create a "kong" IngressClass if none exists already */}}
 {{- $existingKongIngressClass := (lookup "networking.k8s.io/v1" "IngressClass" "" "kong") -}}
-{{- if $existingKongIngressClass -}}
+{{- if (not $existingKongIngressClass) -}}
 {{- if (and .Values.ingressController.enabled (not (eq (include "kong.ingressVersion" .) "extensions/v1beta1"))) -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass


### PR DESCRIPTION
#### What this PR does / why we need it:
The criteria for creating a "kong" IngressClass were previously
backwards: the chart would attempt to create a "kong" IngressClass only
if one already existed. This change inverts that logic to create a
"kong" IngressClass only if one does /not/ already exist.

#### Which issue this PR fixes
Reported at https://github.com/Kong/charts/pull/446#issuecomment-954520414

#### Special notes

13ea4d8 is an unrelated CI workaround. The [original test run](https://github.com/Kong/charts/runs/4049754088?check_suite_focus=true) failed because of issues unrelated to the PR. KTF failed to come up due to a timeout in one of the jobs, but not the other. I'm guessing this is due to worker CPU contention, since it appears to have sat around doing nothing for 5 minutes.

May be a fix elsewhere that does allow them to run concurrently, but making them not is the simplest solution I have for now.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
