### PR TITLE
fix(admission) fix CA certificate secret lookup

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-Nothing yet.
+### Fixed
+
+* Fix lookup for CA certificate secret for admission webhook.
+  ([#704](https://github.com/Kong/charts/pull/704))
 
 ## 2.14.0
 

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -17,6 +17,8 @@
 {{- if $certSecret }}
 {{- $certCert = (b64dec (get $certSecret.data "tls.crt")) -}}
 {{- $certKey = (b64dec (get $certSecret.data "tls.key")) -}}
+{{- end }}
+{{- if $caSecret }}
 {{- $caCert = (b64dec (get $caSecret.data "tls.crt")) -}}
 {{- $caKey = (b64dec (get $caSecret.data "tls.key")) -}}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes an issue with the lookup of the admission webhook certificate and its CA. Separate secrets are being used. Without this check, it can happen that the template is rendered wrong.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
