### PR TITLE
fix: remove terminationGracePeriodSeconds from KIC's container spec

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Use stdout and stderr by default for all logs. Several were writing to prefix
   directory files.
   [#634](https://github.com/Kong/charts/issues/634)
+* Remove `terminationGracePeriodSeconds` from KIC's container spec since this
+  field is only applicable for pods, not containers.
+  [#640](https://github.com/Kong/charts/issues/640)
 
 ### Improvements
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -623,7 +623,6 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
   resources:
 {{ toYaml .Values.ingressController.resources | indent 4 }}
-  terminationGracePeriodSeconds: {{ .Values.ingressController.terminationGracePeriodSecond }}
   volumeMounts:
 {{- if .Values.ingressController.admissionWebhook.enabled }}
   - name: webhook-cert

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -462,10 +462,6 @@ ingressController:
     effectiveSemver:
   args: []
 
-  # Sets the termination grace period for pods spawned by the Kubernetes Deployment.
-  # Ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution
-  terminationGracePeriodSeconds: 30
-
   # Specify individual namespaces to watch for ingress configuration. By default,
   # when no namespaces are set, the controller watches all namespaces and uses a
   # ClusterRole to grant access to Kubernetes resources. When you list specific


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR removes `terminationGracePeriodSeconds` from KIC's container spec (introduced in #597) since that field [is only applicable to pod spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#lifecycle).

#### Which issue this PR fixes

  - fixes #639

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
