### PR TITLE
chore(ci) bump CI dependency versions

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -17,14 +17,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.8.1
+          version: v3.9.0
 
       - name: Add Bitnami
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9.7
+          python-version: "3.10"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
@@ -41,7 +41,7 @@ jobs:
         run: ct lint --check-version-increment=false
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.3.0
         # if: steps.list-changed.outputs.changed == 'true'
         # TODO for some reason, the earlier chart-testing logic is never seeing any changes, though running it locally
         # does show changes. This remains a mystery between a lack of any debug logging, but simply running tests
@@ -63,7 +63,7 @@ jobs:
       - name: setup helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.8.1
+          version: v3.9.0
 
       - name: setup testing environment (kind-cluster)
         run: ./scripts/test-env.sh

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -17,14 +17,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.2.4
+          version: v3.9.0
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.10"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2.2.1
 
       - name: Run chart-testing (lint)
         run: ct lint
@@ -61,14 +61,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.2.4
+          version: v3.9.0
 
       - name: Add dependency chart repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Versions of CI dependencies had diverged across workflows, causing jobs run on main push to fail (it used an older Helm version than the PR job, and the older version lacks features KTF needs).

This bumps all the actions and such to their latest version across all jobs.