### PR TITLE
fix(conf) fixed typo in podDisruptionBudget for minimum available pods

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -631,7 +631,7 @@ podDisruptionBudget:
   enabled: false
   # Uncomment only one of the following when enabled is set to true
   # maxUnavailable: "50%"
-  # minUnavailable: "50%"
+  # minAvailable: "50%"
 
 podSecurityPolicy:
   enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Fixing a typo in pod disruption budget config

Its minAvailable not minUnavailable

Even the YAML in the chart is looking for the right parameter

```
spec:
  {{- if .Values.podDisruptionBudget.minAvailable }}
  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
  {{- end  }}
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `next` branch and targets `next`, not `main`
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
