### PR TITLE
feat(helpers) add non-KONG prefixed env

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -10,7 +10,9 @@ kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/
 
 ## Unreleased
 
-Nothing yet.
+### Improvements
+
+* Added support for non `KONG_` prefixed custom environment variables
 
 ## 2.6.5
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -51,6 +51,7 @@ $ helm install kong/kong --generate-name
   - [Ingress Controller Parameters](#ingress-controller-parameters)
   - [General Parameters](#general-parameters)
     - [The `env` section](#the-env-section)
+    - [The `customEnv` section](#the-customEnv-section)
     - [The `extraLabels` section](#the-extralabels-section)
 - [Kong Enterprise Parameters](#kong-enterprise-parameters)
   - [Overview](#overview)
@@ -505,6 +506,7 @@ directory.
 | replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true         | `1`                 |
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
+| customEnv                          | Custom Environment variables without `KONG_` prefix      |                                |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
 | migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false" |
@@ -721,6 +723,25 @@ For complete list of Kong configurations please check the
 [Kong configuration docs](https://docs.konghq.com/latest/configuration).
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+#### The `customEnv` section
+
+The `customEnv` section can be used to configure all custom properties of other than Kong.
+Any key value put under this section translates to environment variables
+that can be used in Kong's plugin configurations. Every key is upper-cased before setting the environment variable.
+
+An example:
+
+```yaml
+kong:
+  customEnv:                       
+    api_token:
+      valueFrom:
+        secretKeyRef:
+          key: token
+          name: api_key
+    client_name: testClient
+```
 
 #### The `extraLabels` section
 

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -20,6 +20,9 @@ postgresql:
 env:
   anonymous_reports: "off"
   database: "postgres"
+# Added example for customEnv
+customEnv:
+  client_id: "exampleId"
 # - ingress resources are created without hosts
 admin:
   type: NodePort

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -789,10 +789,20 @@ the template that it itself is using form the above sections.
 {{- end -}}
 
 {{/*
+    ====== CUSTOM-SET ENVIRONMENT VARIABLES ======
+*/}}
+
+{{- $customEnv := dict -}}
+{{- range $key, $val := .Values.customEnv }}
+  {{- $upper := upper $key -}}
+  {{- $_ := set $customEnv $upper $val -}}
+{{- end -}}
+
+{{/*
       ====== MERGE AND RENDER ENV BLOCK ======
 */}}
 
-{{- $completeEnv := mergeOverwrite $autoEnv $userEnv -}}
+{{- $completeEnv := mergeOverwrite $autoEnv $userEnv $customEnv -}}
 {{- template "kong.renderEnv" $completeEnv -}}
 
 {{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -81,6 +81,19 @@ env:
   portal_api_error_log: /dev/stderr
   prefix: /kong_prefix/
 
+# This section is any customer specific environments variables that doesn't require KONG_ prefix.
+# These custom environment variables are typicall used in custom plugins or serverless plugins to 
+# access environment specific credentials or tokens.
+# Example as below, uncomment if required and add additional attributes as required.
+
+# customEnv:                     
+#   api_token:
+#     valueFrom:
+#       secretKeyRef:
+#         key: token
+#         name: api_key
+#   client_name: testClient
+
 # This section can be used to configure some extra labels that will be added to each Kubernetes object generated.
 extraLabels: {}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Various use cases where customers need non-prefixed environment variables to accessed in custom plugins or serverless functions. Example of these variables include upstream api_tokens or credentials that customer doesn't want to be shown clear text in the plugin configurations. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
