### PR TITLE
chore(tests) add kong-only deployment with no conf

### DIFF
--- a/charts/kong/ci/test6-values.yaml
+++ b/charts/kong/ci/test6-values.yaml
@@ -1,0 +1,34 @@
+# CI test for testing dbless deployment without ingress controllers
+# - disable ingress controller
+# - no static config
+ingressController:
+  enabled: false
+# - disable DB for kong
+env:
+  anonymous_reports: "off"
+  database: "off"
+postgresql:
+  enabled: false
+proxy:
+  type: NodePort
+deployment:
+  initContainers:
+    - name: "bash"
+      image: "bash:latest"
+      command: ["/bin/sh", "-c", "true"]
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "64Mi"
+        requests:
+          cpu: "100m"
+          memory: "64Mi"
+      volumeMounts:
+      - name: "tmpdir"
+        mountPath: "/opt/tmp"
+  userDefinedVolumes:
+  - name: "tmpdir"
+    emptyDir: {}
+  userDefinedVolumeMounts:
+  - name: "tmpdir"
+    mountPath: "/opt/tmp"


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a test case for Kong-only releases without configuration.

#### Special notes for your reviewer:

Please also review https://github.com/Kong/charts/pull/714 and https://github.com/Kong/charts/pull/715. These were force-merged to fix the problems that this new test is intended to catch.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- ~Changes are documented under the "Unreleased" header in CHANGELOG.md~ tests only
- ~New or modified sections of values.yaml are documented in the README.md~ tests only
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
