### PR TITLE
fix(deployment) use the same pull policy for init

### DIFF
--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
       initContainers:
       - name: clear-stale-pid
         image: {{ include "kong.getRepoTag" .Values.image }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - "rm"
         - "-vrf"


### PR DESCRIPTION
#### What this PR does / why we need it:
Use the same imagePullPolicy as the main proxy container for the
clear-stale-pid initContainer. This initContainer uses the same image as
the proxy container, and there's no reason it shouldn't also use the
same initContainer.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #495 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
