### PR TITLE
chore: bump kong chart to 2.12.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Changelog
 
-## Unreleased
+## 2.12.0
 
 ### Improvements
 
 * Added ClusterRole for cluster-scoped resources when using watchNamespaces.
   [#611](https://github.com/Kong/charts/issues/611)
-* Added `extraObjects` to create additional k8s resources as part of the helm release. 
-  [FTI-4149](https://konghq.atlassian.net/browse/FTI-4149)
+* Added `extraObjects` to create additional k8s resources as part of the helm release.
+  [#652](https://github.com/Kong/charts/issues/652)
+
 ## 2.11.0
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.11.0
+version: 2.12.0
 appVersion: "2.8"
 dependencies:
 - name: postgresql


### PR DESCRIPTION
#### What this PR does / why we need it:

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "v2.12.0" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
