### PR TITLE
Fix token format and release 2.10.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Nothing yet.
 
+## 2.10.1
+
+### Fixed
+
+* Updated manual ServiceAccount Secret mount format for compatibility with
+  Kuma.
+
 ## 2.10.0
 
 ### Added

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.10.0
+version: 2.10.1
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -630,16 +630,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
   - name: {{ template "kong.serviceAccountTokenName" . }}
-    mountPath: /var/run/secrets/kubernetes.io/serviceaccount/token
-    subPath: token
-    readOnly: true
-  - name: {{ template "kong.serviceAccountTokenName" . }}
-    mountPath: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    subPath: ca.crt
-    readOnly: true
-  - name: podinfo
-    mountPath: /var/run/secrets/kubernetes.io/serviceaccount/namespace
-    subPath: namespace
+    mountPath: /var/run/secrets/kubernetes.io/serviceaccount
     readOnly: true
 {{- end }}
   {{- include "kong.userDefinedVolumeMounts" .Values.ingressController | nindent 2 }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -293,11 +293,7 @@ spec:
               path: token
             - key: ca.crt
               path: ca.crt
-        - name: podinfo
-          downwardAPI:
-            items:
-            - path: "namespace"
-              fieldRef:
-                fieldPath: metadata.namespace
+            - key: namespace
+              path: namespace
       {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove the separate SA token/namespace mounts and instead mount the `namespace` key in the SA token we mount for the controller container. This matches the format used in the automount mount. Kuma [has logic to find the token on a per-container basis without automount on the Pod](https://github.com/kumahq/kuma/blob/5e12d423e9a6f3f6f9b5eefaed4a8759395c14b7/pkg/plugins/runtime/k8s/webhooks/injector/injector.go#L390-L401), but it requires the mount use [its standard path](https://github.com/kumahq/kuma/blob/5e12d423e9a6f3f6f9b5eefaed4a8759395c14b7/pkg/plugins/runtime/k8s/webhooks/injector/injector.go#L32) to find it.

We didn't need the separate downward API mount, since the namespace key is already populated in the SAT.

This is easier than the ContainerPatch since we don't need a new template that requires CRD availability checks.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #620 

#### Special notes for your reviewer:

Manual testing pending https://github.com/Kong/kubernetes-testing-framework/issues/303: [testing.txt](https://github.com/Kong/charts/files/9003924/testing.txt). I had some concern that whatever updates the Secret to stuff the token into it would overwrite the entire key set and remove the namespace key, but it is still present when checking after.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
