### PR TITLE
[kong] release 2.6.1 to next and gate IngressClass

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,6 +8,15 @@ automatically on upgrade. You can fix it by running:
 kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/crds/custom-resource-definitions.yaml
 ```
 
+## 2.6.1
+
+### Fixed
+
+* Disabled IngressClass creation on Kubernetes versions that do not support it.
+* Added missing resources (Secrets, KongClusterPlugins) to the admission
+  controller configuration.
+  ([#492](https://github.com/Kong/charts/pull/492))
+
 ## 2.6.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.6.0
+version: 2.6.1
 appVersion: "2.6"

--- a/charts/kong/templates/ingress-class.yaml
+++ b/charts/kong/templates/ingress-class.yaml
@@ -1,4 +1,5 @@
 {{/* Create a "kong" IngressClass if none exists already */}}
+{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") -}}
 {{- $existingKongIngressClass := (lookup "networking.k8s.io/v1" "IngressClass" "" "kong") -}}
 {{- if (not $existingKongIngressClass) -}}
 {{- if (and .Values.ingressController.enabled (not (eq (include "kong.ingressVersion" .) "extensions/v1beta1"))) -}}
@@ -16,5 +17,6 @@ metadata:
   {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
   controller: konghq.com/ingress-controller
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

IngressClass creation lacked a gate similar to https://github.com/Kong/charts/pull/484 for older Kubernetes versions. This adds one, and releases it and the previous admission controller fix as 2.6.1.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes internal report FTI-2990. 1.18 fails with `Error: unable to recognize "": no matches for kind "IngressClass" in version "networking.k8s.io/v1"`

#### Special notes for your reviewer:

Unable to test on 1.18 due to https://kind.sigs.k8s.io/docs/user/known-issues/#failure-to-create-cluster-with-cgroups-v2. Brief review suggests no simple way to force systems back to v1.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Title of the PR and commit headers start with chart name (e.g. `[kong]`)
