### PR TITLE
Fix Kuma more and release 2.10.2

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Nothing yet.
 
+## 2.10.2
+
+### Fixed
+
+* Kuma now also mounts ServiceAccount tokens on releases without a controller
+  container.
+
 ## 2.10.1
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.10.1
+version: 2.10.2
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
+        kuma.io/service-account-token-volume: {{ template "kong.serviceAccountTokenName" . }}
+        {{- end }}
         {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
         {{- if .Values.dblessConfig.config }}
         checksum/dbless.config: {{ toYaml .Values.dblessConfig.config | sha256sum }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Yet more fixes for #620, to address the case where there's no controller container (split/standalone instances and hybrid data planes) and Kuma cannot automatically determine the Secret based on the existing mount in the controller container.

Release 2.10.2.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #620 (third time's a charm)

#### Special notes for your reviewer:
This annotation is actually scheduled for deprecation in favor of ContainerPatch, but [that won't work for this yet](https://github.com/kumahq/kuma/issues/4279#issuecomment-1170421217). IMO we should just keep the annotation, but that's up to the Kuma devs.

My original attempt to use ContainerPatch, which works as long as you don't have other Kuma container mounts, is 
[containerpatch.diff.txt](https://github.com/Kong/charts/files/9014120/containerpatch.diff.txt)

Manual validation:
[testing.txt](https://github.com/Kong/charts/files/9014281/testing.txt)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
