### PR TITLE
feat(deployment) Add cmd / args to deployment.yaml

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added `deployment.kong.args` and `deployment.kong.args` options for Proxy container
+  ([601](https://github.com/Kong/charts/pull/601))
 * Added terminationDelaySeconds for Ingress Controller.
   ([597](https://github.com/Kong/charts/pull/597))
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -717,6 +717,8 @@ kong:
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
+| deployment.kong.args               | Optionally override args field in proxy container                                     |                     |
+| deployment.kong.command            | Optionally override cmd field in proxy container                                      |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
 | deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |
 | deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -119,6 +119,14 @@ spec:
       - name: "proxy"
         image: {{ include "kong.getRepoTag" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.deployment.kong.args }}
+        args:
+        {{ .Values.deployment.kong.args | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .Values.deployment.kong.command }}
+        command:
+        {{ .Values.deployment.kong.command | toYaml | nindent 10 }}
+        {{- end }}
         securityContext:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }}
         env:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -15,6 +15,14 @@
 
 deployment:
   kong:
+    ## Optionally supply args for the Kong container to use. Note that by default, the kong image's
+    # default ENTRYPOINT will be used
+    # args: ["docker-start"]
+
+    ## Optionally supply a command for the Kong container to use. Note that by default, the kong image's
+    # default CMD will be used
+    # command: ["kong"]
+
     # Enable or disable Kong itself
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds two new fields to the `deployment.yaml` manifest (`command` and `args`) which optionally allows users of this chart to override the defaults provided by the docker image's `CMD` and `ENTRYPOINT` directives.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
