### PR TITLE
autoscaling: Add support for behavior config

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Enables the option to add sidecar containers to the migration containers.
   ([540](https://github.com/Kong/charts/pull/540))
+* Added support for autoscaling `behavior`.
+  ([561](https://github.com/Kong/charts/pull/561))
   
 ### Fixed
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -660,6 +660,7 @@ For a complete list of all configuration values you can set in the
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |
 | autoscaling.minReplicas            | Set minimum number of replicas                                                        | `2`                 |
 | autoscaling.maxReplicas            | Set maximum number of replicas                                                        | `5`                 |
+| autoscaling.behavior               | Sets the [behavior for scaling up and down](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) | `{}`                |
 | autoscaling.targetCPUUtilizationPercentage | Target Percentage for when autoscaling takes affect. Only used if cluster doesnt support `autoscaling/v2beta2` | `80`  |
 | autoscaling.metrics                | metrics used for autoscaling for clusters that support autoscaling/v2beta2`           | See [values.yaml](values.yaml) |
 | updateStrategy                     | update strategy for deployment                                                        | `{}`                |

--- a/charts/kong/templates/hpa.yaml
+++ b/charts/kong/templates/hpa.yaml
@@ -13,6 +13,10 @@ spec:
     name: "{{ template "kong.fullname" . }}"
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  {{- if .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+  {{- end }}
   {{- if not (.Capabilities.APIVersions.Has "autoscaling/v2beta2") }}
   targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage | default 80 }}
   {{- else }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -644,6 +644,7 @@ autoscaling:
   enabled: false
   minReplicas: 2
   maxReplicas: 5
+  behavior: {}
   ## targetCPUUtilizationPercentage only used if the cluster doesn't support autoscaling/v2beta
   targetCPUUtilizationPercentage:
   ## Otherwise for clusters that do support autoscaling/v2beta, use metrics


### PR DESCRIPTION
#### What this PR does / why we need it:

We'd like this because we're using AWS NLBs, which suffer from really
slow registration and de-registration times, so we'd like to configure
the auto-scaler to scale down more slowly to prevent it flapping up and
down.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
