### PR TITLE
feat(deployment) allow custom environment variables to be configured for the ingress-controller container

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* feat(deployment) allow custom environment variables to be configured for the ingress-controller container
+  ([568](https://github.com/Kong/charts/pull/568))
+
 ### Improvements
 
 * Ingress `pathType` field is now configurable.

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## Unreleased
 
-* feat(deployment) allow custom environment variables to be configured for the ingress-controller container
-  ([568](https://github.com/Kong/charts/pull/568))
-
 ### Improvements
 
+* feat(deployment) allow custom environment variables to be configured for the ingress-controller container
+  ([568](https://github.com/Kong/charts/pull/568))
 * Ingress `pathType` field is now configurable.
   ([564](https://github.com/Kong/charts/pull/564))
 * Added IngressClass resources to RBAC roles.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -662,32 +662,49 @@ are configured using an array of objects under `proxy.stream` and `udpProxy.stre
 All of the following properties are nested under the `ingressController`
 section of `values.yaml` file:
 
-| Parameter                          | Description                                                                           | Default                                                                      |
-| ---------------------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| enabled                            | Deploy the ingress controller, rbac and crd                                           | true                                                                         |
-| image.repository                   | Docker image with the ingress controller                                              | kong/kubernetes-ingress-controller                                           |
-| image.tag                          | Version of the ingress controller                                                     | 2.0                                                                          |
-| image.effectiveSemver              | Version of the ingress controller used for version-specific features when image.tag is not a valid semantic version |                                                |
-| readinessProbe                     | Kong ingress controllers readiness probe                                              |                                                                              |
-| livenessProbe                      | Kong ingress controllers liveness probe                                               |                                                                              |
-| installCRDs                        | Creates managed CRDs.                                                                 | false                                                                        |
-| env                                | Specify Kong Ingress Controller configuration via environment variables               |                                                                              |
-| ingressClass                       | The name of this controller's ingressClass                                            | kong                                                                         |
-| ingressClassAnnotations            | The ingress-class value for controller                                                | kong                                                                         |
-| args                               | List of ingress-controller cli arguments                                              | []                                                                           |
-| watchNamespaces                    | List of namespaces to watch. Watches all namespaces if empty                          | []                                                                           |
-| admissionWebhook.enabled           | Whether to enable the validating admission webhook                                    | false                                                                        |
-| admissionWebhook.failurePolicy     | How unrecognized errors from the admission endpoint are handled (Ignore or Fail)      | Fail                                                                         |
-| admissionWebhook.port              | The port the ingress controller will listen on for admission webhooks                 | 8080                                                                         |
-| admissionWebhook.certificate.provided   | Whether to generate the admission webhook certificate if not provided            | false                                                                        |
-| admissionWebhook.certificate.secretName | Name of the TLS secret for the provided webhook certificate                      |                                                                              |
-| admissionWebhook.certificate.caBundle   | PEM encoded CA bundle which will be used to validate the provided webhook certificate |                                                                         |
-| deployment.userDefinedVolumes      | Create volumes. Please go to Kubernetes doc for the spec of the volumes               |                                                                              |
-| deployment.userDefinedVolumeMounts | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts     |                                                                              |
+| Parameter                               | Description                                                                                                         | Default                                                                      |
+|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------| ---------------------------------------------------------------------------- |
+| enabled                                 | Deploy the ingress controller, rbac and crd                                                                         | true                                                                         |
+| image.repository                        | Docker image with the ingress controller                                                                            | kong/kubernetes-ingress-controller                                           |
+| image.tag                               | Version of the ingress controller                                                                                   | 2.0                                                                          |
+| image.effectiveSemver                   | Version of the ingress controller used for version-specific features when image.tag is not a valid semantic version |                                                |
+| readinessProbe                          | Kong ingress controllers readiness probe                                                                            |                                                                              |
+| livenessProbe                           | Kong ingress controllers liveness probe                                                                             |                                                                              |
+| installCRDs                             | Creates managed CRDs.                                                                                               | false                                                                        |
+| env                                     | Specify Kong Ingress Controller configuration via environment variables                                             |                                                                              |
+| customEnv                               | Specify custom environment variables (without the CONTROLLER_ prefix)                                               |                                                                              |
+| ingressClass                            | The name of this controller's ingressClass                                                                          | kong                                                                         |
+| ingressClassAnnotations                 | The ingress-class value for controller                                                                              | kong                                                                         |
+| args                                    | List of ingress-controller cli arguments                                                                            | []                                                                           |
+| watchNamespaces                         | List of namespaces to watch. Watches all namespaces if empty                                                        | []                                                                           |
+| admissionWebhook.enabled                | Whether to enable the validating admission webhook                                                                  | false                                                                        |
+| admissionWebhook.failurePolicy          | How unrecognized errors from the admission endpoint are handled (Ignore or Fail)                                    | Fail                                                                         |
+| admissionWebhook.port                   | The port the ingress controller will listen on for admission webhooks                                               | 8080                                                                         |
+| admissionWebhook.certificate.provided   | Whether to generate the admission webhook certificate if not provided                                               | false                                                                        |
+| admissionWebhook.certificate.secretName | Name of the TLS secret for the provided webhook certificate                                                         |                                                                              |
+| admissionWebhook.certificate.caBundle   | PEM encoded CA bundle which will be used to validate the provided webhook certificate                               |                                                                         |
+| deployment.userDefinedVolumes           | Create volumes. Please go to Kubernetes doc for the spec of the volumes                                             |                                                                              |
+| deployment.userDefinedVolumeMounts      | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts                                   |                                                                              |
 
+#### The `env` section
 For a complete list of all configuration values you can set in the
 `env` section, please read the Kong Ingress Controller's
 [configuration document](https://github.com/Kong/kubernetes-ingress-controller/blob/main/docs/references/cli-arguments.md).
+
+#### The `customEnv` section
+
+The `customEnv` section can be used to configure all environment variables other than Ingress Controller configuration.
+Any key value put under this section translates to environment variables.
+Every key is upper-cased before setting the environment variable.
+
+An example:
+
+```yaml
+kong:
+  ingressController:
+    customEnv:
+      TZ: "Europe/Berlin"
+```
 
 ### General Parameters
 

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -7,6 +7,8 @@ ingressController:
   installCRDs: false
   env:
     anonymous_reports: "false"
+  customEnv:
+    TZ: "Europe/Berlin"
 postgresql:
   enabled: true
   postgresqlUsername: kong

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -379,10 +379,20 @@ The name of the service used for the ingress controller's validation webhook
 {{- end -}}
 
 {{/*
+    ====== CUSTOM-SET INGRESS CONTROLLER ENVIRONMENT VARIABLES ======
+*/}}
+
+{{- $customIngressEnv := dict -}}
+{{- range $key, $val := .Values.ingressController.customEnv }}
+  {{- $upper := upper $key -}}
+  {{- $_ := set $customIngressEnv $upper $val -}}
+{{- end -}}
+
+{{/*
       ====== MERGE AND RENDER ENV BLOCK ======
 */}}
 
-{{- $completeEnv := mergeOverwrite $autoEnv $userEnv -}}
+{{- $completeEnv := mergeOverwrite $autoEnv $userEnv $customIngressEnv -}}
 {{- template "kong.renderEnv" $completeEnv -}}
 
 {{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -87,6 +87,8 @@ env:
 # These custom environment variables are typicall used in custom plugins or serverless plugins to
 # access environment specific credentials or tokens.
 # Example as below, uncomment if required and add additional attributes as required.
+# Note that these environment variables will only apply to the proxy and init container. The ingress-controller
+# container has its own customEnv section.
 
 # customEnv:
 #   api_token:
@@ -461,6 +463,11 @@ ingressController:
     #     secretKeyRef:
     #        name: CHANGEME-admin-token-secret
     #        key: CHANGEME-admin-token-key
+
+  # This section is any customer specific environments variables that doesn't require CONTROLLER_ prefix.
+  # Example as below, uncomment if required and add additional attributes as required.
+  # customEnv:
+  #   TZ="Europe/Berlin"
 
   admissionWebhook:
     enabled: false

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -467,7 +467,7 @@ ingressController:
   # This section is any customer specific environments variables that doesn't require CONTROLLER_ prefix.
   # Example as below, uncomment if required and add additional attributes as required.
   # customEnv:
-  #   TZ="Europe/Berlin"
+  #   TZ: "Europe/Berlin"
 
   admissionWebhook:
     enabled: false


### PR DESCRIPTION
* Introduced a the ingressController.customEnv section to allow custom env
variables to be defined for the ingress-controller like it is possible
for the proxy with the customEnv right now
* populate $customIngressEnv dict and add it to the $completeEnv dict
* Updated Readme


<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
fixes #562

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
