### PR TITLE
doc(*) remove legacy installCRDs examples

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -87,7 +87,7 @@ To install Kong:
 $ helm repo add kong https://charts.konghq.com
 $ helm repo update
 
-$ helm install kong/kong --generate-name --set ingressController.installCRDs=false
+$ helm install kong/kong --generate-name
 ```
 
 ## Uninstall
@@ -675,7 +675,7 @@ section of `values.yaml` file:
 | image.effectiveSemver                   | Version of the ingress controller used for version-specific features when image.tag is not a valid semantic version                                      |                                    |
 | readinessProbe                          | Kong ingress controllers readiness probe                                                                                                                 |                                    |
 | livenessProbe                           | Kong ingress controllers liveness probe                                                                                                                  |                                    |
-| installCRDs                             | Creates managed CRDs.                                                                                                                                    | false                              |
+| installCRDs                             | Legacy toggle for Helm 2-style CRD management. Should not be set [unless necessary due to cluster permissions](#removing-cluster-scoped-permissions).    | false                              |
 | env                                     | Specify Kong Ingress Controller configuration via environment variables                                                                                  |                                    |
 | customEnv                               | Specify custom environment variables (without the CONTROLLER_ prefix)                                                                                    |                                    |
 | ingressClass                            | The name of this controller's ingressClass                                                                                                               | kong                               |

--- a/charts/kong/ci/default-values.yaml
+++ b/charts/kong/ci/default-values.yaml
@@ -7,4 +7,3 @@ env:
 ingressController:
   env:
     anonymous_reports: "false"
-  installCRDs: false

--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -13,4 +13,3 @@ ingressController:
     anonymous_reports: "false"
   image:
     unifiedRepoTag: kong/kubernetes-ingress-controller:2.0.2
-  installCRDs: false

--- a/charts/kong/ci/test1-values.yaml
+++ b/charts/kong/ci/test1-values.yaml
@@ -7,7 +7,6 @@ autoscaling:
 # - ingressController deploys without a database (default)
 ingressController:
   enabled: true
-  installCRDs: false
 # - webhook is enabled and deploys
   admissionWebhook:
     enabled: true

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -4,7 +4,6 @@
 # - a mixture of controller, Kong, and shared volumes successfully mount
 ingressController:
   enabled: true
-  installCRDs: false
   env:
     anonymous_reports: "false"
   customEnv:

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -2,7 +2,6 @@
 # - disable ingress controller
 ingressController:
   enabled: false
-  installCRDs: false
 # - disable DB for kong
 env:
   anonymous_reports: "off"

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -2,7 +2,6 @@
 # - disable ingress controller
 ingressController:
   enabled: false
-  installCRDs: false
   env:
     anonymous_reports: "false"
 

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -8,7 +8,6 @@
 
 ingressController:
   enabled: true
-  installCRDs: false
   env:
     anonymous_reports: "false"
 postgresql:

--- a/charts/kong/example-values/README.md
+++ b/charts/kong/example-values/README.md
@@ -1,9 +1,7 @@
 # Example values.yaml configurations
 
 The YAML files in this directory provide basic example configurations for
-common Kong deployment scenarios on Kubernetes. All examples assume Helm 3 and
-disable legacy CRD templates (`ingressController.installCRDs: false`; you must
-change this value to `true` if you use Helm 2).
+common Kong deployment scenarios on Kubernetes.
 
 * [minimal-kong-controller.yaml](minimal-kong-controller.yaml) installs Kong
   open source with the ingress controller in DB-less mode.
@@ -56,11 +54,3 @@ change this value to `true` if you use Helm 2).
 
 All Enterprise examples require some level of additional user configuration to
 install properly. Read the comments at the top of each file for instructions.
-
-Examples are designed for use with Helm 3, and disable Helm 2 CRD installation.
-If you use Helm 2, you will need to enable it:
-
-```
-helm install kong/kong -f /path/to/values.yaml \
-  --set ingressController.installCRDs=true
-```

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -191,7 +191,6 @@ postgresql:
 
 ingressController:
   enabled: true
-  installCRDs: false
   env:
     kong_admin_token:
       valueFrom:

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -54,4 +54,3 @@ postgresql:
 
 ingressController:
   enabled: true
-  installCRDs: false

--- a/charts/kong/example-values/minimal-kong-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-controller.yaml
@@ -10,4 +10,3 @@ env:
 
 ingressController:
   enabled: true
-  installCRDs: false

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -31,7 +31,6 @@ env:
 
 ingressController:
   enabled: true
-  installCRDs: false
 
 proxy:
   # Enable creating a Kubernetes service for the proxy

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
@@ -43,7 +43,6 @@ postgresql:
 
 ingressController:
   enabled: false
-  installCRDs: false
 
 enterprise:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
@@ -26,7 +26,6 @@ secretVolumes:
 
 ingressController:
   enabled: false
-  installCRDs: false
 
 enterprise:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -43,4 +43,3 @@ postgresql:
 
 ingressController:
   enabled: false
-  installCRDs: false

--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -30,4 +30,3 @@ secretVolumes:
 
 ingressController:
   enabled: false
-  installCRDs: false

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -27,4 +27,3 @@ postgresql:
 
 ingressController:
   enabled: false
-  installCRDs: false


### PR DESCRIPTION
#### What this PR does / why we need it:
Remove `installCRDs` from examles and CI and clarify docs a bit. There is one specific circumstance that requires this setting and it should not be present in general-purpose examples.

#### Special notes for your reviewer:
Triggered by report that some user had accidentally set this prior to 2.9 and had originally installed with it set to `true`, deleting CRDs on update to 2.9. These seem like the only remaining place they could have gotten the idea to set it from.

Docs only, no changelog.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
