### PR TITLE
[kong] add additional admission resources

### DIFF
--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -48,6 +48,18 @@ webhooks:
     resources:
     - kongconsumers
     - kongplugins
+{{- if (semverCompare ">= 2.0.4" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+    - kongclusterplugins
+{{- end }}
+  - apiGroups:
+    - ''
+    apiVersions:
+    - 'v1'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
   clientConfig:
     {{- if not .Values.ingressController.admissionWebhook.certificate.provided }}
     caBundle: {{ b64enc $caCert }}

--- a/charts/kong/templates/servicemonitor.yaml
+++ b/charts/kong/templates/servicemonitor.yaml
@@ -1,5 +1,4 @@
 {{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
-{{- $controllerIs2xPlus := include "kong.controller2xplus" . -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -25,7 +24,7 @@ spec:
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
     {{- end }}
-  {{ if (eq $controllerIs2xPlus "true") -}}
+  {{ if (semverCompare ">= 2.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) -}}
   - targetPort: cmetrics
     scheme: http
     {{- if .Values.serviceMonitor.interval }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Reworks the version detection logic to use http://masterminds.github.io/sprig/semver.html directly wherever it's needed, with a small helper to handle the tag/effectiveSemver stuff. The previous system was a quick and bad thing I did to handle controller 2.0 only while it was still in beta, without reading the semverCompare docs. Turns out they can handle pre-release versions, whenever we have one again.

Adds newer resources to the controller admission webhook, to match upstream after https://github.com/Kong/kubernetes-ingress-controller/pull/2000

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #489 

#### Special notes for your reviewer:
Test results look like:

```
15:48:21-0800 esenin $ helm template aaa /tmp/symkong --set ingressController.image.tag=2.0.4 --set ingressController.admissionWebhook.enabled=true --set ingressController.env.anonymous_reports=false | grep -A1 testcomment
    - kongplugins # testcomment
    - kongclusterplugins

15:49:43-0800 esenin $ helm template aaa /tmp/symkong --set ingressController.image.tag=2.0.0 --set ingressController.admissionWebhook.enabled=true --set ingressController.env.anonymous_reports=false | grep -A1 testcomment
    - kongplugins # testcomment
  - apiGroups:

15:49:51-0800 esenin $ helm template aaa /tmp/symkong --set ingressController.image.tag=2.0 --set ingressController.admissionWebhook.enabled=true --set ingressController.env.anonymous_reports=false | grep -A1 testcomment
    - kongplugins # testcomment
  - apiGroups:

16:05:39-0800 esenin $ helm template aaa /tmp/symkong --set ingressController.image.tag=asdsds --set ingressController.image.effectiveSemver=v2.0.4 --set ingressController.admissionWebhook.enabled=true --set ingressController.env.anonymous_reports=false | grep -A1 testcomment
    - kongplugins #testcomment
    - kongclusterplugins
```

You'll note that this does not apply to our current "2.0" default, but unfortunately there's no way around that. This fix won't become active until 2.1.

The gate is necessary because unrecognized types [are failures in the server](https://github.com/Kong/kubernetes-ingress-controller/blob/v2.0.5/internal/admission/server.go#L264-L268). Whether they should be is debatable, but we'd need the gate for backwards compatibility even if we made it a permissive failure with a logged warning.

Furthermore, unrecognized types actually result in a segfault :frowning_face: , but I can't see exactly where it really occurs. The trace unfortunately contains a bunch of error handler and recover garbage, and I forgot to save it.

I didn't gate Secrets for <0.7.0 as that's well out of support.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
