### PR TITLE
feat(values) add fullnameOverride

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 * Bump controller version to 2.4.
   [#627](https://github.com/Kong/charts/issues/627)
+* Added `fullnameOverride` to override the normal resource name string.
+  [#635](https://github.com/Kong/charts/issues/635)
 
 ## 2.10.2
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -783,6 +783,8 @@ kong:
 | serviceMonitor.metricRelabelings   | ServiceMonitor metricRelabelings                                                      | `{}`                |
 | extraConfigMaps                    | ConfigMaps to add to mounted volumes                                                  | `[]`                |
 | extraSecrets                       | Secrets to add to mounted volumes                                                     | `[]`                |
+| nameOverride                       | Replaces "kong" in resource names, like "RELEASENAME-nameOverride" instead of "RELEASENAME-kong" | `""`                |
+| fullnameOverride                   | Overrides the entire resource name string                                             | `[]`                |
 
 **Note:** If you are using `deployment.hostNetwork` to bind to lower ports ( < 1024), which may be the desired option (ports 80 and 433), you also
 need to tweak the `containerSecurityContext` configuration as in the example:

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -784,7 +784,7 @@ kong:
 | extraConfigMaps                    | ConfigMaps to add to mounted volumes                                                  | `[]`                |
 | extraSecrets                       | Secrets to add to mounted volumes                                                     | `[]`                |
 | nameOverride                       | Replaces "kong" in resource names, like "RELEASENAME-nameOverride" instead of "RELEASENAME-kong" | `""`                |
-| fullnameOverride                   | Overrides the entire resource name string                                             | `[]`                |
+| fullnameOverride                   | Overrides the entire resource name string                                             | `""`                |
 
 **Note:** If you are using `deployment.hostNetwork` to bind to lower ports ( < 1024), which may be the desired option (ports 80 and 433), you also
 need to tweak the `containerSecurityContext` configuration as in the example:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -14,7 +14,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 
 {{- define "kong.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- default (printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-") .Values.fullnameOverride -}}
 {{- end -}}
 
 {{- define "kong.chart" -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a full name override. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #157 

#### Special notes for your reviewer:

Compare:

```
10:56:40-0700 esenin $ helm template --namespace default aaa /tmp/symkong -f ~/src/charts/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml --set fullnameOverride=ccc 2>/dev/null | grep -A2 "kind: Service" | head -3 
kind: ServiceAccount
metadata:
  name: ccc
10:56:57-0700 esenin $ helm template --namespace default aaa /tmp/symkong -f ~/src/charts/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml --set nameOverride=ccc 2>/dev/null | grep -A2 "kind: Service" | head -3 
kind: ServiceAccount
metadata:
  name: aaa-ccc
10:57:08-0700 esenin $ helm template --namespace default aaa /tmp/symkong -f ~/src/charts/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml 2>/dev/null | grep -A2 "kind: Service" | head -3 
kind: ServiceAccount
metadata:
  name: aaa-kong
```

`nameOverride` was originally entirely undocumented; it and this are now in the readme but I've left them out of values still.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
