### PR TITLE
fix(rbac) remove unwanted newline chomp and release 2.8.2

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,6 +8,13 @@ Nothing yet.
 
 ### Fixed
 
+* Fixed an unwanted newline chomp in fix PR #595.
+  ([594](https://github.com/Kong/charts/pull/594))
+
+## 2.8.1
+
+### Fixed
+
 * Fixed the stream default type, which should have been an empty array, not an
   empty map. This had no effect on chart behavior, but resulted in warning
   messages when user values.yamls contained non-empty stream configuration.

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.8.1
+version: 2.8.2
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1096,7 +1096,7 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   - get
   - list
   - watch
-{{- end -}}
+{{- end }}
 - apiGroups:
   - networking.internal.knative.dev
   resources:
@@ -1168,7 +1168,7 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   verbs:
   - get
   - update
-{{- end -}}
+{{- end }}
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
Templates are tricky and Kubernetes is perhaps overly eager to parse invalid YAML like this:

```
  - configuration.konghq.com
  resources:
  - kongclusterplugins/status
  verbs:
  - get
  - patch
  - update- apiGroups:
  - networking.k8s.io
  resources:
  - ingressclasses
  verbs:
  - get
  - list
  - watch
```

#### Special notes for your reviewer:
Reviewed container logs this time :facepalm: 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
