### PR TITLE
fix(values) use empty array default for stream

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
-Nothing yet.
+### Fixed
+
+* Fixed the stream default type, which should have been an empty array, not an
+  empty map. This had no effect on chart behavior, but resulted in warning
+  messages when user values.yamls contained non-empty stream configuration.
+  ([594](https://github.com/Kong/charts/pull/594))
 
 ## 2.8.0
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -275,14 +275,14 @@ proxy:
     - http2
 
   # Define stream (TCP) listen
-  # To enable, remove "{}", uncomment the section below, and select your desired
+  # To enable, remove "[]", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their servicePort,
   # e.g. "stream-9000" for the below.
   # Note: although you can select the protocol here, you cannot set UDP if you
   # use a LoadBalancer Service due to limitations in current Kubernetes versions.
   # To proxy both TCP and UDP with LoadBalancers, you must enable the udpProxy Service
   # in the next section and place all UDP stream listen configuration under it.
-  stream: {}
+  stream: []
     #   # Set the container (internal) and service (external) ports for this listen.
     #   # These values should normally be the same. If your environment requires they
     #   # differ, note that Kong will match routes based on the containerPort only.
@@ -334,10 +334,10 @@ udpProxy:
   # loadBalancerIP:
 
   # Define stream (UDP) listen
-  # To enable, remove "{}", uncomment the section below, and select your desired
+  # To enable, remove "[]", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their servicePort,
   # e.g. "stream-9000" for the below.
-  stream: {}
+  stream: []
     #   # Set the container (internal) and service (external) ports for this listen.
     #   # These values should normally be the same. If your environment requires they
     #   # differ, note that Kong will match routes based on the containerPort only.


### PR DESCRIPTION
#### What this PR does / why we need it:
Use the correct type of collection for the stream defaults.

Doing so clears this warning:

```
coalesce.go:220: warning: cannot overwrite table with non table for kong.proxy.stream (map[])
coalesce.go:220: warning: cannot overwrite table with non table for kong.proxy.stream (map[])
```

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
