### PR TITLE
chore(*) release 2.13.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.13.1
+
+### Improvements
+
+* Updated default controller version to [KIC 2.7](https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md#270).
+
 ## 2.13.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.13.0
+version: 2.13.1
 appVersion: "3.0"
 dependencies:
 - name: postgresql

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -465,7 +465,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "2.6"
+    tag: "2.7"
     # Optionally set a semantic version for version-gated features. This can normally
     # be left unset. You only need to set this if your tag is not a semver string,
     # such as when you are using a "next" tag. Set this to the effective semantic


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps controller version to 2.7 and releases 2.13.1.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
