### PR TITLE
chore(chart) clarify comment

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -649,10 +649,12 @@ livenessProbe:
 lifecycle:
   preStop:
     exec:
-      # Note kong quit has a default timeout of 10 seconds
+      # Note kong quit has a default timeout of 10 seconds, and a default
+      # wait of 0 seconds.
       command:
         - kong
         - quit
+        - '--timeout=10'
         - '--wait=15'
 
 # Sets the termination grace period for pods spawned by the Kubernetes Deployment.

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -654,7 +654,6 @@ lifecycle:
       command:
         - kong
         - quit
-        - '--timeout=10'
         - '--wait=15'
 
 # Sets the termination grace period for pods spawned by the Kubernetes Deployment.

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -649,8 +649,8 @@ livenessProbe:
 lifecycle:
   preStop:
     exec:
-      # Note kong quit has a default timeout of 10 seconds, and a default
-      # wait of 0 seconds.
+      # kong quit has a default timeout of 10 seconds, and a default wait of 0 seconds.
+      # Note: together they should be less than the terminationGracePeriodSeconds setting below.
       command:
         - kong
         - quit


### PR DESCRIPTION
The comment might have let a casual reader believe the timeout is configured using the `--wait` flag. This makes it explicit that the 2 are different and we're only overriding the wait.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
      skipped this, since its only comments
- [ ] New or modified sections of values.yaml are documented in the README.md
      skipped this, not applicable
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)

