### PR TITLE
Add Kuma to integration tests

### DIFF
--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -78,9 +78,13 @@ ktf 1>/dev/null
 # Create Testing Environment
 # ------------------------------------------------------------------------------
 
-ktf environments create --name "${TEST_ENV_NAME}" --addon metallb
+ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma
 
 kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -
+
+# The steps necessary to get this to work aren't obvious and it's not something
+# the test cares about, so just disable it
+kubectl patch validatingwebhookconfigurations.admissionregistration.k8s.io kuma-validating-webhook-configuration --patch '{"webhooks": [{"name": "validate.gateway.networking.k8s.io", "failurePolicy": "Ignore"}]}'
 
 echo "INFO: Updating helm dependencies"
 helm dependency update charts/kong/


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds Kuma to the integration tests

#### Special notes for your reviewer:
Kuma installs a webhook that apparently tries to piggyback off the upstream Gateway webhook for HTTPRoute and such. Not quite sure why (if present, it'll run on its own), but in any case I wasn't able to get it to run: it would complain about being unable to find resources or not trusting certificates without a lot of debug information. Since I don't care about it for the purpose of tests, I've changed its policy.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
