### PR TITLE
docs(general) update link to kong-ingress-controller documentation

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -208,7 +208,7 @@ Kong can be configured via two methods:
   This is also known as Kong Ingress Controller or Kong for Kubernetes and is
   the default deployment pattern for this Helm Chart. The configuration
   for Kong is managed via Ingress and a few
-  [Custom Resources](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/concepts/custom-resources.md).
+  [Custom Resources](https://docs.konghq.com/kubernetes-ingress-controller/latest/concepts/custom-resources).
   For more details, please read the
   [documentation](https://docs.konghq.com/kubernetes-ingress-controller/)
   on Kong Ingress Controller.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -210,7 +210,7 @@ Kong can be configured via two methods:
   for Kong is managed via Ingress and a few
   [Custom Resources](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/concepts/custom-resources.md).
   For more details, please read the
-  [documentation](https://github.com/Kong/kubernetes-ingress-controller/tree/main/docs)
+  [documentation](https://github.com/Kong/kubernetes-ingress-controller#documentation)
   on Kong Ingress Controller.
   To configure and fine-tune the controller, please read the
   [Ingress Controller Parameters](#ingress-controller-parameters) section.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -210,7 +210,7 @@ Kong can be configured via two methods:
   for Kong is managed via Ingress and a few
   [Custom Resources](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/concepts/custom-resources.md).
   For more details, please read the
-  [documentation](https://github.com/Kong/kubernetes-ingress-controller#documentation)
+  [documentation](https://docs.konghq.com/kubernetes-ingress-controller/)
   on Kong Ingress Controller.
   To configure and fine-tune the controller, please read the
   [Ingress Controller Parameters](#ingress-controller-parameters) section.


### PR DESCRIPTION
The link to the documentation referred to a non-existent page. Fixed it to the correct one, guess. 