### PR TITLE
[WIP] fix enterprise hybrid mode installing

### DIFF
--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
@@ -32,6 +32,14 @@ cluster:
   tls:
     enabled: true
 
+clustertelemetry:
+  enabled: true
+  tls:
+    containerPort: 8006
+    enabled: true
+    servicePort: 8006
+    type: ClusterIP
+
 proxy:
   enabled: false
 

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
@@ -17,6 +17,7 @@ image:
 env:
   role: data_plane
   cluster_control_plane: CHANGEME-control-service.CHANGEME-namespace.svc.cluster.local:8005
+  cluster_telemetry_endpoint: CHANGEME-cluster-telemetry-service.CHANGEME-namespace.svc.cluster.local:8006
   lua_ssl_trusted_certificate: /etc/secrets/kong-cluster-cert/tls.crt
   cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
   cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Fix the problem that hybrid mode kong installed with example values does not work.
Still work in progress, following issue should be fixed
- [x] cluster telemetry is required in enterprise edition
- [ ] username/password of postgresql should be configured correctly
#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #685

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
