### PR TITLE
Release Kong 2.6.5 and switch to trunk development

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ when it is merged.
 
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
-- [ ] PR is based off the current tip of the `next` branch and targets `next`, not `main`
+- [ ] PR is based off the current tip of the `main` branch.
+- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
 - [ ] New or modified sections of values.yaml are documented in the README.md
 - [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -68,6 +68,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+          CR_SKIP_EXISTING: true

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,6 +8,17 @@ automatically on upgrade. You can fix it by running:
 kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/crds/custom-resource-definitions.yaml
 ```
 
+## Unreleased
+
+Nothing yet.
+
+## 2.6.5
+
+### Fixed
+
+* Generated IngressClass resources persist across updates properly.
+  ([#518](https://github.com/Kong/charts/pull/518))
+
 ## 2.6.4
 
 ### Improvements


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases Kong 2.6.5 and updates docs/CI for trunk-based deployment. Once this is merged onward to `main`, we can remove `next`.

#### Special notes for your reviewer:
https://github.com/helm/chart-releaser/commit/30f8b9d561e569e5aa6a76608e241167394d79d9 added a flag for CR to skip a release if it already exists. This allows us to move to trunk development without releasing on every change, as changes to main without a bump to the chart version no longer result in CI failures.

For demonstration, see https://github.com/rainest/charts-citest/actions/runs/1710140381 and https://github.com/rainest/charts-citest/actions/runs/1710153364, along with https://github.com/rainest/charts-citest/releases/tag/kong-2.6.6 and https://github.com/rainest/charts-citest/releases/tag/kong-2.6.7

Although the `test` commit ran the release job after the original 2.6.6 release job and before the 2.6.7 job, it does not appear in the 2.6.6 release artifacts. It does appear in the 2.6.7 release artifact (the action logs didn't get updated properly to account for the change, so it still indicates that it's performing the release, even though it's actually doing nothing).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
