### PR TITLE
fix(env) change file logs to stdout/stderr

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Fixed Deployment missing if in case of empty tolerations 
   [#630](https://github.com/Kong/charts/issues/630)
+* Use stdout and stderr by default for all logs. Several were writing to prefix
+  directory files.
+  [#634](https://github.com/Kong/charts/issues/634)
 
 ### Improvements
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -668,6 +668,15 @@ the template that it itself is using form the above sections.
 
 {{- $_ := set $autoEnv "KONG_LUA_PACKAGE_PATH" "/opt/?.lua;/opt/?/init.lua;;" -}}
 
+{{- $_ := set $autoEnv "KONG_PROXY_ACCESS_LOG" "/dev/stdout" -}}
+{{- $_ := set $autoEnv "KONG_PROXY_STREAM_ACCESS_LOG" "/dev/stdout basic" -}}
+{{- $_ := set $autoEnv "KONG_ADMIN_ACCESS_LOG" "/dev/stdout" -}}
+{{- $_ := set $autoEnv "KONG_STATUS_ACCESS_LOG" "off" -}}
+{{- $_ := set $autoEnv "KONG_PROXY_ERROR_LOG" "/dev/stderr" -}}
+{{- $_ := set $autoEnv "KONG_PROXY_STREAM_ERROR_LOG" "/dev/stderr" -}}
+{{- $_ := set $autoEnv "KONG_ADMIN_ERROR_LOG" "/dev/stderr" -}}
+{{- $_ := set $autoEnv "KONG_STATUS_ERROR_LOG" "/dev/stderr" -}}
+
 {{- if .Values.ingressController.enabled -}}
   {{- $_ := set $autoEnv "KONG_KIC" "on" -}}
 {{- end -}}
@@ -717,6 +726,13 @@ the template that it itself is using form the above sections.
 {{- $_ := set $autoEnv "KONG_CLUSTER_LISTEN" (include "kong.listen" .Values.cluster) -}}
 
 {{- if .Values.enterprise.enabled }}
+  {{- $_ := set $autoEnv "KONG_PORTAL_API_ACCESS_LOG" "/dev/stdout" -}}
+  {{- $_ := set $autoEnv "KONG_PORTAL_GUI_ACCESS_LOG" "/dev/stdout" -}}
+  {{- $_ := set $autoEnv "KONG_ADMIN_GUI_ACCESS_LOG" "/dev/stdout" -}}
+  {{- $_ := set $autoEnv "KONG_PORTAL_API_ERROR_LOG" "/dev/stderr" -}}
+  {{- $_ := set $autoEnv "KONG_PORTAL_GUI_ERROR_LOG" "/dev/stderr" -}}
+  {{- $_ := set $autoEnv "KONG_ADMIN_GUI_ERROR_LOG" "/dev/stderr" -}}
+
   {{- $_ := set $autoEnv "KONG_ADMIN_GUI_LISTEN" (include "kong.listen" .Values.manager) -}}
   {{- if .Values.manager.ingress.enabled }}
     {{- $_ := set $autoEnv "KONG_ADMIN_GUI_URL" (include "kong.ingress.serviceUrl" .Values.manager.ingress) -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Default all logs to stderr/stdout or off. The Docker distributions hit most of these already, so some of these settings are redundant, but there are several that we never changed at build time.

#### Special notes for your reviewer:
Before:
```
bash-5.1$ grep access_log .kong_env
portal_api_access_log = /dev/stdout
proxy_stream_access_log = logs/access.log basic
portal_gui_access_log = logs/portal_gui_access.log
admin_gui_access_log = /dev/stdout
proxy_access_log = /dev/stdout
admin_access_log = /dev/stdout
status_access_log = off

bash-5.1$ grep error_log .kong_env 
portal_api_error_log = /dev/stderr
admin_gui_error_log = /dev/stderr
status_error_log = logs/status_error.log
proxy_stream_error_log = logs/error.log
admin_error_log = /dev/stderr
proxy_error_log = /dev/stderr
portal_gui_error_log = logs/portal_gui_error.log
```
After:
```
bash-5.1$ grep access_log .kong_env
portal_api_access_log = /dev/stdout
proxy_access_log = /dev/stdout
proxy_stream_access_log = /dev/stdout basic
status_access_log = off
portal_gui_access_log = /dev/stdout
admin_gui_access_log = /dev/stdout
admin_access_log = /dev/stdout

bash-5.1$ grep error_log .kong_env
portal_api_error_log = /dev/stderr
proxy_stream_error_log = /dev/stderr
status_error_log = /dev/stderr
admin_gui_error_log = /dev/stderr
portal_gui_error_log = /dev/stderr
admin_error_log = /dev/stderr
proxy_error_log = /dev/stderr
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
