### PR TITLE
fix(admission) Remove CREATE Secret admission

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Enables the option to add sidecar containers to the migration containers.
   ([540](https://github.com/Kong/charts/pull/540))
+  
+### Fixed
+
+* Removed CREATE from ValidatingWebhookConfiguration objectSelector for Secrets to align with changes in Kong/kubernetes-ingress-controller.
+  ([#542](https://github.com/Kong/charts/pull/542))
 
 ## 2.7.0
 
@@ -20,11 +25,6 @@
 * Added support for non `KONG_` prefixed custom environment variables
   ([#530](https://github.com/Kong/charts/pull/530))
 * Updated to latest CRDs from upstream.
-
-### Fixed
-
-* Removed CREATE from ValidatingWebhookConfiguration objectSelector for Secrets to align with changes in Kong/kubernetes-ingress-controller.
-  ([#542](https://github.com/Kong/charts/pull/542))
 
 ## 2.6.5
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -21,6 +21,11 @@
   ([#530](https://github.com/Kong/charts/pull/530))
 * Updated to latest CRDs from upstream.
 
+### Fixed
+
+* Removed CREATE from ValidatingWebhookConfiguration objectSelector for Secrets to align with changes in Kong/kubernetes-ingress-controller.
+  ([#542](https://github.com/Kong/charts/pull/542))
+
 ## 2.6.5
 
 ### Fixed

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -11,7 +11,7 @@
 {{- $certKey = $cert.Key -}}
 {{- $caCert = $ca.Cert -}}
 {{- $caKey = $ca.Key -}}
- 
+
 {{- $caSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-ca-keypair" (include "kong.fullname" .))) -}}
 {{- $certSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (printf "%s-validation-webhook-keypair" (include "kong.fullname" .))) -}}
 {{- if $certSecret }}
@@ -62,7 +62,6 @@ webhooks:
     apiVersions:
     - 'v1'
     operations:
-    - CREATE
     - UPDATE
     resources:
     - secrets
@@ -72,7 +71,7 @@ webhooks:
     {{- else }}
     {{- if .Values.ingressController.admissionWebhook.certificate.caBundle }}
     caBundle: {{ b64enc .Values.ingressController.admissionWebhook.certificate.caBundle }}
-    {{- end }}    
+    {{- end }}
     {{- end }}
     service:
       name: {{ template "kong.service.validationWebhook" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Validation of Secrets was disabled for creating Secrets in [Kong/kubernetes-ingress-controller#2015](https://github.com/Kong/kubernetes-ingress-controller/pull/2015/files#diff-459e2931c5b319d105569c2f436b978a800c84cd87ffcac2efd1eedc61987e5dL44)

This PR aligns the chart with the change made to the ingress-controller repository.

Also some unrelated whitespace changes.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
