### PR TITLE
fix(helpers) disable keyring in wait-for-db container

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Fixed traffic routing from Istio's envoy proxy to Kong proxy when using Istio's AuthorizationPolicy.
   ([#550](https://github.com/Kong/charts/pull/550))
 * Fixed creation of non-default IngressClasses ([#552](https://github.com/Kong/charts/pull/552))
-* Fixed initial key in keyring not generated in a new Kong cluster ([#556](https://github.com/Kong/charts/pull/556))
+* Fixed: wait_for_db no longer tries to instantiate the keyring in Kong Enterprise ([#556](https://github.com/Kong/charts/pull/556))
 
 ## 2.7.0
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixed traffic routing from Istio's envoy proxy to Kong proxy when using Istio's AuthorizationPolicy.
   ([#550](https://github.com/Kong/charts/pull/550))
 * Fixed creation of non-default IngressClasses ([#552](https://github.com/Kong/charts/pull/552))
+* Fixed initial key in keyring not generated in a new Kong cluster ([#556](https://github.com/Kong/charts/pull/556))
 
 ## 2.7.0
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -538,15 +538,9 @@ The name of the service used for the ingress controller's validation webhook
   {{ toYaml .Values.containerSecurityContext | nindent 4 }} 
   env:
   {{- include "kong.env" . | nindent 2 }}
-  {{ $waitForDBEnterpriseEnvs := "true" }}
-  {{- if .Values.enterprise.enabled }}
-  {{/* unconditionally disable keyring at wait-for-db container, so that it doesn't
-       generate a bootstrap key without acknowledge any other kong cluster */}}
-    {{- $waitForDBEnterpriseEnvs = "export KONG_KEYRING_ENABLED=off" }}
-  {{- end }}
 {{/* TODO the prefix override is to work around https://github.com/Kong/charts/issues/295
      Note that we use args instead of command here to /not/ override the standard image entrypoint. */}}
-  args: [ "/bin/sh", "-c", "export KONG_NGINX_DAEMON=on; export KONG_PREFIX=`mktemp -d`; {{ $waitForDBEnterpriseEnvs }}; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop"]
+  args: [ "/bin/sh", "-c", "export KONG_NGINX_DAEMON=on KONG_PREFIX=`mktemp -d` KONG_KEYRING_ENABLED=off; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop"]
   volumeMounts:
   {{- include "kong.volumeMounts" . | nindent 4 }}
   {{- include "kong.userDefinedVolumeMounts" . | nindent 4 }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -538,9 +538,15 @@ The name of the service used for the ingress controller's validation webhook
   {{ toYaml .Values.containerSecurityContext | nindent 4 }} 
   env:
   {{- include "kong.env" . | nindent 2 }}
+  {{ $waitForDBEnterpriseEnvs := "true" }}
+  {{- if .Values.enterprise.enabled }}
+  {{/* unconditionally disable keyring at wait-for-db container, so that it doesn't
+       generate a bootstrap key without acknowledge any other kong cluster */}}
+    {{- $waitForDBEnterpriseEnvs = "export KONG_KEYRING_ENABLED=off" }}
+  {{- end }}
 {{/* TODO the prefix override is to work around https://github.com/Kong/charts/issues/295
      Note that we use args instead of command here to /not/ override the standard image entrypoint. */}}
-  args: [ "/bin/sh", "-c", "export KONG_NGINX_DAEMON=on; export KONG_PREFIX=`mktemp -d`; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop"]
+  args: [ "/bin/sh", "-c", "export KONG_NGINX_DAEMON=on; export KONG_PREFIX=`mktemp -d`; {{ $waitForDBEnterpriseEnvs }}; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop"]
   volumeMounts:
   {{- include "kong.volumeMounts" . | nindent 4 }}
   {{- include "kong.userDefinedVolumeMounts" . | nindent 4 }}


### PR DESCRIPTION


<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

The wait-for-db container checks for migration readiness. Since
it starts the full kong cluster, it also runs keyring bootstrap process:
the kong clster in that container generates the initial key,
store in its memory, and writes the key_id to keyring_meta table.
But it doesn’t have enough time to broadcast its key to other kong
container that serves proxy, admin, manager etc. By design,
keyring doesn't automatically generate a new key if there's
anything in the keyring_meta table, even no nodes have
knowledge to it; this it to avoid unnecessary rotation of keys.

This PR skips keyring bootstrap at wait-for-db container, so the
bootstrap can be done in an actual kong cluster.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
