### PR TITLE
preStop: Replace sleep with --wait

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -10,7 +10,10 @@ kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/
 
 ## Unreleased
 
-Nothing yet.
+### Improvements
+
+* Replaced `sleep 15` in `preStop` command with `--wait=15` argument to `kong quit`.
+  ([#531](https://github.com/Kong/charts/pull/531))
 
 ## 2.6.5
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -571,7 +571,10 @@ lifecycle:
   preStop:
     exec:
       # Note kong quit has a default timeout of 10 seconds
-      command: ["/bin/sh", "-c", "/bin/sleep 15 && kong quit"]
+      command:
+        - kong
+        - quit
+        - '--wait=15'
 
 # Sets the termination grace period for pods spawned by the Kubernetes Deployment.
 # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution


### PR DESCRIPTION
#### What this PR does / why we need it:

The `kong quit` command has the ability to do the sleep itself which is
cleaner and provides better logging (should we choose to capture it):

- https://github.com/Kong/kong/blob/2.6.0/kong/cmd/quit.lua#L59-L72
- https://github.com/Kong/kong/blob/2.6.0/kong/cmd/quit.lua#L20-L33

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:
We've been testing this because the wait needs to be increased when using NLBs.

I've only quoted the last argument because it has more chance of falling foul of YAML intepretation.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
