### PR TITLE
[kong] add hostNetwork option to deployment

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -685,21 +685,6 @@ For a complete list of all configuration values you can set in the
 need to tweak the `containerSecurityContext` configuration as in the example:
 
 ```yaml
-deployment:
-  daemonset: true # run as daemonset
-  hostNetwork: true # enable hostNetwork
-nodeSelector: # limit the nodes bases on a label
-  ingress: "true"
-proxy:
-  type: NodePort # maybe you don't need or want a LoadBalancer
-  http:
-    containerPort: 80 # containerPor and hostPort neest to be the same
-    nodePort: 32080
-    hostPort: 80
-  tls:
-    containerPort: 443
-    nodePort: 32443
-    hostPort: 443
 containerSecurityContext: # run as root to bind to lower ports
   capabilities:
     add: [NET_BIND_SERVICE]

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -636,6 +636,7 @@ For a complete list of all configuration values you can set in the
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
 | deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |
 | deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |
+| deployment.hostNetwork             | Enable hostNetwork, which binds to the ports to the host                              | `false`             |
 | deployment.userDefinedVolumes      | Create volumes. Please go to Kubernetes doc for the spec of the volumes               |                     |
 | deployment.userDefinedVolumeMounts | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts     |                     |
 | deployment.serviceAccount.create   | Create Service Account for the Deployment / Daemonset and the migrations              | `true`              |
@@ -680,6 +681,32 @@ For a complete list of all configuration values you can set in the
 | extraConfigMaps                    | ConfigMaps to add to mounted volumes                                                  | `[]`                |
 | extraSecrets                       | Secrets to add to mounted volumes                                                     | `[]`                |
 
+**Note:** If you are using `deployment.hostNetwork` to bind to lower ports ( < 1024), which may be the desired option (ports 80 and 433), you also 
+need to tweak the `containerSecurityContext` configuration as in the example:
+
+```yaml
+deployment:
+  daemonset: true # run as daemonset
+  hostNetwork: true # enable hostNetwork
+nodeSelector: # limit the nodes bases on a label
+  ingress: "true"
+proxy:
+  type: NodePort # maybe you don't need or want a LoadBalancer
+  http:
+    containerPort: 80 # containerPor and hostPort neest to be the same
+    nodePort: 32080
+    hostPort: 80
+  tls:
+    containerPort: 443
+    nodePort: 32443
+    hostPort: 443
+containerSecurityContext: # run as root to bind to lower ports
+  capabilities:
+    add: [NET_BIND_SERVICE]
+  runAsGroup: 0
+  runAsNonRoot: false
+  runAsUser: 0
+```
 
 #### The `env` section
 

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
         {{ toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.deployment.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
       {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -50,6 +50,7 @@ deployment:
     enabled: false
   # Use a DaemonSet controller instead of a Deployment controller
   daemonset: false
+  hostNetwork: false
 
 # Override namepsace for Kong chart resources. By default, the chart creates resources in the release namespace.
 # This may not be desirable when using this chart as a dependency.


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

It adds a option for `hostNework` in the deployment. This is useful when someone wants to expose kong direct to the internet, either because it doesn't have a loadbalancer or doesn't want to use one, binding to ports  80 443 for example

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #482
 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
