### PR TITLE
fix(ingress) Use /readyz for readinessProbe

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* Changed `ingressController.readinessProbe` to use `/readyz` to prevent pods from becoming ready and serving 404s prior to the `ingress-controller` first syncing config to the `proxy` [#716](https://github.com/Kong/charts/pull/716).
+
 ## 2.15.2
 
 ### Fixed

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -547,7 +547,7 @@ ingressController:
     failureThreshold: 3
   readinessProbe:
     httpGet:
-      path: "/healthz"
+      path: "/readyz"
       port: 10254
       scheme: HTTP
     initialDelaySeconds: 5


### PR DESCRIPTION
#### What this PR does / why we need it:

To prevent pods from becoming ready and serving 404s prior to the `ingress-controller` first syncing config to the `proxy`.

This can be demonstrated by running a load test whilst deploying a change to the chart values that causes pods to be rolled:

    % (echo "GET http://$PROXY_IP/status/201" | vegeta attack -rate 50 -duration 30s -timeout 5s -http2=false -keepalive=false -output=vegeta.out) &
    [1] 99452

    * % helm upgrade test kong/kong --install --version 2.14.0 --wait --set env.restart=$(date +%s) && fg
    Release "test" has been upgraded. Happy Helming!
    …
    [1]  + 99452 running    ( echo "GET http://$PROXY_IP/status/201" | vegeta attack -rate 50 -duration  )

    % vegeta report vegeta.out
    Requests      [total, rate, throughput]         1500, 50.03, 48.33
    Duration      [total, attack, wait]             29.983s, 29.98s, 3.297ms
    Latencies     [min, mean, 50, 90, 95, 99, max]  1.765ms, 3.823ms, 3.505ms, 5.353ms, 6ms, 8.102ms, 36.237ms
    Bytes In      [total, mean]                     2448, 1.63
    Bytes Out     [total, mean]                     0, 0.00
    Success       [ratio]                           96.60%
    Status Codes  [code:count]                      201:1449  404:51
    Error Set:
    404 Not Found

When tested with this change supplied to the latest chart:

    % (echo "GET http://$PROXY_IP/status/201" | vegeta attack -rate 50 -duration 30s -timeout 5s -http2=false -keepalive=false -output=vegeta.out) &
    [1] 4518

    * % helm upgrade test kong/kong --install --version 2.14.0 --wait --set env.restart=$(date +%s) --set ingressController.readinessProbe.httpGet.path=/readyz && fg
    Release "test" has been upgraded. Happy Helming!
    …
    [1]  + 4518 running    ( echo "GET http://$PROXY_IP/status/201" | vegeta attack -rate 50 -duration  )

    % vegeta report vegeta.out
    Requests      [total, rate, throughput]         1500, 50.03, 50.03
    Duration      [total, attack, wait]             29.983s, 29.98s, 3.651ms
    Latencies     [min, mean, 50, 90, 95, 99, max]  1.569ms, 4.745ms, 3.502ms, 5.851ms, 21.034ms, 22.15ms, 41.41ms
    Bytes In      [total, mean]                     0, 0.00
    Bytes Out     [total, mean]                     0, 0.00
    Success       [ratio]                           100.00%
    Status Codes  [code:count]                      201:1500
    Error Set:

#### Special notes for your reviewer:

The functionality of this endpoint was extended in KIC 2.0.0:

- https://github.com/Kong/kubernetes-ingress-controller/commit/b0ff6129d59466786cb4430f675b5c04c4a84ff3

I thought that the problem might have been introduced by the startup sleep in KIC 2.2.1 but the first version that I can replicate it with is KIC 2.3.x:

- https://github.com/Kong/kubernetes-ingress-controller/commit/30ff318f446227c762936ad8c765b48461d64641

This problem was caught by our own CI tests. A similar approach could be used in `scripts/test-upgrade.sh` to prevent future regressions, but I'd like some feedback on the idea before implementing it in a separate PR.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
