### PR TITLE
fix(helpers) Prevent duplicate plugin inclusion in KONG_PLUGINS env var

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Add support for version `v1beta1` of the Gateway API when generating RBAC rules.
   ([#706](https://github.com/Kong/charts/pull/706))
+* Prevent supplying duplicate plugin inclusion to `KONG_PLUGINS` env variable.
+  ([#711](https://github.com/Kong/charts/pull/711))
 
 ### Fixed
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -599,7 +599,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- range .Values.plugins.secrets -}}
   {{ $myList = append $myList .pluginName -}}
 {{- end }}
-{{- $myList | join "," -}}
+{{- $myList | uniq | join "," -}}
 {{- end -}}
 
 {{- define "kong.wait-for-db" -}}


### PR DESCRIPTION
#### What this PR does 

Prevent supplying duplicate plugin inclusion to `KONG_PLUGINS` env variable.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
