### PR TITLE
Require Gateway APIs for related perms and release 2.8.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.8.1
+
 ### Fixed
 
 * Fixed the stream default type, which should have been an empty array, not an

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,6 +8,9 @@
   empty map. This had no effect on chart behavior, but resulted in warning
   messages when user values.yamls contained non-empty stream configuration.
   ([594](https://github.com/Kong/charts/pull/594))
+* Gateway API permissions are no longer created if Gateway API CRDs are not
+  installed on the cluster. This would block installs by non-super admin users.
+  ([595](https://github.com/Kong/charts/pull/595))
 
 ## 2.8.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.8.0
+version: 2.8.1
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1056,6 +1056,7 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   - get
   - patch
   - update
+{{- if (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") -}}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -1095,6 +1096,7 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   - get
   - list
   - watch
+{{- end -}}
 - apiGroups:
   - networking.internal.knative.dev
   resources:
@@ -1150,6 +1152,7 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   - get
   - patch
   - update
+{{- if (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") -}}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -1165,6 +1168,7 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   verbs:
   - get
   - update
+{{- end -}}
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
Only create Gateway APIs rules in RBAC roles if Gateway API CRDs are present on the cluster. This avoids installation failures when installers lack super-admin, and will not have permission to create roles that can access these resources.

Releases 2.8.1 with this and the other pending hotfix.

Kubernetes RBAC limits the role creation permission to creating roles that the account used to create the role already has itself. Roles are very unlikely to include permissions for Gateway APIs if Gateway API CRDs are not installed.

Reported in community Slack channel https://kubernetes.slack.com/archives/CDCA87FRD/p1652461006349149

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
