### PR TITLE
fix(helpers) change proxy config on values.yaml from servicePort to h…

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -262,7 +262,7 @@ proxy:
   http:
     # Enable plaintext HTTP listen for the proxy
     enabled: true
-    servicePort: 80
+    hostPort: 80
     containerPort: 8000
     # Set a nodePort which is available if service type is NodePort
     # nodePort: 32080
@@ -272,7 +272,7 @@ proxy:
   tls:
     # Enable HTTPS listen for the proxy
     enabled: true
-    servicePort: 443
+    hostPort: 443
     containerPort: 8443
     # Set a target port for the TLS port in proxy service
     # overrideServiceTargetPort: 8000


### PR DESCRIPTION

#### What this PR does / why we need it:
This PR fix a configuration on values.yaml. The field servicePort on Proxy configuration doesn't exist on template deployment.yaml. The correct name is hostPort.

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
