### PR TITLE
chore: bump controller version to 2.4

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,14 +1,11 @@
 # Changelog
 
-## 2.10.3
-
-### Fixed
-
-* Fix URL for more detail on Command Line Arguements / environment variables for Helm.
+## Unreleased
 
 ### Improvements
 
-* Bump controller version to 2.4 [#627](https://github.com/Kong/charts/issues/627)
+* Bump controller version to 2.4.
+  [#627](https://github.com/Kong/charts/issues/627)
 
 ## 2.10.2
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## Unreleased
+## 2.10.3
+
+### Fixed
 
 * Fix URL for more detail on Command Line Arguements / environment variables for Helm.
+
+### Improvements
+
+* Bump controller version to 2.4 [#627](https://github.com/Kong/charts/issues/627)
 
 ## 2.10.2
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -10,7 +10,8 @@ maintainers:
   email: traines@konghq.com
 name: kong
 sources:
-version: 2.10.2
+- https://github.com/Kong/charts/tree/main/charts/kong
+version: 2.10.3
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.10.3
+version: 2.10.2
 appVersion: "2.8"
 dependencies:
 - name: postgresql

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -449,7 +449,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "2.3"
+    tag: "2.4"
     # Optionally set a semantic version for version-gated features. This can normally
     # be left unset. You only need to set this if your tag is not a semver string,
     # such as when you are using a "next" tag. Set this to the effective semantic


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps KIC version to "2.4"

#### Special notes for your reviewer:

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "2.11.0" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
