### PR TITLE
docs(upgrade) Correct 2.4.0 upgrade with KIC enabled

### DIFF
--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -150,19 +150,17 @@ proxy configuration. We recommend you establish an active maintenance window
 under which to perform this upgrade and inform users and stakeholders so as to
 avoid unexpected disruption.
 
-First, run an upgrade that keeps the current version, but disables the ingress
-controller:
+First, run an update on your deployment that disables the ingress controller:
 
 ```console
-$ helm upgrade --wait \
-  --set ingressController.enabled=false \
-  --version <CURRENT_CHART_VERSION> \
+$ kubectl patch deployment \
+  <YOUR_RELEASE_NAME>-kong \
   --namespace <YOUR_RELEASE_NAMESPACE> \
-  <YOUR_RELEASE_NAME> kong/kong
+  --type json -p='[{"op": "remove", "path": "/spec/template/spec/containers/0"}]'
 ```
 
-Once the upgrade completes you will only have the proxy itself running, and can
-run a second upgrade to re-enable the ingress controller and update to chart
+Once the update completes you will only have the proxy itself running, and can
+run a helm upgrade to re-enable the ingress controller and update to chart
 version 2.4:
 
 ```console


### PR DESCRIPTION
When upgrading 2.3.0 with ingress-controller and postgresql enabled, the originally suggested helm upgrade always fails (for all my installations at least): the service account gets deleted and then the update of the deployment is failing because of the missing service account. Also tried with disabling pre- and post-migrations, but still did not work.

So I'd suggest doing a manual deployment update instead of the helm upgrade.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Documented 2.4.0 upgrade fails

#### Which issue this PR fixes
- none -

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)

Dieter Rothacker dieter.rothacker@mercedes-benz.com, Mercedes-Benz Mobility AG on behalf of Mercedes-Benz Tech Innovation GmbH.
https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md