### PR TITLE
feat(values) Support string values for affinity and topologySpreadConstraints

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,6 +8,10 @@
   ([#706](https://github.com/Kong/charts/pull/706))
 * Prevent supplying duplicate plugin inclusion to `KONG_PLUGINS` env variable.
   ([#711](https://github.com/Kong/charts/pull/711))
+* Allow specifying affinity and topologySpreadConstraints as strings through
+  values.yaml. String values are fed through helms `tpl` function to allow
+  using both values and helpers.
+  ([#712](https://github.com/Kong/charts/pull/712))
 
 ### Fixed
 

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -276,11 +276,19 @@ spec:
         {{- end }} {{/* End of Kong container spec */}}
     {{- if .Values.affinity }}
       affinity:
+    {{- if eq (kindOf .Values.affinity) "string" }}
+{{ tpl .Values.affinity . | indent 8 }}
+    {{- else }}
 {{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
     {{- end }}
     {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
+    {{- if eq (kindOf .Values.topologySpreadConstraints) "string" }}
+{{ tpl .Values.topologySpreadConstraints . | indent 8 }}
+    {{- else }}
 {{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+    {{- end }}
     {{- end }}
       securityContext:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -742,10 +742,12 @@ terminationGracePeriodSeconds: 30
 
 # Affinity for pod assignment
 # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# Supports value of type object and string. String values are fed through helm tpl function.
 # affinity: {}
 
 # Topology spread constraints for pod assignment (requires Kubernetes >= 1.19)
 # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+# Supports value of type array and string. String values are fed through helm tpl function.
 # topologySpreadConstraints: []
 
 # Tolerations for pod assignment


### PR DESCRIPTION
#### What this PR does

This PR adds support for both string and object/array values for `affinity` and `topologySpreadConstraints`. String values will be fed through helms [`tpl` function](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function) which allows users to use both helpers and chart values. This can be used for example to select a specific version or kong deployment.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
