### PR TITLE
chore(deps) upgrade Postgres sub-chart

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -10,6 +10,16 @@ kubectl apply -f https://raw.githubusercontent.com/Kong/charts/main/charts/kong/
 
 ## Unreleased
 
+### Breaking Changes
+
+* There are upstream changes to the Postgres sub-chart that change many
+  values.yaml keys. The default `postgresqlUsername` and `postgresqlDatabase`
+  keys used in this chart's values.yaml are now `auth.username` and
+  `auth.database`. If you set other Postgres sub-chart values, consult the
+  [upstream README](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
+  and [upgrade guide](https://docs.bitnami.com/kubernetes/infrastructure/postgresql/administration/upgrade/#to-1100)
+  to see what you need to change.
+
 ### Improvements
 
 * Added Gateway API resources to RBAC rules.

--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -13,6 +13,19 @@ The solution to the problem is to specify a password to the `postgresql` chart.
 This is to ensure that the password is not generated randomly but is set to
 the same one that is user-provided on each upgrade.
 
+The Postgres chart provides [two options](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#postgresql-common-parameters)
+for setting a password:
+
+- `auth.password` sets a password directly in values.yaml, in cleartext. This
+  is fine if you are using the instance for testing and have no security
+  concerns.
+- `auth.existingSecret` specifies a Secret that contains [specific keys](https://github.com/bitnami/charts/blob/a6146a1ed392c8683c30b21e3fef905d86b0d2d6/bitnami/postgresql/values.yaml#L134-L143).
+  This should be used if you need to properly secure the Postgres instance.
+
+If you have already upgraded, the old password is lost. You will need to
+delete the Helm release and the Postgres PersistentVolumeClaim before
+re-installing with a non-random password.
+
 #### Kong fails to start on a fresh installation with Postgres. What do I do?
 
 Please make sure that there is no `PersistentVolumes` present from a previous

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -8,10 +8,9 @@ ingressController:
     anonymous_reports: "false"
 postgresql:
   enabled: true
-  postgresqlUsername: kong
-  postgresqlDatabase: kong
-  service:
-    port: 5432
+  auth:
+    username: kong
+    password: kong
 env:
   anonymous_reports: "off"
   database: "postgres"

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -13,8 +13,9 @@ ingressController:
     anonymous_reports: "false"
 postgresql:
   enabled: true
-  postgresqlUsername: kong
-  postgresqlDatabase: kong
+  auth:
+    username: kong
+    password: kong
   service:
     port: 5432
 env:

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -185,10 +185,9 @@ portalapi:
 
 postgresql:
   enabled: true
-  postgresqlUsername: kong
-  postgresqlDatabase: kong
-  service:
-    port: 5432
+  auth:
+    username: kong
+    database: kong
 
 ingressController:
   enabled: true

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -48,10 +48,9 @@ env:
 
 postgresql:
   enabled: true
-  postgresqlUsername: kong
-  postgresqlDatabase: kong
-  service:
-    port: 5432
+  auth:
+    username: kong
+    database: kong
 
 ingressController:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -37,10 +37,9 @@ secretVolumes:
 
 postgresql:
   enabled: true
-  postgresqlUsername: kong
-  postgresqlDatabase: kong
-  service:
-    port: 5432
+  auth:
+    username: kong
+    database: kong
 
 ingressController:
   enabled: false

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -21,10 +21,9 @@ admin:
 
 postgresql:
   enabled: true
-  postgresqlUsername: kong
-  postgresqlDatabase: kong
-  service:
-    port: 5432
+  auth:
+    username: kong
+    database: kong
 
 ingressController:
   enabled: false

--- a/charts/kong/requirements.yaml
+++ b/charts/kong/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: postgresql
-  version: 8.6.8
+  version: 11.0.0
   repository: https://charts.bitnami.com/bitnami
   condition: postgresql.enabled

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -507,17 +507,23 @@ ingressController:
 # - (recommended) Deploy and maintain a database and pass the connection
 #   details to Kong via the `env` section.
 # - You can use the below `postgresql` sub-chart to deploy a database
-#   along-with Kong as part of a single Helm release.
+#   along-with Kong as part of a single Helm release. Running a database
+#   independently is recommended for production, but the built-in Postgres is
+#   useful for quickly creating test instances.
 
 # PostgreSQL chart documentation:
 # https://github.com/bitnami/charts/blob/master/bitnami/postgresql/README.md
+#
+# WARNING: by default, the Postgres chart generates a random password each
+# time it upgrades, which breaks access to existing volumes. You should set a
+# password explicitly:
+# https://github.com/Kong/charts/blob/main/charts/kong/FAQs.md#kong-fails-to-start-after-helm-upgrade-when-postgres-is-used-what-do-i-do
 
 postgresql:
   enabled: false
-  # postgresqlUsername: kong
-  # postgresqlDatabase: kong
-  # service:
-  #   port: 5432
+  auth:
+    username: kong
+    database: kong
 
 # -----------------------------------------------------------------------------
 # Miscellaneous parameters


### PR DESCRIPTION
#### What this PR does / why we need it:
Upgrades the Postgres version and clarifies documentation.

#### Special notes for your reviewer:
- We may not actually need the manual password set anymore, ironically. It looks like the new version uses lookups. Need to test.
- Draft pending figuring out issues with the subchart values. For some reason auth.username and auth.database (and auth.password) aren't propagating and PG is using the defaults.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
