### PR TITLE
fix(admission): change admissionWebhook.failurePolicy value to Ignore

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 * Added option to disable test job pods.
   [#598](https://github.com/Kong/charts/issues/598)
-* Admission failure policy is not set to `Ignore` by default.
+* Changed default admission failure policy from `Fail` to `Ignore`.
+  [#612](https://github.com/Kong/charts/issues/612)
 
 ## 2.9.1
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added option to disable test job pods.
   [#598](https://github.com/Kong/charts/issues/598)
+* Admission failure policy is not set to `Ignore` by default.
 
 ## 2.9.1
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -492,7 +492,7 @@ ingressController:
 
   admissionWebhook:
     enabled: false
-    failurePolicy: Fail
+    failurePolicy: Ignore
     port: 8080
     certificate:
       provided: false


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
[kubernetes-ingress-controller/issues/2501](https://github.com/Kong/kubernetes-ingress-controller/issues/2501)

#### Special notes for your reviewer:
As suggested in [kubernetes-ingress-controller/issues/2501](https://github.com/Kong/kubernetes-ingress-controller/issues/2501) PR was tested manually:

##### Testing done:
1. Verified that unique constraint of secrets does trigger failure when admission failure policy is `Ignore` as described in [kubernetes-ingress-controller/issues/2431. Verified that `Fail` policy prevents config from being applied
](https://github.com/Kong/kubernetes-ingress-controller/issues/2431
)
2. Verified that when controller is unreachable, the config is accepted if policy is `Ignore`.

- Installed kic with admission failure policy enabled, failure policy `Ignore` and faked the controller connectivity problem by setting `CONTROLLER_ADMISSION_WEBHOOK_LISTEN` to `off` in helm charts.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
