### PR TITLE
podDisruptionBudget: Update apiVersion to policy/v1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Updated podDisruptionBudget from `policy/v1beta1` to `policy/v1`.
+  ([574](https://github.com/Kong/charts/pull/574))
+
 ### Improvements
 
 * feat(deployment) allow custom environment variables to be configured for the ingress-controller container
@@ -23,7 +26,7 @@
 * Improved support and documentation for installations that [lack
   cluster-scoped permissions](https://github.com/Kong/charts/blob/main/charts/kong/README.md#removing-cluster-scoped-permissions).
   ([565](https://github.com/Kong/charts/pull/565))
-  
+
 ### Fixed
 
 * Removed CREATE from ValidatingWebhookConfiguration objectSelector for Secrets to align with changes in Kong/kubernetes-ingress-controller.

--- a/charts/kong/templates/pdb.yaml
+++ b/charts/kong/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kong.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

When podDisruptionBudget is enabled, you receive a deprecation notice
when running Kong: `policy/v1beta1 PodDisruptionBudget is deprecated in
v1.21+` -- it notes to use `policy/v1` which this commit takes care of.

#### Special notes for your reviewer:

Here are the full warning messages I received when I implemented the pdb:

```
W0407 09:06:52.855601 57074 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0407 09:06:53.046176 57074 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```

#### Checklist
- [X] PR is based off the current tip of the `main` branch.
- [X] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [X] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
