### PR TITLE
Prevent IngressClass from being deleted/recreated

### DIFF
--- a/charts/kong/templates/ingress-class.yaml
+++ b/charts/kong/templates/ingress-class.yaml
@@ -1,8 +1,21 @@
-{{/* Create a "kong" IngressClass if none exists already */}}
-{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") -}}
-{{- $existingKongIngressClass := (lookup "networking.k8s.io/v1" "IngressClass" "" "kong") -}}
-{{- if (not $existingKongIngressClass) -}}
+{{/* Default to not managing if unsupported or created outside this chart */}}
+{{- $includeIngressClass := false -}}
 {{- if (and .Values.ingressController.enabled (not (eq (include "kong.ingressVersion" .) "extensions/v1beta1"))) -}}
+  {{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") -}}
+    {{- with (lookup "networking.k8s.io/v1" "IngressClass" "" "kong") -}}
+      {{- if (hasKey .metadata "annotations") -}}
+        {{- if (eq $.Release.Name (get .metadata.annotations "meta.helm.sh/release-name")) -}}
+          {{/* IngressClass exists and is managed by this chart */}}
+          {{- $includeIngressClass = true -}}
+        {{- end -}}
+      {{- end -}}
+    {{- else -}}
+      {{/* IngressClass doesn't exist */}}
+      {{- $includeIngressClass = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $includeIngressClass -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
@@ -17,6 +30,4 @@ metadata:
   {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
   controller: konghq.com/ingress-controller
-{{- end -}}
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

This conditional is intended to not create the `IngressClass` if it has
already been created outside of the chart, e.g. manually prior to it
being included in v2.3.0

The previous implementation that used `lookup` to check if the
`IngressClass` existed caused the template to be omitted from the chart
and Helm would delete it on the second release, then it would be
recreated on the third release and so on.

Fix this by checking whether the existing `IngressClass` was installed
by this chart based on Helm's annotations. The conditionals have been
refactored to set a variable (like the CRDs template) since the
conditions are now more complex and Helm makes it hard to safely lookup
nested values.

#### Which issue this PR fixes

  - fixes #512

#### Special notes for your reviewer:

I can't see any automated regression tests that cover subtle problems
like this and I'm not sure you'd want to script them, so here's the
manual testing that I've performed.

Doesn't create when there is an existing `IngressClass`:

    $ kubectl apply -f- <<EOS
    apiVersion: networking.k8s.io/v1
    kind: IngressClass
    metadata:
      name: kong
    spec:
      controller: konghq.com/ingress-controller
    EOS

    ingressclass.networking.k8s.io/kong created
    $ helm upgrade kong charts/kong/ --install --set ingressController.installCRDs=false >/dev/null
    $ helm get manifest kong | grep IngressClass
    $ helm upgrade kong charts/kong/ --install --set ingressController.installCRDs=false >/dev/null
    $ helm get manifest kong | grep IngressClass

Does create and doesn't delete when there is no existing `IngressClass`:

    $ kubectl delete IngressClass/kong
    ingressclass.networking.k8s.io "kong" deleted
    $ helm upgrade kong charts/kong/ --install --set ingressController.installCRDs=false >/dev/null
    $ helm get manifest kong | grep IngressClass
    kind: IngressClass
    $ helm upgrade kong charts/kong/ --install --set ingressController.installCRDs=false >/dev/null
    $ helm get manifest kong | grep IngressClass
    kind: IngressClass

#### Checklist
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
