### PR TITLE
feat(deployment): add app and version label to pods

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,6 +8,12 @@ automatically on upgrade. You can fix it by running:
 kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/crds/custom-resource-definitions.yaml
 ```
 
+## 2.6.2
+
+### Improvmenet
+
+* Add `add` and `version` labels to pods.
+
 ## 2.6.1
 
 ### Fixed

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -10,9 +10,9 @@ kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/
 
 ## 2.6.2
 
-### Improvmenet
+### Improvements
 
-* Add `add` and `version` labels to pods.
+* Added `add` and `version` labels to pods. ([#504](https://github.com/Kong/charts/pull/504))
 
 ## 2.6.1
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,5 +10,5 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.6.1
+version: 2.6.2
 appVersion: "2.6"

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
         app.kubernetes.io/component: app
+        app: {{ template "kong.fullname" . }}
+        version: {{ .Chart.AppVersion | quote }}
         {{- if .Values.podLabels }}
         {{ toYaml .Values.podLabels | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds `app` and `version` labels to the pod. I "think" this is one of the standard practices. If not, it's a requirement for istio [istio doc](https://istio.io/latest/docs/ops/deployment/requirements/#pod-requirements). 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
