### PR TITLE
feat(controller) support user-defined mounts and bump version

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Enables the option to add sidecar containers to the migration containers.
   ([540](https://github.com/Kong/charts/pull/540))
+* Added support for user-defined controller volume mounts.
+  ([560](https://github.com/Kong/charts/pull/560))
   
 ### Fixed
 
@@ -13,8 +15,10 @@
   ([#542](https://github.com/Kong/charts/pull/542))
 * Fixed traffic routing from Istio's envoy proxy to Kong proxy when using Istio's AuthorizationPolicy.
   ([#550](https://github.com/Kong/charts/pull/550))
-* Fixed creation of non-default IngressClasses ([#552](https://github.com/Kong/charts/pull/552))
-* Fixed: wait_for_db no longer tries to instantiate the keyring in Kong Enterprise ([#556](https://github.com/Kong/charts/pull/556))
+* Fixed creation of non-default IngressClasses
+  ([#552](https://github.com/Kong/charts/pull/552))
+* Fixed: wait_for_db no longer tries to instantiate the keyring in Kong Enterprise
+  ([#556](https://github.com/Kong/charts/pull/556))
 
 ## 2.7.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,4 +11,4 @@ maintainers:
 name: kong
 sources:
 version: 2.7.0
-appVersion: "2.7"
+appVersion: "2.8"

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -487,7 +487,7 @@ The chart can deploy additional volumes along with Kong. This can be useful to i
 
 ### User Defined Volume Mounts
 
-The chart can mount the volumes which defined in the `user defined volume` or others. The `deployment.userDefinedVolumeMounts` field in values.yaml takes an array of object that get appended as-is to the existing `spec.template.spec.containers[].volumeMounts` and `spec.template.spec.initContainers[].volumeMounts` array in the kong deployment resource.
+The chart can mount user-defined volumes. The `deployment.userDefinedVolumeMounts` and `ingressController.userDefinedVolumeMounts` fields in values.yaml take an array of object that get appended as-is to the existing `spec.template.spec.containers[].volumeMounts` and `spec.template.spec.initContainers[].volumeMounts` array in the kong deployment resource.
 
 ### Using a DaemonSet
 
@@ -621,14 +621,14 @@ section of `values.yaml` file:
 | Parameter                          | Description                                                                           | Default                                                                      |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | enabled                            | Deploy the ingress controller, rbac and crd                                           | true                                                                         |
-| image.repository                   | Docker image with the ingress controller                                              | kong/kubernetes-ingress-controller |
-| image.tag                          | Version of the ingress controller                                                     | 2.0 |
-| image.effectiveSemver              | Version of the ingress controller used for version-specific features when image.tag is not a valid semantic version | |
+| image.repository                   | Docker image with the ingress controller                                              | kong/kubernetes-ingress-controller                                           |
+| image.tag                          | Version of the ingress controller                                                     | 2.0                                                                          |
+| image.effectiveSemver              | Version of the ingress controller used for version-specific features when image.tag is not a valid semantic version |                                                |
 | readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
 | livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
-| installCRDs                        | Creates managed CRDs.                                                                 | false
+| installCRDs                        | Creates managed CRDs.                                                                 | false                                                                        |
 | env                                | Specify Kong Ingress Controller configuration via environment variables               |                                                                              |
-| ingressClass                       | The name of this controller's ingressClass                                                | kong                                                                         |
+| ingressClass                       | The name of this controller's ingressClass                                            | kong                                                                         |
 | ingressClassAnnotations            | The ingress-class value for controller                                                | kong                                                                         |
 | args                               | List of ingress-controller cli arguments                                              | []                                                                           |
 | watchNamespaces                    | List of namespaces to watch. Watches all namespaces if empty                          | []                                                                           |
@@ -636,8 +636,10 @@ section of `values.yaml` file:
 | admissionWebhook.failurePolicy     | How unrecognized errors from the admission endpoint are handled (Ignore or Fail)      | Fail                                                                         |
 | admissionWebhook.port              | The port the ingress controller will listen on for admission webhooks                 | 8080                                                                         |
 | admissionWebhook.certificate.provided   | Whether to generate the admission webhook certificate if not provided            | false                                                                        |
-| admissionWebhook.certificate.secretName | Name of the TLS secret for the provided webhook certificate                      |                                                                            |
-| admissionWebhook.certificate.caBundle   | PEM encoded CA bundle which will be used to validate the provided webhook certificate |                                                                            |
+| admissionWebhook.certificate.secretName | Name of the TLS secret for the provided webhook certificate                      |                                                                              |
+| admissionWebhook.certificate.caBundle   | PEM encoded CA bundle which will be used to validate the provided webhook certificate |                                                                         |
+| deployment.userDefinedVolumes      | Create volumes. Please go to Kubernetes doc for the spec of the volumes               |                                                                              |
+| deployment.userDefinedVolumeMounts | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts     |                                                                              |
 
 For a complete list of all configuration values you can set in the
 `env` section, please read the Kong Ingress Controller's
@@ -880,7 +882,7 @@ Although the above examples both use the initial super-admin, we recommend
 [creating a less-privileged RBAC user](https://docs.konghq.com/enterprise/latest/kong-manager/administration/rbac/add-user/)
 for the controller after installing. It needs at least workspace admin
 privileges in its workspace (`default` by default, settable by adding a
-`workspace` variable under `ingressController.env`). Once you create the
+`workspace` variable under `singressController.env`). Once you create the
 controller user, add its token to a secret and update your `kong_admin_token`
 variable to use it. Remove the `password` variable from Kong's environment
 variables and the secret containing the super-admin token after.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -882,7 +882,7 @@ Although the above examples both use the initial super-admin, we recommend
 [creating a less-privileged RBAC user](https://docs.konghq.com/enterprise/latest/kong-manager/administration/rbac/add-user/)
 for the controller after installing. It needs at least workspace admin
 privileges in its workspace (`default` by default, settable by adding a
-`workspace` variable under `singressController.env`). Once you create the
+`workspace` variable under `ingressController.env`). Once you create the
 controller user, add its token to a secret and update your `kong_admin_token`
 variable to use it. Remove the `password` variable from Kong's environment
 variables and the secret containing the super-admin token after.

--- a/charts/kong/ci/test1-values.yaml
+++ b/charts/kong/ci/test1-values.yaml
@@ -19,6 +19,12 @@ ingressController:
   serviceAccount:
     annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME
+  userDefinedVolumeMounts:
+  - name: "tmpdir"
+    mountPath: "/tmp/foo"
+    readOnly: true
+  - name: "controllerdir"
+    mountPath: "/tmp/controller"
 # - pod labels can be added to the deployment template
 podLabels:
   app: kong
@@ -43,3 +49,27 @@ proxy:
     path: /
 env:
   anonymous_reports: "off"
+
+deployment:
+  initContainers:
+    - name: "bash"
+      image: "bash:latest"
+      command: ["/bin/sh", "-c", "true"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "64Mi"
+        requests:
+          cpu: "100m"
+          memory: "64Mi"
+      volumeMounts:
+      - name: "tmpdir"
+        mountPath: "/tmp/foo"
+  userDefinedVolumes:
+  - name: "tmpdir"
+    emptyDir: {}
+  - name: "controllerdir"
+    emptyDir: {}
+  userDefinedVolumeMounts:
+  - name: "tmpdir"
+    mountPath: "/tmp/foo"

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -1,6 +1,7 @@
 # This tests the following unrelated aspects of Ingress Controller
 # - ingressController deploys with a database
 # - stream listens work
+# - a mixture of controller, Kong, and shared volumes successfully mount
 ingressController:
   enabled: true
   installCRDs: false
@@ -48,3 +49,15 @@ updateStrategy:
   rollingUpdate:
     maxSurge: 1
     maxUnavailable: 0
+deployment:
+  initContainers:
+    - name: "bash"
+      image: "bash:latest"
+      command: ["/bin/sh", "-c", "true"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "64Mi"
+        requests:
+          cpu: "100m"
+          memory: "64Mi"

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.7"
+  tag: "2.8"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.7"
+  tag: "2.8"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-controller.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: kong
-  tag: "2.7"
+  tag: "2.8"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "2.7"
+  tag: "2.8"
 
 enterprise:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.7"
+  tag: "2.8"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -11,7 +11,7 @@
 
 image:
   repository: kong
-  tag: "2.7"
+  tag: "2.8"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "2.7"
+  tag: "2.8"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -459,8 +459,8 @@ The name of the service used for the ingress controller's validation webhook
 {{- end -}}
 
 {{- define "kong.userDefinedVolumeMounts" -}}
-{{- if .Values.deployment.userDefinedVolumeMounts }}
-{{- toYaml .Values.deployment.userDefinedVolumeMounts }}
+{{- if .userDefinedVolumeMounts }}
+{{- toYaml .userDefinedVolumeMounts }}
 {{- end }}
 {{- end -}}
 
@@ -543,7 +543,7 @@ The name of the service used for the ingress controller's validation webhook
   args: [ "/bin/sh", "-c", "export KONG_NGINX_DAEMON=on KONG_PREFIX=`mktemp -d` KONG_KEYRING_ENABLED=off; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop"]
   volumeMounts:
   {{- include "kong.volumeMounts" . | nindent 4 }}
-  {{- include "kong.userDefinedVolumeMounts" . | nindent 4 }}
+  {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 4 }}
   resources:
   {{- toYaml .Values.resources | nindent 4 }}
 {{- end -}}
@@ -605,12 +605,13 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
   resources:
 {{ toYaml .Values.ingressController.resources | indent 4 }}
-{{- if .Values.ingressController.admissionWebhook.enabled }}
   volumeMounts:
+{{- if .Values.ingressController.admissionWebhook.enabled }}
   - name: webhook-cert
     mountPath: /admission-webhook
     readOnly: true
 {{- end }}
+  {{- include "kong.userDefinedVolumeMounts" .Values.ingressController | nindent 2 }}
 {{- end -}}
 
 {{- define "secretkeyref" -}}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -258,7 +258,7 @@ spec:
         {{- end }}
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 10 }}
-        {{- include "kong.userDefinedVolumeMounts" . | nindent 10 }}
+        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 10 }}
         readinessProbe:
 {{ toYaml .Values.readinessProbe | indent 10 }}
         livenessProbe:

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -66,7 +66,7 @@ spec:
         args: [ "kong", "migrations", "finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" . | nindent 8 }}
+        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -66,7 +66,7 @@ spec:
         args: [ "kong", "migrations", "up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" . | nindent 8 }}
+        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources| nindent 10 }}
       securityContext:

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -74,7 +74,7 @@ spec:
         args: [ "kong", "migrations", "bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" . | nindent 8 }}
+        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -39,6 +39,8 @@ deployment:
   #   hostnames:
   #   - "foo.local"
   #   - "bar.local"
+
+  ## Define any volumes and mounts you want present in the Kong proxy container
   # userDefinedVolumes:
   # - name: "volumeName"
   #   emptyDir: {}
@@ -472,6 +474,12 @@ ingressController:
   ingressClass: kong
   # annotations for IngressClass resource (Kubernetes 1.18+)
   ingressClassAnnotations: {}
+
+  ## Define any volumes and mounts you want present in the ingress controller container
+  ## Volumes are defined above in deployment.userDefinedVolumes
+  # userDefinedVolumeMounts:
+  # - name: "volumeName"
+  #   mountPath: "/opt/user/dir/mount"
 
   rbac:
     # Specifies whether RBAC resources should be created

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -102,10 +102,10 @@ extraLabels: {}
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "2.7"
+  tag: "2.8"
   # Kong Enterprise
   # repository: kong/kong-gateway
-  # tag: "2.7"
+  # tag: "2.8"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
#### What this PR does / why we need it:
Allow user-defined controller mounts, largely to enable usage of the functionality added in https://github.com/Kong/kubernetes-ingress-controller/pull/2258

Also bumps Kong version to 2.8 because it's a chore and I didn't want to bother with a separate PR.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #543 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
