### PR TITLE
feat(validation): add KongIngress to the ValidatingWebhookConfiguration

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -14,6 +14,7 @@
   ([#688](https://github.com/Kong/charts/pull/688))
 * Increased the default memory requests and limits for the Kong pod to 2G
   ([#690](https://github.com/Kong/charts/pull/690))
+* Add a rule for `KongIngress` to the ValidatingWebhookConfiguration.
 
 ### Fixed
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Increased the default memory requests and limits for the Kong pod to 2G
   ([#690](https://github.com/Kong/charts/pull/690))
 * Add a rule for `KongIngress` to the ValidatingWebhookConfiguration.
+  ([#702](https://github.com/Kong/charts/pull/702))
 
 ### Fixed
 

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -57,6 +57,9 @@ webhooks:
 {{- if (semverCompare ">= 2.0.4" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
     - kongclusterplugins
 {{- end }}
+{{- if (semverCompare ">= 2.8.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+    - kongingresses
+{{- end }}
   - apiGroups:
     - ''
     apiVersions:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds KongIngress to the ValidatingWebhookConfiguration for KIC >= 2.8 ([KIC PR](https://github.com/Kong/kubernetes-ingress-controller/pull/3261)).

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3247.

#### Special notes for your reviewer:

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
