### PR TITLE
feat(pathType) support user-defined ingress pathType

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Improvements
 
+* Ingress `pathType` field is now configurable.
+  ([564](https://github.com/Kong/charts/pull/564))
 * Added IngressClass resources to RBAC roles.
   ([563](https://github.com/Kong/charts/pull/563))
 * Ingresses now support wildcard hostnames.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -568,36 +568,37 @@ nodes.
 mixed TCP/UDP LoadBalancer Services). It _does not_ support the `http`, `tls`,
 or `ingress` sections, as it is used only for stream listens.
 
-| Parameter                          | Description                                                                           | Default             |
-| ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
-| SVC.enabled                        | Create Service resource for SVC (admin, proxy, manager, etc.)                         |                     |
-| SVC.http.enabled                   | Enables http on the service                                                           |                     |
-| SVC.http.servicePort               | Service port to use for http                                                          |                     |
-| SVC.http.containerPort             | Container port to use for http                                                        |                     |
-| SVC.http.nodePort                  | Node port to use for http                                                             |                     |
-| SVC.http.hostPort                  | Host port to use for http                                                             |                     |
-| SVC.http.parameters                | Array of additional listen parameters                                                 | `[]`                |
-| SVC.tls.enabled                    | Enables TLS on the service                                                            |                     |
-| SVC.tls.containerPort              | Container port to use for TLS                                                         |                     |
-| SVC.tls.servicePort                | Service port to use for TLS                                                           |                     |
-| SVC.tls.nodePort                   | Node port to use for TLS                                                              |                     |
-| SVC.tls.hostPort                   | Host port to use for TLS                                                              |                     |
-| SVC.tls.overrideServiceTargetPort  | Override service port to use for TLS without touching Kong containerPort              |                     |
-| SVC.tls.parameters                 | Array of additional listen parameters                                                 | `["http2"]`         |
-| SVC.type                           | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          |                     |
-| SVC.clusterIP                      | k8s service clusterIP                                                                 |                     |
-| SVC.loadBalancerSourceRanges       | Limit service access to CIDRs if set and service type is `LoadBalancer`               | `[]`                |
-| SVC.loadBalancerIP                 | Reuse an existing ingress static IP for the service                                   |                     |
-| SVC.externalIPs                    | IPs for which nodes in the cluster will also accept traffic for the servic            | `[]`                |
-| SVC.externalTrafficPolicy          | k8s service's externalTrafficPolicy. Options: Cluster, Local                          |                     |
-| SVC.ingress.enabled                | Enable ingress resource creation (works with SVC.type=ClusterIP)                      | `false`             |
-| SVC.ingress.ingressClassName       | Set the ingressClassName to associate this Ingress with an IngressClass               |                     |
-| SVC.ingress.tls                    | Name of secret resource, containing TLS secret                                        |                     |
-| SVC.ingress.hostname               | Ingress hostname                                                                      | `""`                |
-| SVC.ingress.path                   | Ingress path.                                                                         | `/`                 |
-| SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                |
-| SVC.annotations                    | Service annotations                                                                   | `{}`                |
-| SVC.labels                         | Service labels                                                                        | `{}`                |
+| Parameter                          | Description                                                                           | Default                  |
+|------------------------------------|---------------------------------------------------------------------------------------|--------------------------|
+| SVC.enabled                        | Create Service resource for SVC (admin, proxy, manager, etc.)                         |                          |
+| SVC.http.enabled                   | Enables http on the service                                                           |                          |
+| SVC.http.servicePort               | Service port to use for http                                                          |                          |
+| SVC.http.containerPort             | Container port to use for http                                                        |                          |
+| SVC.http.nodePort                  | Node port to use for http                                                             |                          |
+| SVC.http.hostPort                  | Host port to use for http                                                             |                          |
+| SVC.http.parameters                | Array of additional listen parameters                                                 | `[]`                     |
+| SVC.tls.enabled                    | Enables TLS on the service                                                            |                          |
+| SVC.tls.containerPort              | Container port to use for TLS                                                         |                          |
+| SVC.tls.servicePort                | Service port to use for TLS                                                           |                          |
+| SVC.tls.nodePort                   | Node port to use for TLS                                                              |                          |
+| SVC.tls.hostPort                   | Host port to use for TLS                                                              |                          |
+| SVC.tls.overrideServiceTargetPort  | Override service port to use for TLS without touching Kong containerPort              |                          |
+| SVC.tls.parameters                 | Array of additional listen parameters                                                 | `["http2"]`              |
+| SVC.type                           | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          |                          |
+| SVC.clusterIP                      | k8s service clusterIP                                                                 |                          |
+| SVC.loadBalancerSourceRanges       | Limit service access to CIDRs if set and service type is `LoadBalancer`               | `[]`                     |
+| SVC.loadBalancerIP                 | Reuse an existing ingress static IP for the service                                   |                          |
+| SVC.externalIPs                    | IPs for which nodes in the cluster will also accept traffic for the servic            | `[]`                     |
+| SVC.externalTrafficPolicy          | k8s service's externalTrafficPolicy. Options: Cluster, Local                          |                          |
+| SVC.ingress.enabled                | Enable ingress resource creation (works with SVC.type=ClusterIP)                      | `false`                  |
+| SVC.ingress.ingressClassName       | Set the ingressClassName to associate this Ingress with an IngressClass               |                          |
+| SVC.ingress.tls                    | Name of secret resource, containing TLS secret                                        |                          |
+| SVC.ingress.hostname               | Ingress hostname                                                                      | `""`                     |
+| SVC.ingress.path                   | Ingress path.                                                                         | `/`                      |
+| SVC.ingress.pathType               | Ingress pathType. One of `ImplementationSpecific`, `Exact` or `Prefix`                | `ImplementationSpecific` |
+| SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                     |
+| SVC.annotations                    | Service annotations                                                                   | `{}`                     |
+| SVC.labels                         | Service labels                                                                        | `{}`                     |
 
 #### Stream listens
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -66,6 +66,7 @@ Create Ingress resource for a Kong service
 {{- $servicePort := include "kong.ingress.servicePort" . }}
 {{- $path := .ingress.path -}}
 {{- $hostname := .ingress.hostname -}}
+{{- $pathType := .ingress.pathType -}}
 apiVersion: {{ .ingressVersion }}
 kind: Ingress
 metadata:
@@ -100,7 +101,7 @@ spec:
           {{- if $path }}
           path: {{ $path }}
           {{- if (not (eq .ingressVersion "extensions/v1beta1")) }}
-          pathType: ImplementationSpecific
+          pathType: {{ $pathType }}
           {{- end }}
           {{- end -}}
   {{- if (hasKey .ingress "tls") }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -168,6 +168,8 @@ admin:
     annotations: {}
     # Ingress path.
     path: /
+    # Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
 
 # Specify Kong status listener configuration
 # This listen is internal-only. It cannot be exposed through a service or ingress.
@@ -289,6 +291,8 @@ proxy:
     annotations: {}
     # Ingress path.
     path: /
+    # Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
 
   # Optionally specify a static load balancer IP.
   # loadBalancerIP:
@@ -830,6 +834,8 @@ manager:
     annotations: {}
     # Ingress path.
     path: /
+    # Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
 
 portal:
   # Enable creating a Kubernetes service for the Developer Portal
@@ -874,6 +880,8 @@ portal:
     annotations: {}
     # Ingress path.
     path: /
+    # Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
 
 portalapi:
   # Enable creating a Kubernetes service for the Developer Portal API
@@ -918,6 +926,8 @@ portalapi:
     annotations: {}
     # Ingress path.
     path: /
+    # Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
 
 clustertelemetry:
   enabled: false


### PR DESCRIPTION
Add support for user-defined ingress pathType. Right now it was hard-coded to be `ImplementationSpecific`.
According to https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types the values can be one of
`ImplementationSpecific`, `Exact` or `Prefix`.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
