### PR TITLE
Move unreleased item to proper changelog section

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Added cert-manager issuer support for proxy default and cluster mtls certificates
   ([592](https://github.com/Kong/charts/pull/592))
 
+## 2.12.0
+
 ### Improvements
 
 * Added ClusterRole for cluster-scoped resources when using watchNamespaces.

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 2.12.0
+## Unreleased
+
+### Improvements
+
+* Added cert-manager issuer support for proxy default and cluster mtls certificates
+  ([592](https://github.com/Kong/charts/pull/592))
 
 ### Improvements
 


### PR DESCRIPTION
There was no existing unreleased section at the time this was merged and its changelog entry was mistakenly added to an existing release's section.