### PR TITLE
Support cluster-scoped resources when using watchNamespaces

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-Nothing yet.
+### Improvements
+
+* Added ClusterRole for cluster-scoped resources when using watchNamespaces.
+  [#611](https://github.com/Kong/charts/issues/611)
 
 ## 2.11.0
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -532,27 +532,17 @@ resource.
 ### Removing cluster-scoped permissions
 
 You can limit the controller's access to allow it to only watch specific
-namespaces for resources. By default, the controller watches all namespaces.
-Limiting access requires several changes to configuration:
+namespaces for namespaced resources. By default, the controller watches all
+namespaces. Limiting access requires several changes to configuration:
 
 - Set `ingressController.watchNamespaces` to a list of namespaces you want to
   watch. The chart will automatically generate roles for each namespace and
   assign them to the controller's service account.
-- Set `ingressController.env.enable_controller_kongclusterplugin=false` and
-  `ingressController.env.enable_controller_ingress_class_networkingv1=false`.
-  These are cluster-scoped resources, and controllers with no ClusterRole
-  cannot access them.
 - Optionally set `ingressContrller.installCRDs=false` if your user role (the
   role you use when running `helm install`, not the controller service
   account's role) does not have access to get CRDs. By default, the chart
   attempts to look up the controller CRDs for [a legacy behavior
   check](#crd-management).
-
-Because there is no namespaced version of IngressClass, controllers without
-cluster-scoped permissions cannot access them. The controller will rely
-entirely on whether the ingress class annotation or `ingressClassName` value
-matches the value set by `--ingress-class` or `CONTROLLER_INGRESS_CLASS` to
-determine which Ingresses it should use.
 
 ### Using a DaemonSet
 

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -2,12 +2,15 @@
 # - ingressController deploys with a database
 # - stream listens work
 # - a mixture of controller, Kong, and shared volumes successfully mount
+# - watchNamespaces is set
 ingressController:
   enabled: true
   env:
     anonymous_reports: "false"
   customEnv:
     TZ: "Europe/Berlin"
+  watchNamespaces:
+  - default
 postgresql:
   enabled: true
   auth:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1162,13 +1162,6 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
 */}}
 {{- define "kong.kubernetesRBACClusterRules" -}}
 - apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - list
-  - watch
-- apiGroups:
   - configuration.konghq.com
   resources:
   - kongclusterplugins

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -369,7 +369,6 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- if (not (eq (len .Values.ingressController.watchNamespaces) 0)) }}
   {{- $_ := set $autoEnv "CONTROLLER_WATCH_NAMESPACE" (.Values.ingressController.watchNamespaces | join ",") -}}
-  {{- $_ := set $autoEnv "CONTROLLER_ENABLE_CONTROLLER_KONGCLUSTERPLUGIN" false -}}
 {{- end }}
 
 {{/*

--- a/charts/kong/templates/controller-rbac-resources.yaml
+++ b/charts/kong/templates/controller-rbac-resources.yaml
@@ -140,6 +140,30 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "kong.serviceAccountName" $ }}
     namespace: {{ template "kong.namespace" $ }}
-{{- end -}}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+  name: {{ template "kong.fullname" . }}
+rules:
+{{ include "kong.kubernetesRBACClusterRules" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "kong.fullname" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "kong.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "kong.serviceAccountName" . }}
+    namespace: {{ template "kong.namespace" . }}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -470,8 +470,8 @@ ingressController:
   # when no namespaces are set, the controller watches all namespaces and uses a
   # ClusterRole to grant access to Kubernetes resources. When you list specific
   # namespaces, the controller will watch those namespaces only and will create
-  # namespaced-scoped Roles for each of them. Note that watching specific namespaces
-  # disables KongClusterPlugin usage, as KongClusterPlugins only exist as cluster resources.
+  # namespaced-scoped Roles for each of them. The controller will still use a
+  # ClusterRole for cluster-scoped resources.
   # Requires controller 2.0.0 or newer.
   watchNamespaces: []
 


### PR DESCRIPTION
#### What this PR does / why we need it:
When watchNamespaces is non-empty, create a ClusterRole that contains
cluster-scoped resources only.

Remove endpoints from the cluster resource template. They appear to have
been included by mistake.

Configure one of the CI values to use watchNamespaces.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #607

When watchNamespaces was originally developed, the only cluster-scoped resource we had was KongClusterPlugin, and KongPlugin could substitute for it with an acceptable loss of functionality. Since, CNCF has introduced IngressClass and GatewayClass, which have no namespace-scoped equivalent. We need to read these to properly implement the v1 Ingress and vAny Gateway specs.

#### Special notes for your reviewer:
Ready for review, but do not merge pending discussion with product and field team stakeholders in KUBE-61.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
