### PR TITLE
chore(*) change IngressClass controller string

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Enables the option to add sidecar containers to the migration containers.
   ([540](https://github.com/Kong/charts/pull/540))
+* Update the IngressClass controller string to match the value used upstream.
+  ([557](https://github.com/Kong/charts/pull/557))
   
 ### Fixed
 

--- a/charts/kong/templates/ingress-class.yaml
+++ b/charts/kong/templates/ingress-class.yaml
@@ -29,5 +29,5 @@ metadata:
   labels:
   {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
-  controller: konghq.com/ingress-controller
+  controller: ingress-controllers.konghq.com/kong
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
The controller string originally used here wasn't also used in upstream. This changes it to match the string used in docs, examples, and https://github.com/Kong/kubernetes-ingress-controller/pull/2313

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
