### PR TITLE
fix(dbless) disable mounts when not in use

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.15.2
+
+### Fixed
+
+* Do not attempt to mount DB-less config if none provided by chart.
+
 ## 2.15.1
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.15.1
+version: 2.15.2
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -480,7 +480,6 @@ The name of the service used for the ingress controller's validation webhook
 {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
 {{- if gt $dblessSourceCount 1 -}}
     {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
-{{- end }}
 - name: kong-custom-dbless-config-volume
   {{- if .Values.dblessConfig.configMap }}
   configMap:
@@ -492,6 +491,7 @@ The name of the service used for the ingress controller's validation webhook
   configMap:
     name: {{ template "kong.dblessConfig.fullname" . }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.ingressController.admissionWebhook.enabled }}
 - name: webhook-cert
@@ -550,6 +550,8 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- end }}
 {{- end }}
+{{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
+{{- if gt $dblessSourceCount 1 -}}
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 - name: kong-custom-dbless-config-volume
   mountPath: /kong_dbless/
@@ -557,6 +559,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- range .Values.secretVolumes }}
 - name:  {{ . }}
   mountPath: /etc/secrets/{{ . }}
+{{- end }}
 {{- end }}
 {{- range .Values.plugins.configMaps }}
 {{- $mountPath := printf "/opt/kong/plugins/%s" .pluginName }}
@@ -909,7 +912,10 @@ the template that it itself is using form the above sections.
 {{- end }}
 
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+{{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
+{{- if gt $dblessSourceCount 1 -}}
   {{- $_ := set $autoEnv "KONG_DECLARATIVE_CONFIG" "/kong_dbless/kong.yml" -}}
+{{- end }}
 {{- end }}
 
 {{- $_ := set $autoEnv "KONG_PLUGINS" (include "kong.plugins" .) -}}


### PR DESCRIPTION
Also, the chart attempted to mount configs that didn't exist.

Need post-mortem CI review to determine why that didn't fail tests. We likely do not test DB-less installs with neither a controller nor a config.