### PR TITLE
Release Kong 2.8.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## Unreleased
 
-* Updated podDisruptionBudget from `policy/v1beta1` to `policy/v1`.
-  ([574](https://github.com/Kong/charts/pull/574))
+Nothing yet.
+
+## 2.8.0
 
 ### Improvements
 
-* feat(services) add Ingress for cluster sync
+* Added Ingress for cluster sync.
   ([583](https://github.com/Kong/charts/pull/583))
-* feat(deployment) allow custom environment variables to be configured for the ingress-controller container
+* Added controller support for custom environment variables.
   ([568](https://github.com/Kong/charts/pull/568))
 * Ingress `pathType` field is now configurable.
   ([564](https://github.com/Kong/charts/pull/564))
@@ -28,6 +29,8 @@
 * Improved support and documentation for installations that [lack
   cluster-scoped permissions](https://github.com/Kong/charts/blob/main/charts/kong/README.md#removing-cluster-scoped-permissions).
   ([565](https://github.com/Kong/charts/pull/565))
+* Updated podDisruptionBudget from `policy/v1beta1` to `policy/v1`.
+  ([574](https://github.com/Kong/charts/pull/574))
 * Updated controller version to 2.3.
   
 ### Fixed

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -28,7 +28,8 @@
 * Improved support and documentation for installations that [lack
   cluster-scoped permissions](https://github.com/Kong/charts/blob/main/charts/kong/README.md#removing-cluster-scoped-permissions).
   ([565](https://github.com/Kong/charts/pull/565))
-
+* Updated controller version to 2.3.
+  
 ### Fixed
 
 * Removed CREATE from ValidatingWebhookConfiguration objectSelector for Secrets to align with changes in Kong/kubernetes-ingress-controller.

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.7.0
+version: 2.8.0
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -17,6 +17,7 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [2.8.0](#280)
 - [2.7.0](#270)
 - [2.4.0](#240)
 - [2.3.0](#230)
@@ -61,6 +62,33 @@ text ending with `field is immutable`. This is typically due to a bug with the
 `init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+## 2.8.0
+
+2.8 updates the Postgres subchart version from 8.6.8 to 11.1.15. This changes
+a number of values.yaml keys and the default Postgres version. The previous
+default Postgres version was [11.7.0-debian-10-r37](https://github.com/bitnami/charts/blob/590c6b0f4e07161614453b12efe71f22e0c00a46/bitnami/postgresql/values.yaml#L18).
+
+To use the new version on an existing install, you should [follow Bitnami's
+instructions for updating values.yaml keys and upgrading their chart]() as well
+as [the Postgres upgrade instructions](https://www.postgresql.org/docs/current/upgrading.html).
+
+You can alternately use the new chart without upgrading Postgres by setting
+`postgresql.image.tag=11.7.0-debian-10-r37` or use the old version of the
+chart. Helm documentation is unclear on whether ignoring a subchart version
+change for a release is possible, so we recommend [dumping the
+database](https://www.postgresql.org/docs/current/backup-dump.html) and
+creating a separate release if you wish to continue using 8.6.8:
+
+```
+$ helm install my-release -f values.yaml --version 8.6.8 bitnami/postgresql
+```
+
+Afterwords, you will upgrade your Kong chart release with
+`postgresql.enabled=false` and `env.pg_host` and `env.pg_password` set to the
+appropriate hostname and Secret reference for your new release (these are set
+automatically when the subchart is enabled, but will not be set automatically
+with a separate release).
 
 ## 2.7.0
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -449,7 +449,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "2.2"
+    tag: "2.3"
     # Optionally set a semantic version for version-gated features. This can normally
     # be left unset. You only need to set this if your tag is not a semver string,
     # such as when you are using a "next" tag. Set this to the effective semantic


### PR DESCRIPTION
Per something I don't quite understand on the gateway end, the Postgres fix was not released in 2.8.1: https://github.com/Kong/kong/issues/8259#issuecomment-1097568845

Continuing this one with the pinned Postgres version.