### PR TITLE
Add manual token mount and release 2.10

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,10 +2,19 @@
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.10.0
+
+### Added
+
 * Added option to disable test job pods.
   [#598](https://github.com/Kong/charts/issues/598)
 * Changed default admission failure policy from `Fail` to `Ignore`.
   [#612](https://github.com/Kong/charts/issues/612)
+* ServiceAccount tokens are now only mounted in the controller container to
+  limit attack surface.
+  [#619](https://github.com/Kong/charts/issues/619)
 
 ## 2.9.1
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.9.1
+version: 2.10.0
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -60,6 +60,13 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Create the name of the secret for service account token to use
+*/}}
+{{- define "kong.serviceAccountTokenName" -}}
+{{ include "kong.serviceAccountName" . }}-token
+{{- end -}}
+
+{{/*
 Create Ingress resource for a Kong service
 */}}
 {{- define "kong.ingress" -}}
@@ -619,6 +626,11 @@ The name of the service used for the ingress controller's validation webhook
 {{- if .Values.ingressController.admissionWebhook.enabled }}
   - name: webhook-cert
     mountPath: /admission-webhook
+    readOnly: true
+{{- end }}
+{{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
+  - name: {{ template "kong.serviceAccountTokenName" . }}
+    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
     readOnly: true
 {{- end }}
   {{- include "kong.userDefinedVolumeMounts" .Values.ingressController | nindent 2 }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -630,7 +630,16 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
   - name: {{ template "kong.serviceAccountTokenName" . }}
-    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+    mountPath: /var/run/secrets/kubernetes.io/serviceaccount/token
+	subPath: token
+    readOnly: true
+  - name: {{ template "kong.serviceAccountTokenName" . }}
+    mountPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+	subPath: ca.crt
+    readOnly: true
+  - name: podinfo
+    mountPath: /var/run/secrets/kubernetes.io/serviceaccount/namespace
+	subPath: namespace
     readOnly: true
 {{- end }}
   {{- include "kong.userDefinedVolumeMounts" .Values.ingressController | nindent 2 }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -256,11 +256,11 @@ Parameters: takes a service (e.g. .Values.proxy) as its argument and returns KON
   {{- $portMaps := list -}}
 
   {{- if .http.enabled -}}
-		{{- $portMaps = append $portMaps (printf "%d:%d" (int64 .http.servicePort) (int64 .http.containerPort)) -}}
+        {{- $portMaps = append $portMaps (printf "%d:%d" (int64 .http.servicePort) (int64 .http.containerPort)) -}}
   {{- end -}}
 
   {{- if .tls.enabled -}}
-		{{- $portMaps = append $portMaps (printf "%d:%d" (int64 .tls.servicePort) (int64 .tls.containerPort)) -}}
+        {{- $portMaps = append $portMaps (printf "%d:%d" (int64 .tls.servicePort) (int64 .tls.containerPort)) -}}
   {{- end -}}
 
   {{- $portMapsString := ($portMaps | join ", ") -}}
@@ -610,8 +610,8 @@ The name of the service used for the ingress controller's validation webhook
   imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{/* disableReadiness is a hidden setting to drop this block entirely for use with a debugger
      Helm value interpretation doesn't let you replace the default HTTP checks with any other
-	 check type, and all HTTP checks freeze when a debugger pauses operation.
-	 Setting disableReadiness to ANY value disables the probes.
+     check type, and all HTTP checks freeze when a debugger pauses operation.
+     Setting disableReadiness to ANY value disables the probes.
 */}}
 {{- if (not (hasKey .Values.ingressController "disableProbes")) }}
   readinessProbe:
@@ -631,15 +631,15 @@ The name of the service used for the ingress controller's validation webhook
 {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
   - name: {{ template "kong.serviceAccountTokenName" . }}
     mountPath: /var/run/secrets/kubernetes.io/serviceaccount/token
-	subPath: token
+    subPath: token
     readOnly: true
   - name: {{ template "kong.serviceAccountTokenName" . }}
     mountPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-	subPath: ca.crt
+    subPath: ca.crt
     readOnly: true
   - name: podinfo
     mountPath: /var/run/secrets/kubernetes.io/serviceaccount/namespace
-	subPath: namespace
+    subPath: namespace
     readOnly: true
 {{- end }}
   {{- include "kong.userDefinedVolumeMounts" .Values.ingressController | nindent 2 }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -65,10 +65,8 @@ spec:
       {{- end }}
       {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
       serviceAccountName: {{ template "kong.serviceAccountName" . }}
-      automountServiceAccountToken: true
-      {{- else }}
+      {{- end }}
       automountServiceAccountToken: false
-      {{ end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range .Values.image.pullSecrets }}
@@ -286,4 +284,14 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 8 -}}
       {{- include "kong.userDefinedVolumes" . | nindent 8 -}}
+      {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
+        - name: {{ template "kong.serviceAccountTokenName" . }}
+          secret:
+            secretName: {{ template "kong.serviceAccountTokenName" . }}
+            items:
+            - key: token
+              path: token
+            - key: ca.crt
+              path: ca.crt
+      {{- end }}
 {{- end }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -293,5 +293,11 @@ spec:
               path: token
             - key: ca.crt
               path: ca.crt
+        - name: podinfo
+          downwardAPI:
+            items:
+            - path: "namespace"
+              fieldRef:
+                fieldPath: metadata.namespace
       {{- end }}
 {{- end }}

--- a/charts/kong/templates/secret-sa-token.yaml
+++ b/charts/kong/templates/secret-sa-token.yaml
@@ -1,0 +1,10 @@
+{{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "kong.serviceAccountTokenName" . }} 
+  namespace: {{ template "kong.namespace" . }}
+  annotations:
+    kubernetes.io/service-account.name: {{ template "kong.serviceAccountName" . }}
+type: kubernetes.io/service-account-token
+{{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds the manual token mount with fixes from https://github.com/Kong/kubernetes-ingress-controller/pull/2612 on top.

Releases 2.10.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
