### PR TITLE
chore(crds) update CRDs

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Added cert-manager issuer support for proxy default and cluster mtls certificates
   ([592](https://github.com/Kong/charts/pull/592))
+* Updated CRDs with the new ordering field for KongPlugins, the new
+  IngressClassParameters resource, and assorted field description updates.
+  These [require a manual update](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#updates-to-crds).
 
 ## 2.12.0
 

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -17,6 +17,7 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [2.13.0](#2130)
 - [2.8.0](#280)
 - [2.7.0](#270)
 - [2.4.0](#240)
@@ -65,6 +66,26 @@ text ending with `field is immutable`. This is typically due to a bug with the
 `init-migrations` job, which was not removed automatically prior to 1.5.0.
 If you encounter this error, deleting any existing `init-migrations` jobs will
 clear it.
+
+### Updates to CRDs
+
+Helm installs CRDs at initial install but [does not update them
+after](https://github.com/helm/community/blob/main/hips/hip-0011.md). Some
+chart releases include updates to CRDs that must be applied to successfully
+upgrade. Because Helm does not handle these updates, you must manually apply
+them before upgrading your release.
+
+``` kubectl apply -f
+https://raw.githubusercontent.com/Kong/charts/kong-<version>/charts/kong/crds/custom-resource-definitions.yaml
+```
+
+For example, if your release is 2.6.4, you would apply
+`https://raw.githubusercontent.com/Kong/charts/kong-2.6.4/charts/kong/crds/custom-resource-definitions.yaml`.
+
+## 2.13.0
+
+2.13.0 includes updated CRDs. You must [apply these manually](#updates-to-crds)
+before upgrading an existing release.
 
 ## 2.8.0
 

--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -1,15 +1,68 @@
 # generated using: kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/crd?ref=main
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: ingressclassparameterses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: IngressClassParameters
+    listKind: IngressClassParametersList
+    plural: ingressclassparameterses
+    singular: ingressclassparameters
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressClassParameters is the Schema for the IngressClassParameters
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              enableLegacyRegexDetection:
+                default: false
+                description: EnableLegacyRegexDetection automatically detects if ImplementationSpecific
+                  Ingress paths are regular expression paths using the legacy 2.x
+                  heuristic. The controller adds the "~" prefix to those paths if
+                  the Kong version is 3.0 or higher.
+                type: boolean
+              serviceUpstream:
+                default: false
+                description: Offload load-balancing to kube-proxy or sidecar
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
   names:
+    categories:
+    - kong-ingress-controller
     kind: KongClusterPlugin
     listKind: KongClusterPluginList
     plural: kongclusterplugins
@@ -86,6 +139,26 @@ spec:
             type: string
           metadata:
             type: object
+          ordering:
+            description: Ordering overrides the normal plugin execution order
+            properties:
+              after:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: PluginOrderingPhase indicates which plugins in a phase
+                  should affect the target plugin's order
+                type: object
+              before:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: PluginOrderingPhase indicates which plugins in a phase
+                  should affect the target plugin's order
+                type: object
+            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -119,23 +192,19 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
   names:
+    categories:
+    - kong-ingress-controller
     kind: KongConsumer
     listKind: KongConsumerList
     plural: kongconsumers
@@ -188,23 +257,19 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
   names:
+    categories:
+    - kong-ingress-controller
     kind: KongIngress
     listKind: KongIngressList
     plural: kongingresses
@@ -231,15 +296,21 @@ spec:
           metadata:
             type: object
           proxy:
-            description: KongIngressService contains KongIngress service configuration
+            description: Proxy defines additional connection options for the routes
+              to be configured in the Kong Gateway, e.g. `connection_timeout`, `retries`,
+              e.t.c.
             properties:
               connect_timeout:
+                description: The timeout in milliseconds for establishing a connection
+                  to the upstream server.
                 minimum: 0
                 type: integer
               path:
+                description: The path to be used in requests to the upstream server.(optional)
                 pattern: ^/.*$
                 type: string
               protocol:
+                description: The protocol used to communicate with the upstream.
                 enum:
                 - http
                 - https
@@ -250,38 +321,59 @@ spec:
                 - udp
                 type: string
               read_timeout:
+                description: The timeout in milliseconds between two successive read
+                  operations for transmitting a request to the upstream server.
                 minimum: 0
                 type: integer
               retries:
+                description: The number of retries to execute upon failure to proxy.
                 minimum: 0
                 type: integer
               write_timeout:
+                description: The timeout in milliseconds between two successive write
+                  operations for transmitting a request to the upstream server.
                 minimum: 0
                 type: integer
             type: object
           route:
-            description: KongIngressRoute contains KongIngress route configuration
+            description: Route define rules to match client requests. Each Route is
+              associated with a Service, and a Service may have multiple Routes associated
+              to it.
             properties:
               headers:
                 additionalProperties:
                   items:
                     type: string
                   type: array
+                description: Headers contains one or more lists of values indexed
+                  by header name that will cause this Route to match if present in
+                  the request. The Host header cannot be used with this attribute.
                 type: object
               https_redirect_status_code:
+                description: HTTPSRedirectStatusCode is the status code Kong responds
+                  with when all properties of a Route match except the protocol.
                 type: integer
               methods:
+                description: Methods is a list of HTTP methods that match this Route.
                 items:
                   type: string
                 type: array
               path_handling:
+                description: PathHandling controls how the Service path, Route path
+                  and requested path are combined when sending a request to the upstream.
                 enum:
                 - v0
                 - v1
                 type: string
               preserve_host:
+                description: PreserveHost sets When matching a Route via one of the
+                  hosts domain names, use the request Host header in the upstream
+                  request headers. If set to false, the upstream Host header will
+                  be that of the Service’s host.
                 type: boolean
               protocols:
+                description: Protocols is an array of the protocols this Route should
+                  allow.
                 items:
                   enum:
                   - http
@@ -294,41 +386,86 @@ spec:
                   type: string
                 type: array
               regex_priority:
+                description: RegexPriority is a number used to choose which route
+                  resolves a given request when several routes match it using regexes
+                  simultaneously.
                 type: integer
               request_buffering:
+                description: RequestBuffering sets whether to enable request body
+                  buffering or not.
                 type: boolean
               response_buffering:
+                description: ResponseBuffering sets whether to enable response body
+                  buffering or not.
                 type: boolean
               snis:
+                description: SNIs is a list of SNIs that match this Route when using
+                  stream routing.
                 items:
                   type: string
                 type: array
               strip_path:
+                description: StripPath sets When matching a Route via one of the paths
+                  strip the matching prefix from the upstream request URL.
                 type: boolean
             type: object
           upstream:
-            description: KongIngressUpstream contains KongIngress upstream configuration
+            description: Upstream represents a virtual hostname and can be used to
+              loadbalance incoming requests over multiple targets (e.g. Kubernetes
+              `Services` can be a target, OR `Endpoints` can be targets).
             properties:
               algorithm:
+                description: Algorithm is the load balancing algorithm to use.
                 enum:
                 - round-robin
                 - consistent-hashing
                 - least-connections
                 type: string
               hash_fallback:
+                description: 'HashFallback defines What to use as hashing input if
+                  the primary hash_on does not return a hash. Accepted values are:
+                  "none", "consumer", "ip", "header", "cookie".'
                 type: string
               hash_fallback_header:
+                description: HashFallbackHeader is the header name to take the value
+                  from as hash input. Only required when "hash_fallback" is set to
+                  "header".
+                type: string
+              hash_fallback_query_arg:
+                description: HashFallbackQueryArg is the "hash_fallback" version of
+                  HashOnQueryArg.
+                type: string
+              hash_fallback_uri_capture:
+                description: HashFallbackURICapture is the "hash_fallback" version
+                  of HashOnURICapture.
                 type: string
               hash_on:
+                description: 'HashOn defines what to use as hashing input. Accepted
+                  values are: "none", "consumer", "ip", "header", "cookie", "path",
+                  "query_arg", "uri_capture".'
                 type: string
               hash_on_cookie:
+                description: The cookie name to take the value from as hash input.
+                  Only required when "hash_on" or "hash_fallback" is set to "cookie".
                 type: string
               hash_on_cookie_path:
+                description: The cookie path to set in the response headers. Only
+                  required when "hash_on" or "hash_fallback" is set to "cookie".
                 type: string
               hash_on_header:
+                description: HashOnHeader defines the header name to take the value
+                  from as hash input. Only required when "hash_on" is set to "header".
+                type: string
+              hash_on_query_arg:
+                description: HashOnQueryArg is the query string parameter whose value
+                  is the hash input when "hash_on" is set to "query_arg".
+                type: string
+              hash_on_uri_capture:
+                description: HashOnURICapture is the name of the capture group whose
+                  value is the hash input when "hash_on" is set to "uri_capture".
                 type: string
               healthchecks:
-                description: Healthcheck represents a health-check config of an upstream
+                description: Healthchecks defines the health check configurations
                   in Kong.
                 properties:
                   active:
@@ -434,8 +571,11 @@ spec:
                     type: number
                 type: object
               host_header:
+                description: HostHeader is The hostname to be used as Host header
+                  when proxying requests through Kong.
                 type: string
               slots:
+                description: Slots is the number of slots in the load balancer algorithm.
                 minimum: 10
                 type: integer
             type: object
@@ -444,23 +584,19 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
   names:
+    categories:
+    - kong-ingress-controller
     kind: KongPlugin
     listKind: KongPluginList
     plural: kongplugins
@@ -533,6 +669,26 @@ spec:
             type: string
           metadata:
             type: object
+          ordering:
+            description: Ordering overrides the normal plugin execution order
+            properties:
+              after:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: PluginOrderingPhase indicates which plugins in a phase
+                  should affect the target plugin's order
+                type: object
+              before:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: PluginOrderingPhase indicates which plugins in a phase
+                  should affect the target plugin's order
+                type: object
+            type: object
           plugin:
             description: PluginName is the name of the plugin to which to apply the
               config
@@ -566,23 +722,19 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: tcpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
   names:
+    categories:
+    - kong-ingress-controller
     kind: TCPIngress
     listKind: TCPIngressList
     plural: tcpingresses
@@ -719,8 +871,8 @@ spec:
                                   the service port The format of the error shall comply
                                   with the following rules: - built-in error values
                                   shall be specified in this file and those shall
-                                  use   CamelCase names - cloud provider specific
-                                  error values must have names that comply with the   format
+                                  use CamelCase names - cloud provider specific error
+                                  values must have names that comply with the format
                                   foo.example.com/CamelCase. --- The regex it matches
                                   is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
                                 maxLength: 316
@@ -752,23 +904,19 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: udpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
   names:
+    categories:
+    - kong-ingress-controller
     kind: UDPIngress
     listKind: UDPIngressList
     plural: udpingresses
@@ -873,8 +1021,8 @@ spec:
                                   the service port The format of the error shall comply
                                   with the following rules: - built-in error values
                                   shall be specified in this file and those shall
-                                  use   CamelCase names - cloud provider specific
-                                  error values must have names that comply with the   format
+                                  use CamelCase names - cloud provider specific error
+                                  values must have names that comply with the format
                                   foo.example.com/CamelCase. --- The regex it matches
                                   is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
                                 maxLength: 316
@@ -906,9 +1054,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -998,6 +998,15 @@ Environment variables are sorted alphabetically
 kong.kubernetesRBACRoles outputs a static list of RBAC rules (the "rules" block
 of a Role or ClusterRole) that provide the ingress controller access to the
 Kubernetes namespace-scoped resources it uses to build Kong configuration.
+
+Collectively, these are built from:
+kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/rbac?ref=main
+kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/rbac/knative?ref=main
+kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/rbac/gateway?ref=main
+
+However, there is no way to generate the split between cluster and namespaced
+role sets used in the charts. Updating these requires separating out cluster
+resource roles into their separate templates.
 */}}
 {{- define "kong.kubernetesRBACRules" -}}
 - apiGroups:
@@ -1068,6 +1077,14 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   - get
   - patch
   - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - ingressclassparameterses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - configuration.konghq.com
   resources:
@@ -1193,6 +1210,65 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
   - gateway.networking.k8s.io
   resources:
   - httproutes/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants/status
+  verbs:
+  - get
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tcproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tcproutes/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - tlsroutes/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - udproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - udproutes/status
   verbs:
   - get
   - update

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -81,6 +81,11 @@ deployment:
 # is set below. In general, you should not set values here if they are set elsewhere.
 env:
   database: "off"
+  # the chart uses the traditional router (for Kong 3.x+) because the ingress
+  # controller generates traditional routes. if you do not use the controller,
+  # you may set this to "traditional_compatible" or "expression" to use the new
+  # DSL-based router
+  router_flavor: "traditional"
   nginx_worker_processes: "2"
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -82,9 +82,5 @@ ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma
 
 kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -
 
-# The steps necessary to get this to work aren't obvious and it's not something
-# the test cares about, so just disable it
-kubectl patch validatingwebhookconfigurations.admissionregistration.k8s.io kuma-validating-webhook-configuration --patch '{"webhooks": [{"name": "validate.gateway.networking.k8s.io", "failurePolicy": "Ignore"}]}'
-
 echo "INFO: Updating helm dependencies"
 helm dependency update charts/kong/

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -78,7 +78,7 @@ ktf 1>/dev/null
 # Create Testing Environment
 # ------------------------------------------------------------------------------
 
-ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma
+ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma --kubernetes-version 1.24.4
 
 kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds pending 2.6 CRDs (IngressClassParameters, KongPlugin's new ordering section, new upstream fields in KongIngress, various description updates).

Adds a generic upgrade entry about CRD updates. They're basically all the same.

#### Special notes for your reviewer:

We actually forgot to add IngressClassParameters to the kustomization. This generation _did not_ run from main, and instead ran from:

```
kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/crd?ref=30f06af6b73044f1fd11ff977920713b2d782a79 > crds/custom-resource-definitions.yaml
```
That tip doesn't include changes to the CRDs themselves, it just adds the existing ICP file to the kustomization.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
