### PR TITLE
fix(dbless) remove unnecessary failure condition

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.15.1
+
+### Fixed
+
+* Remove unnecessary failure condition from [#695](https://github.com/Kong/charts/pull/695).
+
 ## 2.15.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.15.0
+version: 2.15.1
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -480,8 +480,6 @@ The name of the service used for the ingress controller's validation webhook
 {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
 {{- if gt $dblessSourceCount 1 -}}
     {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
-{{- else if lt $dblessSourceCount 1 }}
-    {{- fail "Invalid configuration: .Values.ingressController.enabled==false and .Values.env.database==\"off\"; this implies a dbless config. However, none of the options for setting the dbless config (.Values.dblessConfig.configMap, .Values.dblessConfig.secret, or .Values.dblessConfig.config) are set." -}}
 {{- end }}
 - name: kong-custom-dbless-config-volume
   {{- if .Values.dblessConfig.configMap }}


### PR DESCRIPTION
Community change fails configs with DB-less but no static config, but it shouldn't. Config can be handled outside the chart.