### PR TITLE
fix(conf) fix creation of non-default IngressClasses

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * Removed CREATE from ValidatingWebhookConfiguration objectSelector for Secrets to align with changes in Kong/kubernetes-ingress-controller.
   ([#542](https://github.com/Kong/charts/pull/542))
+* Fixed creation of non-default IngressClasses ([#552](https://github.com/Kong/charts/pull/552))
 
 ## 2.7.0
 

--- a/charts/kong/templates/ingress-class.yaml
+++ b/charts/kong/templates/ingress-class.yaml
@@ -2,7 +2,7 @@
 {{- $includeIngressClass := false -}}
 {{- if (and .Values.ingressController.enabled (not (eq (include "kong.ingressVersion" .) "extensions/v1beta1"))) -}}
   {{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1/IngressClass") -}}
-    {{- with (lookup "networking.k8s.io/v1" "IngressClass" "" "kong") -}}
+    {{- with (lookup "networking.k8s.io/v1" "IngressClass" "" .Values.ingressController.ingressClass) -}}
       {{- if (hasKey .metadata "annotations") -}}
         {{- if (eq $.Release.Name (get .metadata.annotations "meta.helm.sh/release-name")) -}}
           {{/* IngressClass exists and is managed by this chart */}}


### PR DESCRIPTION
When using a custom IngressClass we should check for existence of that class, not the default 'kong' one.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
If a user wants to have two Kong instances installed with different IngressClasses the second installation will not actually create the IngressClass since it checks for the existence of the 'kong' IngressClass.

#### Special notes for your reviewer:
Tested with:
```yaml
ingressController:
  ingressClass: test-kong
```
and
`helm template --validate -f values.yaml kong -n kong .`
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `main` branch.
- [X] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [X] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
