### PR TITLE
chore(docs) remove next references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,11 @@ GitHub issue describing your proposal first, to discuss it with the chart
 maintainers.
 
 ## Submitting a pull request
-The Kong charts repository accepts contributions via GitHub pull requests to
-the `next` branch.
 
 ### Preparing a pull request
 
 Before submitting a pull request, please run through the following steps:
-- Rebase your branch off the current tip of the `next` branch.
+- Rebase your branch off the current tip of the `main` branch.
 - Run `helm lint` and correct any issues it finds.
 - If your change adds new user-facing (exposed in values.yaml) features or
   changes existing features, update README.md accordingly. Documentation should
@@ -34,10 +32,9 @@ changes; the maintainers will squash as needed when merging the pull request.
 
 ### Accepted pull requests
 
-Accepted pull requests are merged into the `next` branch and are not typically
-released immediately. The chart maintainers periodically bundle all changes in
-`next` together and merge them into `main` with a version bump to create a
-release.
+Accepted pull requests are merged into the `main` branch and are not typically
+released immediately. The chart maintainers periodically merge a version bump
+into `main` to create a release.
 
 ## Commit message format
 


### PR DESCRIPTION
#### What this PR does / why we need it:
CONTRIBUTING had outdated references to the old `next` workflow. This removes them.