### PR TITLE
[kong] Release 2.6.0 to next

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+**Note:** chart versions 2.3.0 through 2.5.0 contained an incorrect
+KongIngress CRD. The `proxy.path` field was missing. Helm will not fix this
+automatically on upgrade. You can fix it by running:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/crds/custom-resource-definitions.yaml
+```
+
+## 2.6.0
+
+### Improvements
+
+* Added an initContainer to clear leftover PID file in the event of a Kong
+  container crash, allowing the container to restart.
+  ([#480](https://github.com/Kong/charts/pull/480))
+* Added deployment.hostNetwork to enable host network access.
+  ([#486](https://github.com/Kong/charts/pull/486))
+
+### Fixed
+
+* NOTES.txt documentation link now uses up-to-date location.
+* Ingress availability check tightened to require the Ingress API specifically
+  in `networking.k8s.io/v1`.
+  ([#484](https://github.com/Kong/charts/pull/484))
+* Flipped backwards logic for creating an IngressClass when no IngressClass was
+  present.
+  ([#485](https://github.com/Kong/charts/pull/485))
+* Removed unnecessary hardcoded controller container argument.
+  ([#481](https://github.com/Kong/charts/pull/481))
+* Restored missing `proxy.path` field to KongIngress CRD.
+
 ## 2.5.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.5.0
+version: 2.6.0
 appVersion: "2.6"

--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -190,6 +190,9 @@ spec:
           proxy:
             description: Service represents a Service in Kong. Read https://getkong.org/docs/0.13.x/admin-api/#Service-object
             properties:
+              path:
+                type: string
+                pattern: ^/.*$
               connect_timeout:
                 minimum: 0
                 type: integer


### PR DESCRIPTION
Release mostly because I don't want to leave the broken KongIngress around any longer than necessary.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
