### PR TITLE
Release Kong 2.9.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Nothing yet.
 
+## 2.9.1
+
+### Fixed
+
+* Fixed another unwanted newline chomp that broke GatewayClass
+  permissions.
+
 ## 2.9.0
 
 * Added terminationDelaySeconds for Ingress Controller.

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.9.0
+version: 2.9.1
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1155,7 +1155,7 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   - get
   - patch
   - update
-{{- if (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") -}}
+{{- if (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") }}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:

--- a/charts/kong/templates/tests/test-jobs.yaml
+++ b/charts/kong/templates/tests/test-jobs.yaml
@@ -17,21 +17,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ .Release.Name }}-test-ingress-v1beta1"
-  annotations:
-    "helm.sh/hook": test
-spec:
-  restartPolicy: OnFailure
-  containers:
-    - name: "{{ .Release.Name }}-curl"
-      image: curlimages/curl
-      command:
-        - curl
-        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin-v1beta1"
----
-apiVersion: v1
-kind: Pod
-metadata:
   name: "{{ .Release.Name }}-test-httproute"
   annotations:
     "helm.sh/hook": test
@@ -42,4 +27,4 @@ spec:
       image: curlimages/curl
       command:
         - curl
-        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin-httproute"
+        - "http://{{ .Release.Name }}-kong-proxy.{{ .Release.Namespace }}.svc.cluster.local/httproute"

--- a/charts/kong/templates/tests/test-resources.yaml
+++ b/charts/kong/templates/tests/test-resources.yaml
@@ -77,7 +77,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: "/httpbin-httproute"
+            value: "/httproute"
       backendRefs:
         - name: "{{ .Release.Name }}-httpbin"
           port: 80


### PR DESCRIPTION
#### What this PR does / why we need it:
Per @gAmUssA there was yet more breakage in Gateway RBAC. "valid" YAML with unchomped newlines remains the bane of my existence. For comparison before/after: [test.txt](https://github.com/Kong/charts/files/8856071/test.txt)

Hopefully also avoid similar errors in the future. I thought this was not caught because we had no Gateway tests in the chart, but we _did_ already have Gateway tests in the chart. On review of the tests and their very successful logs, it looks like many of the tests were happily satisfied by the first test resource because of Kong prefix handling behavior.

#### Special notes for your reviewer:

[testrun.txt](https://github.com/Kong/charts/files/8856093/testrun.txt) was the example run that should have failed but didn't.

@shaneutt minor thing that still irks me there is that I'm fairly certain this does not include the container logs from the test install--I'd also wanted to check whether the Gateway flag was enabled (review of the test script says it should be) but found that there were no logs showing that the gatewayclasses controller was enabled (and presumably failing). Is there a way that we can use a chart-testing case (which will log container logs automatically) for the instance we run `helm test` against, or failing that some other way we can dump the container logs to stderr for GitHub to read?

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
