### PR TITLE
Support statefulset for future integrations of new plugins

### DIFF
--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -2,6 +2,8 @@
 apiVersion: apps/v1
 {{- if .Values.deployment.daemonset }}
 kind: DaemonSet
+{{- else if .Values.deployment.statefulset }}
+kind: StatefulSet
 {{- else }}
 kind: Deployment
 {{- end }}
@@ -22,6 +24,9 @@ spec:
   {{- if not .Values.deployment.daemonset }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- end }}
+  {{- if .Values.deployment.statefulset }}
+  serviceName: {{ .Values.deployment.statefulsetServiceName }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -57,8 +57,13 @@ deployment:
   test:
     # Enable creation of test resources for use with "helm test"
     enabled: false
+
   # Use a DaemonSet controller instead of a Deployment controller
   daemonset: false
+  # Use a StatefulSet controller instead of a Deployment / DaemonSet controller
+  # daemonset flag will take precedence if both are set to true
+  statefulset: false
+
   hostNetwork: false
   # kong_prefix empty dir size
   prefixDir:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
I'm writing a kong plugin that requires a statefulset - so updated kong helm chart with this capability! 
configurable by statefulset value (similar to daemonset)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes "missing support for statefulset" - not listed as issue yet.

#### Special notes for your reviewer:
tested and working :)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
