### PR TITLE
feat(services) add Ingress for cluster sync

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Improvements
 
+* feat(services) add Ingress for cluster sync
+  ([582](https://github.com/Kong/charts/pull/582))
 * feat(deployment) allow custom environment variables to be configured for the ingress-controller container
   ([568](https://github.com/Kong/charts/pull/568))
 * Ingress `pathType` field is now configurable.

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -98,12 +98,10 @@ spec:
               port:
                 number: {{ $servicePort }}
             {{- end }}
-          {{- if $path }}
           path: {{ $path }}
           {{- if (not (eq .ingressVersion "extensions/v1beta1")) }}
           pathType: {{ $pathType }}
           {{- end }}
-          {{- end -}}
   {{- if (hasKey .ingress "tls") }}
   tls:
   - hosts:
@@ -450,7 +448,7 @@ The name of the service used for the ingress controller's validation webhook
     secretName: {{ .Values.ingressController.admissionWebhook.certificate.secretName }}
     {{- else }}
     secretName: {{ template "kong.fullname" . }}-validation-webhook-keypair
-    {{- end }}  
+    {{- end }}
 {{- end }}
 {{- range $secretVolume := .Values.secretVolumes }}
 - name: {{ . }}
@@ -546,7 +544,7 @@ The name of the service used for the ingress controller's validation webhook
   image: {{ include "kong.getRepoTag" .Values.image }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   securityContext:
-  {{ toYaml .Values.containerSecurityContext | nindent 4 }} 
+  {{ toYaml .Values.containerSecurityContext | nindent 4 }}
   env:
   {{- include "kong.env" . | nindent 2 }}
 {{/* TODO the prefix override is to work around https://github.com/Kong/charts/issues/295
@@ -571,7 +569,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- define "kong.controller-container" -}}
 - name: ingress-controller
   securityContext:
-{{ toYaml .Values.containerSecurityContext | nindent 4 }}  
+{{ toYaml .Values.containerSecurityContext | nindent 4 }}
   args:
   {{ if .Values.ingressController.args}}
   {{- range $val := .Values.ingressController.args }}

--- a/charts/kong/templates/service-kong-cluster-telemetry.yaml
+++ b/charts/kong/templates/service-kong-cluster-telemetry.yaml
@@ -9,5 +9,9 @@
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
 {{- $_ := set $serviceConfig "serviceName" "clustertelemetry" -}}
 {{- include "kong.service" $serviceConfig }}
+{{ if .Values.clustertelemetry.ingress.enabled }}
+---
+{{ include "kong.ingress" $serviceConfig }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/service-kong-cluster.yaml
+++ b/charts/kong/templates/service-kong-cluster.yaml
@@ -9,5 +9,9 @@
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
 {{- $_ := set $serviceConfig "serviceName" "cluster" -}}
 {{- include "kong.service" $serviceConfig }}
+{{ if .Values.cluster.ingress.enabled }}
+---
+{{ include "kong.ingress" $serviceConfig }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -257,6 +257,23 @@ proxy:
     parameters:
     - http2
 
+  # Kong cluster ingress settings. Useful if you want to split CP and DP
+  # in different clusters.
+  ingress:
+    # Enable/disable exposure using ingress.
+    enabled: false
+    ingressClassName:
+    # TLS secret name.
+    # tls: kong-cluster.example.com-tls
+    # Ingress hostname
+    hostname:
+    # Map of ingress annotations.
+    annotations: {}
+    # Ingress path.
+    path: /
+    # Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
+
   # Define stream (TCP) listen
   # To enable, remove "{}", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their servicePort,
@@ -964,6 +981,23 @@ clustertelemetry:
     parameters: []
 
   type: ClusterIP
+
+  # Kong clustertelemetry ingress settings. Useful if you want to split
+  # CP and DP in different clusters.
+  ingress:
+    # Enable/disable exposure using ingress.
+    enabled: false
+    ingressClassName:
+    # TLS secret name.
+    # tls: kong-clustertelemetry.example.com-tls
+    # Ingress hostname
+    hostname:
+    # Map of ingress annotations.
+    annotations: {}
+    # Ingress path.
+    path: /
+    # Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)
+    pathType: ImplementationSpecific
 
 extraConfigMaps: []
 # extraConfigMaps:


### PR DESCRIPTION
#### What this PR does / why we need it:
This is an alternative pull request to #573 . This one uses the default Ingress feature of K8s to create OpenShift routes. I just need to add Ingress option for cluster communication as well, that's why I edited the matching service templates. I need this for automatic creation of OpenShift routes as I need them for cluster to cluster communication between CP and DP. 
I also had to remove an unnecessary if statement, because _ingress.path_ already has a default value in values.yml. I need the option to be able to leave the _ingress.path_ blank.

#### Special notes for your reviewer:
As I said, this is an alternative to #573 and I would be happy if we could find a common solution here.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
