### PR TITLE
fix(proxy): set default protocol to UDP for udpProxy

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Improvements
 
+* UDP proxy (udpProxy) assumes the UDP protocol by default for stream entries (udpProxy.stream). 
+  This can be still overridden to TCP by specifying the protocol explicitly, but it is not recommended to do so.
+  [#682](https://github.com/Kong/charts/pull/682)
 * Supported `autoscaling/v2` API
   ([#679](https://github.com/Kong/charts/pull/679))
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -184,6 +184,15 @@ spec:
     protocol: TCP
   {{- end }}
   {{- if (hasKey . "stream") }}
+    {{- $defaultProtocol := "TCP" }}
+    {{- if (hasSuffix "udp-proxy" .serviceName) }}
+      {{- $defaultProtocol = "UDP" }}
+    {{- end }}
+    {{- range $index, $streamEntry := .stream }}
+      {{- if (not (hasKey $streamEntry "protocol")) }}
+        {{- $_ := set $streamEntry "protocol" $defaultProtocol }}
+      {{- end }}
+    {{- end }}
   {{- range .stream }}
   - name: stream{{ if (eq (default "TCP" .protocol) "UDP") }}udp{{ end }}-{{ .containerPort }}
     port: {{ .servicePort }}


### PR DESCRIPTION

#### What this PR does / why we need it:

For a udpProxy, the protocol is considered to be UDP by default.


#### Which issue this PR fixes

Fixes #681


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
