### PR TITLE
fix: remove podSecurityPolicy if not supported in cluster

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -10,6 +10,13 @@
 * Supported `autoscaling/v2` API
   ([#679](https://github.com/Kong/charts/pull/679))
 
+### Fixed
+
+* Removed `PodSecurityPolicy` if the API is not supported in k8s cluster
+  to be compatible to k8s 1.25+.
+  [#680](https://github.com/Kong/charts/pull/680)
+
+
 ## 2.13.1
 
 ### Improvements
@@ -21,7 +28,7 @@
 ### Improvements
 
 * Added cert-manager issuer support for proxy default and cluster mtls certificates
-  ([592](https://github.com/Kong/charts/pull/592))
+  ([#592](https://github.com/Kong/charts/pull/592))
 * Updated CRDs with the new ordering field for KongPlugins, the new
   IngressClassParameters resource, and assorted field description updates.
   These [require a manual update](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#updates-to-crds).

--- a/charts/kong/templates/psp.yaml
+++ b/charts/kong/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podSecurityPolicy.enabled }}
+{{- if and (.Values.podSecurityPolicy.enabled) (.Capabilities.APIVersions.Has "policy/v1beta1") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

since k8s 1.25, `policy/v1beta1` APIs are removed. We need to remove the APIs to avoid install failures in k8s 1.25+. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - part of #662, still needs to add support for pod security admission support to achieve full support

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
