### PR TITLE
chore(docs) fix changelog version

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -14,7 +14,7 @@ Nothing yet.
 
 * Removed KNative permission from the Gateway permissions set.
 
-## 2.8.1
+## 2.8.2
 
 ### Fixed
 


### PR DESCRIPTION
Forgot to update the version header when doing the 2.8.2 changelog :facepalm: 