### PR TITLE
Add configurable minReadySeconds

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -9,6 +9,9 @@
   [#682](https://github.com/Kong/charts/pull/682)
 * Supported `autoscaling/v2` API
   ([#679](https://github.com/Kong/charts/pull/679))
+* Add support for specifying the minium number of seconds for which newly created pods should be ready without
+  any of its container crashing, for it to be considered available. (`deployment.minReadySeconds`)
+  ([]())
 
 ### Fixed
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -11,7 +11,7 @@
   ([#679](https://github.com/Kong/charts/pull/679))
 * Add support for specifying the minium number of seconds for which newly created pods should be ready without
   any of its container crashing, for it to be considered available. (`deployment.minReadySeconds`)
-  ([]())
+  ([#688](https://github.com/Kong/charts/pull/688))
 
 ### Fixed
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -752,6 +752,7 @@ kong:
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
+| deployment.minReadySeconds         | Minimum number of seconds for which newly created pods should be ready without any of its container crashing, for it to be considered available. |                     |
 | deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |
 | deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |
 | deployment.hostNetwork             | Enable hostNetwork, which binds to the ports to the host                              | `false`             |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
   {{- end }}
 {{ toYaml .Values.updateStrategy | indent 4 }}
   {{- end }}
+  {{- if .Values.deployment.minReadySeconds }}
+  minReadySeconds: {{ .Values.deployment.minReadySeconds }}
+  {{- end }}
 
   template:
     metadata:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -19,6 +19,9 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+  ## Minimum number of seconds for which a newly created pod should be ready without any of its container crashing,
+  ## for it to be considered available.
+  # minReadySeconds: 60
   ## Specify the service account to create and to be assigned to the deployment / daemonset and for the migrations
   serviceAccount:
     create: true


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

This PR adds `deployment.minReadySeconds` value and respective field in deployment
template. This allows users to configure the number of seconds until
newly created pods are considered ready.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
