### PR TITLE
fix(conf) Updating the default memory limits for kong pod to 2G

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add support for specifying the minium number of seconds for which newly created pods should be ready without
   any of its container crashing, for it to be considered available. (`deployment.minReadySeconds`)
   ([#688](https://github.com/Kong/charts/pull/688))
+* Increased the default memory requests and limits for the Kong pod to 2G
 
 ### Fixed
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -13,6 +13,7 @@
   any of its container crashing, for it to be considered available. (`deployment.minReadySeconds`)
   ([#688](https://github.com/Kong/charts/pull/688))
 * Increased the default memory requests and limits for the Kong pod to 2G
+  ([#690](https://github.com/Kong/charts/pull/690))
 
 ### Fixed
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -695,10 +695,10 @@ updateStrategy: {}
 resources: {}
   # limits:
   #  cpu: 1
-  #  memory: 1G
+  #  memory: 2G
   # requests:
   #  cpu: 1
-  #  memory: 1G
+  #  memory: 2G
 
 # readinessProbe for Kong pods
 readinessProbe:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
When running a Kong Dev Portal, 1G of memory isnt enough to push portal themes across to the control plane using portal cli, so the default of 1G is not a good starting point, so upping to 2G instead.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
