### PR TITLE
feat(crds) allow users to control CRD behavior

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -16,6 +16,9 @@
   ([560](https://github.com/Kong/charts/pull/560))
 * Added support for autoscaling `behavior`.
   ([561](https://github.com/Kong/charts/pull/561))
+* Improved support and documentation for installations that [lack
+  cluster-scoped permissions](https://github.com/Kong/charts/blob/main/charts/kong/README.md#removing-cluster-scoped-permissions).
+  ([565](https://github.com/Kong/charts/pull/565))
   
 ### Fixed
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -454,16 +454,16 @@ event you need to recover from unintended CRD deletion.
 
 ### InitContainers
 
-The chart able to deploy initcontainers along with Kong. This can be very
-useful when require to setup additional custom initialization. The
+The chart is able to deploy initcontainers along with Kong. This can be very
+useful when there's a requirement for custom initialization. The
 `deployment.initcontainers` field in values.yaml takes an array of objects that
 get appended as-is to the existing `spec.template.initContainers` array in the
 kong deployment resource. 
 
 ### HostAliases
 
-The chart able to inject host aliases into containers. This can be very useful
-when require to resolve additional domain name which can't be looked-up
+The chart is able to inject host aliases into containers. This can be very useful
+when it's required to resolve additional domain name which can't be looked-up
 directly from dns server. The `deployment.hostAliases` field in values.yaml
 takes an array of objects that set to `spec.template.hostAliases` field in the
 kong deployment resource.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -43,6 +43,7 @@ $ helm install kong/kong --generate-name
   - [Migration Sidecar Containers](#migration-sidecar-containers)
   - [User Defined Volumes](#user-defined-volumes)
   - [User Defined Volume Mounts](#user-defined-volume-mounts)
+  - [Removing cluster-scoped permissions](#removing-cluster-scoped-permissions)
   - [Using a DaemonSet](#using-a-daemonset)
   - [Example configurations](#example-configurations)
 - [Configuration](#configuration)
@@ -453,12 +454,19 @@ event you need to recover from unintended CRD deletion.
 
 ### InitContainers
 
-The chart able to deploy initcontainers along with Kong. This can be very useful when require to setup additional custom initialization. The `deployment.initcontainers` field in values.yaml takes an array of objects that get appended as-is to the existing `spec.template.initContainers` array in the kong deployment resource. 
+The chart able to deploy initcontainers along with Kong. This can be very
+useful when require to setup additional custom initialization. The
+`deployment.initcontainers` field in values.yaml takes an array of objects that
+get appended as-is to the existing `spec.template.initContainers` array in the
+kong deployment resource. 
 
 ### HostAliases
 
-The chart able to inject host aliases into containers. This can be very useful when require to resolve additional domain name which can't
-be looked-up directly from dns server. The `deployment.hostAliases` field in values.yaml takes an array of objects that set to `spec.template.hostAliases` field in the kong deployment resource.
+The chart able to inject host aliases into containers. This can be very useful
+when require to resolve additional domain name which can't be looked-up
+directly from dns server. The `deployment.hostAliases` field in values.yaml
+takes an array of objects that set to `spec.template.hostAliases` field in the
+kong deployment resource.
 
 ### Sidecar Containers
 
@@ -483,11 +491,46 @@ as finished and the deployment of the chart will reach the timeout.
 
 ### User Defined Volumes
 
-The chart can deploy additional volumes along with Kong. This can be useful to include additional volumes which required during iniatilization phase (InitContainer). The  `deployment.userDefinedVolumes` field in values.yaml takes an array of objects that get appended as-is to the existing `spec.template.spec.volumes` array in the kong deployment resource.
+The chart can deploy additional volumes along with Kong. This can be useful to
+include additional volumes which required during iniatilization phase
+(InitContainer). The  `deployment.userDefinedVolumes` field in values.yaml
+takes an array of objects that get appended as-is to the existing
+`spec.template.spec.volumes` array in the kong deployment resource.
 
 ### User Defined Volume Mounts
 
-The chart can mount user-defined volumes. The `deployment.userDefinedVolumeMounts` and `ingressController.userDefinedVolumeMounts` fields in values.yaml take an array of object that get appended as-is to the existing `spec.template.spec.containers[].volumeMounts` and `spec.template.spec.initContainers[].volumeMounts` array in the kong deployment resource.
+The chart can mount user-defined volumes. The
+`deployment.userDefinedVolumeMounts` and
+`ingressController.userDefinedVolumeMounts` fields in values.yaml take an array
+of object that get appended as-is to the existing
+`spec.template.spec.containers[].volumeMounts` and
+`spec.template.spec.initContainers[].volumeMounts` array in the kong deployment
+resource.
+
+### Removing cluster-scoped permissions
+
+You can limit the controller's access to allow it to only watch specific
+namespaces for resources. By default, the controller watches all namespaces.
+Limiting access requires several changes to configuration:
+
+- Set `ingressController.watchNamespaces` to a list of namespaces you want to
+  watch. The chart will automatically generate roles for each namespace and
+  assign them to the controller's service account.
+- Set `ingressController.env.enable_controller_kongclusterplugin=false` and
+  `ingressController.env.enable_controller_ingress_class_networkingv1=false`.
+  These are cluster-scoped resources, and controllers with no ClusterRole
+  cannot access them.
+- Optionally set `ingressContrller.installCRDs=false` if your user role (the
+  role you use when running `helm install`, not the controller service
+  account's role) does not have access to get CRDs. By default, the chart
+  attempts to look up the controller CRDs for [a legacy behavior
+  check](#crd-management).
+
+Because there is no namespaced version of IngressClass, controllers without
+cluster-scoped permissions cannot access them. The controller will rely
+entirely on whether the ingress class annotation or `ingressClassName` value
+matches the value set by `--ingress-class` or `CONTROLLER_INGRESS_CLASS` to
+determine which Ingresses it should use.
 
 ### Using a DaemonSet
 
@@ -800,7 +843,8 @@ configuration can be placed under the `.env` key.
 
 Kong Enterprise 2.3+ can run with or without a license. If you wish to run 2.3+
 without a license, you can skip this step and leave `enterprise.license_secret`
-unset. In this case only a limited subset of features will be available. Earlier versions require a license.
+unset. In this case only a limited subset of features will be available.
+Earlier versions require a license.
 
 If you have paid for a license, but you do not have a copy of yours, please
 contact Kong Support. Once you have it, you will need to store it in a Secret:
@@ -927,7 +971,10 @@ Setting `.enterprise.smtp.disabled: true` will set `KONG_SMTP_MOCK=on` and
 allow Admin/Developer invites to proceed without sending email. Note, however,
 that these have limited functionality without sending email.
 
-If your SMTP server requires authentication, you must provide the `username` and `smtp_password_secret` keys under `.enterprise.smtp.auth`. `smtp_password_secret` must be a Secret containing an `smtp_password` key whose value is your SMTP password.
+If your SMTP server requires authentication, you must provide the `username`
+and `smtp_password_secret` keys under `.enterprise.smtp.auth`.
+`smtp_password_secret` must be a Secret containing an `smtp_password` key whose
+value is your SMTP password.
 
 By default, SMTP uses `AUTH` `PLAIN` when you provide credentials. If your provider requires `AUTH LOGIN`, set `smtp_auth_type: login`.
 

--- a/charts/kong/templates/custom-resource-definitions.yaml
+++ b/charts/kong/templates/custom-resource-definitions.yaml
@@ -1,15 +1,7 @@
 {{- $installCRDs := false -}}
-{{- if .Values.ingressController.installCRDs -}}
-  {{- if .Values.ingressController.enabled -}}
-    {{/* Managed CRD installation is enabled, and the controller is enabled.
-    */}}
-    {{- $installCRDs = true -}}
-  {{- else if (not .Values.deployment.kong.enabled) -}}
-    {{/* Managed CRD installation is enabled, and neither the controller nor Kong or enabled.
-         This is a CRD-only release.
-    */}}
-    {{- $installCRDs = true -}}
-  {{- end -}}
+{{- if (hasKey .Values.ingressController "installCRDs") -}}
+  {{/* Explicitly set, honor whatever's set */}}
+  {{- $installCRDs = .Values.ingressController.installCRDs -}}
 {{- else -}}
   {{/* Legacy default handling. CRD installation is _not_ enabled, but CRDs are already present
        and are managed by this release. This release previously relied on the <2.0 default


### PR DESCRIPTION
#### What this PR does / why we need it:
Brings `ingressController.installCRDs` back and honors it if present. By default, it is not present: the default values.yaml does not set it and it is only documented under the new section discussing deployments without cluster permissions, not the values.yaml key list. We only expect its use in this case. If it is not set, we continue to use our current behavior, which looks up CRDs, sees if they're owned by the Helm release, and keeps them in the output if so.

Document no cluster permissions environments, which require disabling some controllers in addition to using `watchNamespaces` to disable ClusterRole creation.

Wrapped some unrelated README.md sections.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #544 

#### Special notes for your reviewer:
When I originally designed this feature, I was unaware of the `hasKey` helper. Without this, you cannot distinguish between "value is explicitly set to false" and "value is unset", because unset values are falsy. I am now aware of it, and per #544 some users want to disable the lookup. Honoring the explicit value lets them do so.

I also removed some checks we kept around from the original CRD template, which only honored `true` if either the controller was enabled or neither the controller nor Kong were enabled. The original conditions were, AFAIK, to allow the default `true` without creating CRDs unnecessarily on Kong-only installs, and aren't necessary without any default.

[test.txt](https://github.com/Kong/charts/files/8328576/test.txt) shows the expected behavior:

- Installing with `installCRDs=true` creates managed CRDs.
- Upgrading without `installCRDs` set lets managed CRDs persist if they are present.
- Setting `installCRDs=false` deletes managed CRDs.
- Upgrading without `installCRDs` set does not create managed CRDs if none are already present.

All testing done with this branch, as it's no longer possible to easily install 1.15 (when we originally last had the `installCRDs=true` default) due to deprecated APIs and older version KIND images not working.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
