### PR TITLE
docs(hybrid) clarify hybrid mode upgrade process

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -228,8 +228,10 @@ Kong can be configured via two methods:
 split release technique is generally applicable to any deployment with
 different types of Kong nodes. Separating Admin API and proxy nodes is one of
 the more common use cases for splitting across multiple releases, but you can
-also split releases for hybrid mode CP/DP nodes, split proxy and Developer
-Portal nodes, etc.*
+also split releases for split proxy and Developer Portal nodes, multiple groups
+of proxy nodes with separate listen configurations for network segmentation, etc.
+However, it does not apply to hybrid mode, as only the control plane release
+interacts with the database.*
 
 Users may wish to split their Kong deployment into multiple instances that only
 run some of Kong's services (i.e. you run `helm install` once for every
@@ -306,6 +308,9 @@ values.yaml specifics for each.
 
 Cluster certificates are not generated automatically. You must [create a
 certificate and key pair](#certificates) for intra-cluster communication.
+
+When upgrading the Kong version, you must [upgrade the control plane release
+first and then upgrade the data plane release](https://docs.konghq.com/gateway/latest/plan-and-deploy/hybrid-mode/#version-compatibility).
 
 #### Certificates
 

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -46,6 +46,9 @@ migrations finish`.
 If you split your Kong deployment across multiple Helm releases (to create
 proxy-only and admin-only nodes, for example), you must
 [set which migration jobs run based on your upgrade order](https://github.com/Kong/charts/blob/main/charts/kong/README.md#separate-admin-and-proxy-nodes).
+However, this does not apply to hybrid mode, which can run both migrations but
+requires [upgrading the control plane version
+first](https://docs.konghq.com/gateway/latest/plan-and-deploy/hybrid-mode/#version-compatibility).
 
 While the migrations themselves are automated, the chart does not automatically
 ensure that you follow the recommended upgrade path. If you are upgrading from


### PR DESCRIPTION
#### What this PR does / why we need it:
Existing docs incorrectly included hybrid under the split release guidelines. Hybrid has different requirements that do not overlap with these.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
