### PR TITLE
fix(values): fix values file in example-values/doc-examples

### DIFF
--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -113,11 +113,6 @@ env:
       secretKeyRef:
         key: pg_host
         name: kong-config-secret
-  pg_password:
-    valueFrom:
-      secretKeyRef:
-        key: password
-        name: kong-config-secret
   pg_ssl: "off"
   pg_ssl_verify: "off"
   pg_user: kong
@@ -167,7 +162,7 @@ ingressController:
     publish_service: kong/quickstart-kong-proxy
   image:
     repository: docker.io/kong/kubernetes-ingress-controller
-    tag: "2.2"
+    tag: "2.7"
   ingressClass: default
   installCRDs: false
 manager:
@@ -252,11 +247,9 @@ portalapi:
   type: ClusterIP
 postgresql:
   enabled: true
-  global:
-    postgresql:
-      database: kong
-      existingSecret: kong-config-secret
-      username: kong
+  auth:
+    database: kong
+    username: kong
 proxy:
   annotations:
     prometheus.io/port: "9542"


### PR DESCRIPTION
#### What this PR does / why we need it:

- `charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml` file, that is used in in the docs,
was not working. `postgresql.global.postgresql` is no longer a valid path. `bitnami/postgress` uses `postgresql.auth` path.
- KIC version was set to `2.2`. The newest version is `2.7`.
- `existingSecret` was removed, as it prevented generation of `$fullname-postgresql`. Instead postgres generates the secret with `postgres-password`. Other uses of `kong-config-secret` are still valid, so it was left intact.

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
