### PR TITLE
chore(*) update Enterprise version

### DIFF
--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.7.0.0-alpine"
+  tag: "2.7"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.7.0.0-alpine"
+  tag: "2.7"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.7.0.0-alpine"
+  tag: "2.7"
 
 enterprise:
   enabled: true

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -103,7 +103,7 @@ image:
   tag: "2.7"
   # Kong Enterprise
   # repository: kong/kong-gateway
-  # tag: "2.7.0.0-alpine"
+  # tag: "2.7"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
Sets all the Enterprise images to their minor tag, which has been available for a while.