### PR TITLE
feat(ci): add dependabot for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  labels:
+  - github_actions


### PR DESCRIPTION
#### What this PR does / why we need it:

To automate PRs for bumping Github Action dependencies.
