### PR TITLE
Dbless toyaml

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+### Improvements
+
+* Add `dblessConfig.secret` and `dblessConfig.kind` Values options, to allow
+  users to generate or provide their db-less config as a Secret
+  [#695](https://github.com/Kong/charts/pull/695)
 * Add support for version `v1beta1` of the Gateway API when generating RBAC rules.
-  ([#706](https://github.com/Kong/charts/pull/706))
 
 ### Fixed
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### Improvements
 
-* Restructure the `dblessConfig` section of the values file, giving the keys
-  more meaningful names and making it possible to specify the Kind (either
-  ConfigMap or Secret) of the config resources.
+* Add the `dblessConfig.secret` key to the values file, allowing the user to
+  supply a Secret for their dbless config file.
   [#695](https://github.com/Kong/charts/pull/695)
 * Add support for version `v1beta1` of the Gateway API when generating RBAC rules.
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Improvements
 
-* Add `dblessConfig.secret` and `dblessConfig.kind` Values options, to allow
-  users to generate or provide their db-less config as a Secret
+* Restructure the `dblessConfig` section of the values file, giving the keys
+  more meaningful names and making it possible to specify the Kind (either
+  ConfigMap or Secret) of the config resources.
   [#695](https://github.com/Kong/charts/pull/695)
 * Add support for version `v1beta1` of the Gateway API when generating RBAC rules.
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -160,11 +160,13 @@ When deploying Kong in DB-less mode(`env.database: "off"`)
 and without the Ingress Controller(`ingressController.enabled: false`),
 you have to provide a [declarative configuration](https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format) for Kong to run.
 You can provide an existing ConfigMap
-(`dblessConfig.configMap`) or place the whole configuration into
-`values.yaml` (`dblessConfig.config`)
-parameter. See the example configuration in the default values.yaml
-for more details. You can use `--set-file dblessConfig.config=/path/to/declarative-config.yaml`
-in Helm commands to substitute in a complete declarative config file.
+(`dblessConfig.configMap`) or Secret (`dblessConfig.secret`) or place the whole
+configuration into `values.yaml` (`dblessConfig.config`) parameter. By default
+this will create a ConfigMap, but if needed this can create a Secret by setting
+`dblessConfig.kind` to `"Secret"`. See the example configuration in the default
+values.yaml for more details. You can use `--set-file
+dblessConfig.config=/path/to/declarative-config.yaml` in Helm commands to
+substitute in a complete declarative config file.
 
 Note that externally supplied ConfigMaps are not hashed or tracked in deployment annotations.
 Subsequent ConfigMap updates will require user-initiated new deployment rollouts

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -159,11 +159,12 @@ read the [env](#the-env-section) section.
 When deploying Kong in DB-less mode(`env.database: "off"`)
 and without the Ingress Controller(`ingressController.enabled: false`),
 you have to provide a [declarative configuration](https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format) for Kong to run.
-You can provide an existing ConfigMap or Secret (`dblessConfig.existingConfig`)
-or place the whole configuration into `values.yaml` (`dblessConfig.createConfig`)
-parameter. See the example configuration in the default values.yaml for more
-details. You can use `--set-file dblessConfig.createConfig.data=/path/to/declarative-config.yaml`
-in Helm commands to substitute in a complete declarative config file.
+You can provide an existing ConfigMap
+(`dblessConfig.configMap`) or Secret (`dblessConfig.secret`) or place the whole
+configuration into `values.yaml` (`dblessConfig.config`) parameter. See the
+example configuration in the default values.yaml for more details. You can use
+`--set-file dblessConfig.config=/path/to/declarative-config.yaml` in Helm
+commands to substitute in a complete declarative config file.
 
 Note that externally supplied ConfigMaps are not hashed or tracked in deployment annotations.
 Subsequent ConfigMap updates will require user-initiated new deployment rollouts

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -159,14 +159,11 @@ read the [env](#the-env-section) section.
 When deploying Kong in DB-less mode(`env.database: "off"`)
 and without the Ingress Controller(`ingressController.enabled: false`),
 you have to provide a [declarative configuration](https://docs.konghq.com/gateway-oss/latest/db-less-and-declarative-config/#the-declarative-configuration-format) for Kong to run.
-You can provide an existing ConfigMap
-(`dblessConfig.configMap`) or Secret (`dblessConfig.secret`) or place the whole
-configuration into `values.yaml` (`dblessConfig.config`) parameter. By default
-this will create a ConfigMap, but if needed this can create a Secret by setting
-`dblessConfig.kind` to `"Secret"`. See the example configuration in the default
-values.yaml for more details. You can use `--set-file
-dblessConfig.config=/path/to/declarative-config.yaml` in Helm commands to
-substitute in a complete declarative config file.
+You can provide an existing ConfigMap or Secret (`dblessConfig.existingConfig`)
+or place the whole configuration into `values.yaml` (`dblessConfig.createConfig`)
+parameter. See the example configuration in the default values.yaml for more
+details. You can use `--set-file dblessConfig.createConfig.data=/path/to/declarative-config.yaml`
+in Helm commands to substitute in a complete declarative config file.
 
 Note that externally supplied ConfigMaps are not hashed or tracked in deployment annotations.
 Subsequent ConfigMap updates will require user-initiated new deployment rollouts

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -478,6 +478,9 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- end }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+{{- if gt (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) 1 -}}
+    {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
+{{- end }}
 - name: kong-custom-dbless-config-volume
   {{- if .Values.dblessConfig.configMap }}
   configMap:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -479,12 +479,21 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 - name: kong-custom-dbless-config-volume
+  {{- if .Values.dblessConfig.configMap }}
   configMap:
-    {{- if .Values.dblessConfig.configMap }}
     name: {{ .Values.dblessConfig.configMap }}
-    {{- else }}
+  {{- else if .Values.dblessConfig.secret }}
+  secret:
+    secretName: {{ .Values.dblessConfig.secret }}
+  {{- else if eq "secret" (lower .Values.dblessConfig.kind) }}
+  secret:
+    secretName: {{ template "kong.dblessConfig.fullname" . }}
+  {{- else if eq "configmap" (lower .Values.dblessConfig.kind) }}
+  configMap:
     name: {{ template "kong.dblessConfig.fullname" . }}
-    {{- end }}
+  {{- else }}
+    {{- fail ".Values.dblessConfig.kind must be set to either \"ConfigMap\" or \"Secret\"" }}
+  {{- end }}
 {{- end }}
 {{- if .Values.ingressController.admissionWebhook.enabled }}
 - name: webhook-cert

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -478,25 +478,24 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- end }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
-{{- if gt (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) 1 -}}
-    {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
+{{- if and .Values.dblessConfig.existingConfig.enabled .Values.dblessConfig.createConfig.enabled -}}
+    {{- fail "Ambiguous configuration: .Values.dblessConfig.existingConfig.enabled and .Values.dblessConfig.createConfig.enabled cannot both be set" -}}
 {{- end }}
+{{- with .Values.dblessConfig }}
 - name: kong-custom-dbless-config-volume
-  {{- if .Values.dblessConfig.configMap }}
+  {{- if or (.existingConfig.kind | lower | eq "configmap" | and .existingConfig.enabled) (.createConfig.kind | lower | eq "configmap" | and .createConfig.enabled) }}
   configMap:
-    name: {{ .Values.dblessConfig.configMap }}
-  {{- else if .Values.dblessConfig.secret }}
+    name:
+  {{- else if or (.existingConfig.kind | lower | eq "secret" | and .existingConfig.enabled) (.createConfig.kind | lower | eq "secret" | and .createConfig.enabled) }}
   secret:
-    secretName: {{ .Values.dblessConfig.secret }}
-  {{- else if eq "secret" (lower .Values.dblessConfig.kind) }}
-  secret:
-    secretName: {{ template "kong.dblessConfig.fullname" . }}
-  {{- else if eq "configmap" (lower .Values.dblessConfig.kind) }}
-  configMap:
-    name: {{ template "kong.dblessConfig.fullname" . }}
+    secretName:
   {{- else }}
-    {{- fail ".Values.dblessConfig.kind must be set to either \"ConfigMap\" or \"Secret\"" }}
+    {{- fail "\"kind\" options under .Values.dblessConfig must be set to either \"ConfigMap\" or \"Secret\"" }}
   {{- end }}
+  {{- if .existingConfig.enabled }} {{ .existingConfig.name -}}
+  {{- else if .createConfig.enabled }} {{ template "kong.dblessConfig.fullname" $ -}}
+  {{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.ingressController.admissionWebhook.enabled }}
 - name: webhook-cert

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -48,7 +48,7 @@ app.kubernetes.io/instance: "{{ .Release.Name }}"
 {{- end -}}
 
 {{- define "kong.dblessConfig.fullname" -}}
-{{- $name := default "kong-custom-dbless-config" .Values.dblessConfig.nameOverride -}}
+{{- $name := default "kong-custom-dbless-config" .Values.dblessConfig.createConfig.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -1,15 +1,17 @@
 {{- if .Values.deployment.kong.enabled }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
-{{- if .Values.dblessConfig.createConfig.enabled  }}
+{{- if not (or .Values.dblessConfig.configMap .Values.dblessConfig.secret) }}
+{{- if .Values.dblessConfig.config }}
 apiVersion: v1
+kind: ConfigMap
 metadata:
   name: {{ template "kong.dblessConfig.fullname" . }}
   namespace: {{ template "kong.namespace" . }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-kind: ConfigMap
 data:
-  kong.yml: {{- .Values.dblessConfig.createConfig.data | toYaml | nindent 4 }}
+  kong.yml: | {{- .Values.dblessConfig.config | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -1,16 +1,23 @@
 {{- if .Values.deployment.kong.enabled }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
-{{- if not .Values.dblessConfig.configMap }}
+{{- if not (or .Values.dblessConfig.configMap .Values.dblessConfig.secret)  }}
 apiVersion: v1
-kind: ConfigMap
 metadata:
   name: {{ template "kong.dblessConfig.fullname" . }}
   namespace: {{ template "kong.namespace" . }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
+{{- if eq "secret" (lower .Values.dblessConfig.kind) }}
+kind: Secret
 data:
-  kong.yml:
-{{ .Values.dblessConfig.config | toYaml | indent 4 }}
+  kong.yml: {{ .Values.dblessConfig.config | b64enc }}
+{{- else if eq "configmap" (lower .Values.dblessConfig.kind) }}
+kind: ConfigMap
+data:
+  kong.yml: {{ .Values.dblessConfig.config | toYaml | nindent 4 }}
+{{- else }}
+  {{- fail ".Values.dblessConfig.kind must be set to either \"ConfigMap\" or \"Secret\"" }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -7,17 +7,9 @@ metadata:
   namespace: {{ template "kong.namespace" . }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-{{- if .Values.dblessConfig.createConfig.kind | lower | eq "secret" }}
-kind: Secret
-data:
-  kong.yml: {{ .Values.dblessConfig.createConfig.data | b64enc }}
-{{- else if .Values.dblessConfig.createConfig.kind | lower | eq "configmap" }}
 kind: ConfigMap
 data:
   kong.yml: {{- .Values.dblessConfig.createConfig.data | toYaml | nindent 4 }}
-{{- else }}
-  {{- fail ".Values.dblessConfig.createConfig.kind must be set to either \"ConfigMap\" or \"Secret\"" }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -1,22 +1,22 @@
 {{- if .Values.deployment.kong.enabled }}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
-{{- if not (or .Values.dblessConfig.configMap .Values.dblessConfig.secret)  }}
+{{- if .Values.dblessConfig.createConfig.enabled  }}
 apiVersion: v1
 metadata:
   name: {{ template "kong.dblessConfig.fullname" . }}
   namespace: {{ template "kong.namespace" . }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-{{- if eq "secret" (lower .Values.dblessConfig.kind) }}
+{{- if .Values.dblessConfig.createConfig.kind | lower | eq "secret" }}
 kind: Secret
 data:
-  kong.yml: {{ .Values.dblessConfig.config | b64enc }}
-{{- else if eq "configmap" (lower .Values.dblessConfig.kind) }}
+  kong.yml: {{ .Values.dblessConfig.createConfig.data | b64enc }}
+{{- else if .Values.dblessConfig.createConfig.kind | lower | eq "configmap" }}
 kind: ConfigMap
 data:
-  kong.yml: {{- .Values.dblessConfig.config | toYaml | nindent 4 }}
+  kong.yml: {{- .Values.dblessConfig.createConfig.data | toYaml | nindent 4 }}
 {{- else }}
-  {{- fail ".Values.dblessConfig.kind must be set to either \"ConfigMap\" or \"Secret\"" }}
+  {{- fail ".Values.dblessConfig.createConfig.kind must be set to either \"ConfigMap\" or \"Secret\"" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/config-dbless.yaml
+++ b/charts/kong/templates/config-dbless.yaml
@@ -14,7 +14,7 @@ data:
 {{- else if eq "configmap" (lower .Values.dblessConfig.kind) }}
 kind: ConfigMap
 data:
-  kong.yml: {{ .Values.dblessConfig.config | toYaml | nindent 4 }}
+  kong.yml: {{- .Values.dblessConfig.config | toYaml | nindent 4 }}
 {{- else }}
   {{- fail ".Values.dblessConfig.kind must be set to either \"ConfigMap\" or \"Secret\"" }}
 {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -453,7 +453,8 @@ dblessConfig:
       #     paths:
       #     - "/example"
   # How to store the passed-in configuration; set to "Secret" to store using a
-  # Secret instead of a ConfigMap
+  # Secret instead of a ConfigMap. Note that this value is ignored if you are
+  # not passing in a configuration through .dblessConfig.config above.
   kind: ConfigMap
   ## Optionally specify any extra sidecar containers to be included in the
   ## migration jobs

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -442,16 +442,16 @@ dblessConfig:
   # Or Kong's configuration is managed from an existing Secret (with Key: kong.yml)
   secret: ""
   # Or the configuration is passed in full-text below
-  config: "" # |
-    # _format_version: "1.1"
-    # services:
-    #   # Example configuration
-    #   # - name: example.com
-    #   #   url: http://example.com
-    #   #   routes:
-    #   #   - name: example
-    #   #     paths:
-    #   #     - "/example"
+  config: |
+  # # _format_version: "1.1"
+  # # services:
+  # #   # Example configuration
+  # #   # - name: example.com
+  # #   #   url: http://example.com
+  # #   #   routes:
+  # #   #   - name: example
+  # #   #     paths:
+  # #   #     - "/example"
   ## Optionally specify any extra sidecar containers to be included in the
   ## migration jobs
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -437,25 +437,26 @@ migrations:
 # Note: Use this section only if you are deploying Kong in DB-less mode
 # and not as an Ingress Controller.
 dblessConfig:
-  # Either Kong's configuration is managed from an existing ConfigMap (with Key: kong.yml)
-  configMap: ""
-  # Or Kong's configuration is managed from an existing Secret (with Key: kong.yml)
-  secret: ""
+  # Either Kong's configuration is managed from an existing ConfigMap or Secret
+  # (with Key: kong.yml)
+  existingConfig:
+    enabled: false
+    kind: ConfigMap
+    name: ""
   # Or the configuration is passed in full-text below
-  config: |
-    _format_version: "1.1"
-    services:
-      # Example configuration
-      # - name: example.com
-      #   url: http://example.com
-      #   routes:
-      #   - name: example
-      #     paths:
-      #     - "/example"
-  # How to store the passed-in configuration; set to "Secret" to store using a
-  # Secret instead of a ConfigMap. Note that this value is ignored if you are
-  # not passing in a configuration through .dblessConfig.config above.
-  kind: ConfigMap
+  createConfig:
+    enabled: true
+    kind: ConfigMap
+    data: |
+      _format_version: "1.1"
+      services:
+        # Example configuration
+        # - name: example.com
+        #   url: http://example.com
+        #   routes:
+        #   - name: example
+        #     paths:
+        #     - "/example"
   ## Optionally specify any extra sidecar containers to be included in the
   ## migration jobs
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -437,29 +437,21 @@ migrations:
 # Note: Use this section only if you are deploying Kong in DB-less mode
 # and not as an Ingress Controller.
 dblessConfig:
-  # Either Kong's configuration is managed from an existing ConfigMap or Secret
-  # (with Key: kong.yml)
-  existingConfig:
-    enabled: false
-    # This can be set to either ConfigMap or Secret
-    kind: ConfigMap
-    name: ""
+  # Either Kong's configuration is managed from an existing ConfigMap (with Key: kong.yml)
+  configMap: ""
+  # Or Kong's configuration is managed from an existing Secret (with Key: kong.yml)
+  secret: ""
   # Or the configuration is passed in full-text below
-  createConfig:
-    enabled: true
-    data: |
-      _format_version: "1.1"
-      services:
-        # Example configuration
-        # - name: example.com
-        #   url: http://example.com
-        #   routes:
-        #   - name: example
-        #     paths:
-        #     - "/example"
-    # # override config resource name
-    # nameOverride: ""
-
+  config: "" # |
+    # _format_version: "1.1"
+    # services:
+    #   # Example configuration
+    #   # - name: example.com
+    #   #   url: http://example.com
+    #   #   routes:
+    #   #   - name: example
+    #   #     paths:
+    #   #     - "/example"
   ## Optionally specify any extra sidecar containers to be included in the
   ## migration jobs
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -441,11 +441,15 @@ dblessConfig:
   # (with Key: kong.yml)
   existingConfig:
     enabled: false
+    # This can be set to either ConfigMap or Secret
     kind: ConfigMap
     name: ""
   # Or the configuration is passed in full-text below
   createConfig:
     enabled: true
+    # This can be set to either ConfigMap or Secret; it is recommended to keep
+    # this at its default value though, as storing sensitive data in Helm
+    # release values is not recommended.
     kind: ConfigMap
     data: |
       _format_version: "1.1"
@@ -459,6 +463,7 @@ dblessConfig:
         #     - "/example"
     # # override config resource name
     # nameOverride: ""
+
   ## Optionally specify any extra sidecar containers to be included in the
   ## migration jobs
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -457,6 +457,8 @@ dblessConfig:
         #   - name: example
         #     paths:
         #     - "/example"
+    # # override config resource name
+    # nameOverride: ""
   ## Optionally specify any extra sidecar containers to be included in the
   ## migration jobs
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -447,10 +447,6 @@ dblessConfig:
   # Or the configuration is passed in full-text below
   createConfig:
     enabled: true
-    # This can be set to either ConfigMap or Secret; it is recommended to keep
-    # this at its default value though, as storing sensitive data in Helm
-    # release values is not recommended.
-    kind: ConfigMap
     data: |
       _format_version: "1.1"
       services:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -439,6 +439,8 @@ migrations:
 dblessConfig:
   # Either Kong's configuration is managed from an existing ConfigMap (with Key: kong.yml)
   configMap: ""
+  # Or Kong's configuration is managed from an existing Secret (with Key: kong.yml)
+  secret: ""
   # Or the configuration is passed in full-text below
   config: |
     _format_version: "1.1"
@@ -450,6 +452,9 @@ dblessConfig:
       #   - name: example
       #     paths:
       #     - "/example"
+  # How to store the passed-in configuration; set to "Secret" to store using a
+  # Secret instead of a ConfigMap
+  kind: ConfigMap
   ## Optionally specify any extra sidecar containers to be included in the
   ## migration jobs
   ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Add support for non-string types of `dblessConfig.config` values. This allows users to pass in the config structure instead of having to render it to yaml beforehand; this can be useful as it allows customization of a base config using `--set` or extra values files.

#### Special notes for your reviewer:

This PR depends on #695 since they're both making changes to the same code, to avoid merge conflicts don't bother looking at this until #695 is merged

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
