### PR TITLE
Release Kong 2.9.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,8 +2,17 @@
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.9.0
+
 * Added terminationDelaySeconds for Ingress Controller.
   ([597](https://github.com/Kong/charts/pull/597))
+* Made KNative permissions conditional on CRD availability.
+
+### Fixed
+
+* Removed KNative permission from the Gateway permissions set.
 
 ## 2.8.1
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.8.2
+version: 2.9.0
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1057,7 +1057,7 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   - get
   - patch
   - update
-{{- if (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") -}}
+{{- if (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") }}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -1089,6 +1089,8 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   verbs:
   - get
   - update
+{{- end }}
+{{- if (.Capabilities.APIVersions.Has "networking.internal.knative.dev/v1alpha1") }}
 - apiGroups:
   - networking.internal.knative.dev
   resources:
@@ -1097,7 +1099,6 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   - get
   - list
   - watch
-{{- end }}
 - apiGroups:
   - networking.internal.knative.dev
   resources:
@@ -1106,6 +1107,7 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   - get
   - patch
   - update
+{{- end }}
 - apiGroups:
   - networking.k8s.io
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
Releases 2.9, which includes the termination field for the controller and a gate for whether we create KNative permissions. Similar to https://github.com/Kong/kubernetes-ingress-controller/pull/2529 I expect that should cause issues for most non-admin users--not sure why the original report that had trouble with GWAPI didn't also have issues with that (they were a KNative user, I guess).

Manual checking in [rbac.txt](https://github.com/Kong/charts/files/8818876/rbac.txt). An earlier run found the issue with the `if` chomp.

#### Which issue this PR fixes
- One of the Knative permissions was accidentally under the Gateway condition
- The Gateway `if` chomped both newlines which should have broken other stuff earlier and definitely broke KNative permissions with the change. Now it does not chomp the following Newline.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
