### PR TITLE
update template to allow wildcard domain names

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* add quote on hostname template to be able to use wildcard domains.
+
 ### Improvements
 
 * Enables the option to add sidecar containers to the migration containers.

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -84,7 +84,7 @@ spec:
   ingressClassName: {{ .ingress.ingressClassName }}
 {{- end }}
   rules:
-  - host: {{ $hostname }}
+  - host: {{ $hostname | quote }}
     http:
       paths:
         - backend:
@@ -106,7 +106,7 @@ spec:
   {{- if (hasKey .ingress "tls") }}
   tls:
   - hosts:
-    - {{ $hostname }}
+    - {{ $hostname | quote }}
     secretName: {{ .ingress.tls }}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Small change to template to allow using wildcard domain names (ex: *.example.com)

#### Special notes for your reviewer:
- quoted the hostname value to be able to set a wildcard hostname

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines]
