### PR TITLE
Disable jobs flag

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-Nothing yet.
+* Added option to disable test job pods.
+  [#598](https://github.com/Kong/charts/issues/598)
 
 ## 2.9.0
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -726,6 +726,7 @@ kong:
 | deployment.serviceAccount.create   | Create Service Account for the Deployment / Daemonset and the migrations              | `true`              |
 | deployment.serviceAccount.name     | Name of the Service Account, a default one will be generated if left blank.           | ""                  |
 | deployment.serviceAccount.annotations | Annotations for the Service Account                                                | {}                  |
+| deployment.test.enabled            | Enable creation of test resources for use with "helm test"                            | `false`             |
 | autoscaling.enabled                | Set this to `true` to enable autoscaling                                              | `false`             |
 | autoscaling.minReplicas            | Set minimum number of replicas                                                        | `2`                 |
 | autoscaling.maxReplicas            | Set maximum number of replicas                                                        | `5`                 |

--- a/charts/kong/templates/tests/test-jobs.yaml
+++ b/charts/kong/templates/tests/test-jobs.yaml
@@ -1,3 +1,4 @@
+{{- if  .Values.deployment.test.enabled }}
 ---
 apiVersion: v1
 kind: Pod
@@ -43,3 +44,4 @@ spec:
       command:
         - curl
         - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin-httproute"
+{{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
This adds a conditional option to disable test jobs from running. The test jobs are currently formatted to look at the release name `{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin` with kong-proxy being hard coded. There are cases where the service name does not match that url resulting in unlimited restarts on the test pods. For example, if the Helm `nameOverride` value is used or if the service is created by something outside of the chart (Terraform).
#### Which issue this PR fixes
  - fixes #598 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
