### PR TITLE
chore(*) release Kong chart 2.6.2

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -12,7 +12,24 @@ kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/
 
 ### Improvements
 
-* Added `add` and `version` labels to pods. ([#504](https://github.com/Kong/charts/pull/504))
+* Added `app` and `version` labels to pods.
+  ([#504](https://github.com/Kong/charts/pull/504))
+* Reworked leftover socket file cleanup to avoid similar problems of the same
+  class.
+  ([#508](https://github.com/Kong/charts/pull/508))
+
+### Fixed
+
+* SecurityContext and resources applied to PID cleanup initContainer also.
+  ([#503](https://github.com/Kong/charts/pull/503))
+* Disabled the admission webhook on Helm Secrets, fixing an issue where it
+  prevented Helm from updating release metadata.
+  ([#500](https://github.com/Kong/charts/pull/500))
+* initContainers that use the Kong image use the same imagePullPolicy as the
+  main Kong container.
+  ([#501](https://github.com/Kong/charts/pull/501))
+* Applied mesh sidecar annotations to the Pod, not the Deployment.
+  ([#507](https://github.com/Kong/charts/pull/507))
 
 ## 2.6.1
 


### PR DESCRIPTION
Please review/merge https://github.com/Kong/charts/pull/508 before this. If we need to rework it, I'll remove it from this release (it's only needed for 2.7, so not urgent).

Release 2.6.2 to next. No version bump in Chart.yaml, it was previously added in https://github.com/Kong/charts/blame/0565c0372d2561ff96bc111eb63e686f807b2d56/charts/kong/Chart.yaml#L13

For the future, note that PRs to next other than the actual release PR shouldn't bump that number; we make a determination at release time whether we need a minor or patch version bump.