### PR TITLE
feat(rbac) add support for IngressClass

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
-* add quote on hostname template to be able to use wildcard domains.
-
 ### Improvements
 
+* Added IngressClass resources to RBAC roles.
+  ([563](https://github.com/Kong/charts/pull/563))
+* Ingresses now support wildcard hostnames.
+  ([559](https://github.com/Kong/charts/pull/559))
 * Enables the option to add sidecar containers to the migration containers.
   ([540](https://github.com/Kong/charts/pull/540))
 * Added support for user-defined controller volume mounts.

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -879,7 +879,7 @@ Environment variables are sorted alphabetically
 {{/*
 kong.kubernetesRBACRoles outputs a static list of RBAC rules (the "rules" block
 of a Role or ClusterRole) that provide the ingress controller access to the
-Kubernetes resources it uses to build Kong configuration.
+Kubernetes namespace-scoped resources it uses to build Kong configuration.
 */}}
 {{- define "kong.kubernetesRBACRules" -}}
 - apiGroups:
@@ -946,22 +946,6 @@ Kubernetes resources it uses to build Kong configuration.
   - ""
   resources:
   - services/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongclusterplugins
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - configuration.konghq.com
-  resources:
-  - kongclusterplugins/status
   verbs:
   - get
   - patch
@@ -1065,21 +1049,6 @@ Kubernetes resources it uses to build Kong configuration.
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
-  - gatewayclasses
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
-  - gatewayclasses/status
-  verbs:
-  - get
-  - update
-- apiGroups:
-  - gateway.networking.k8s.io
-  resources:
   - gateways
   verbs:
   - get
@@ -1140,6 +1109,60 @@ Kubernetes resources it uses to build Kong configuration.
   - get
   - patch
   - update
+{{- end -}}
+
+{{/*
+kong.kubernetesRBACClusterRoles outputs a static list of RBAC rules (the "rules" block
+of a Role or ClusterRole) that provide the ingress controller access to the
+Kubernetes Cluster-scoped resources it uses to build Kong configuration.
+*/}}
+{{- define "kong.kubernetesRBACClusterRules" -}}
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
 {{- end -}}
 
 {{- define "kong.ingressVersion" -}}

--- a/charts/kong/templates/controller-rbac-resources.yaml
+++ b/charts/kong/templates/controller-rbac-resources.yaml
@@ -96,6 +96,7 @@ metadata:
   name: {{ template "kong.fullname" . }}
 rules:
 {{ include "kong.kubernetesRBACRules" . }}
+{{ include "kong.kubernetesRBACClusterRules" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
#### What this PR does / why we need it:
Split the RBAC rule template in two, one for namespace-scoped and one
for cluster-scoped resources. Only render the cluster-scoped rules if
generating a ClusterRole.

Add support for IngressClass resources to the cluster-scoped rule
template.

#### Special notes for your reviewer:
This removes some rules from existing roles if you use `--watch-namespaces`. Those rules were unusable because they were for cluster-scoped resources inside a namespace-scoped Role.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
