### PR TITLE
chore(ci): bump CI dependencies, disable anonymous reporting in tests and some indentation fixes

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -17,14 +17,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.9.0
+          version: v3.11.0
 
       - name: Add Bitnami
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
@@ -51,11 +51,9 @@ jobs:
         run: ct install --all
 
   integration-test:
-    # Not a real requirement, but due to worker CPU contention, this can fail if it runs concurrent with lint-test
-    needs: lint-test
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -63,7 +61,7 @@ jobs:
       - name: setup helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.9.0
+          version: v3.11.0
 
       - name: setup testing environment (kind-cluster)
         run: ./scripts/test-env.sh

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -17,11 +17,11 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.9.0
+          version: v3.11.0
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.9.0
+          version: v3.11.0
 
       - name: Add dependency chart repos
         run: |

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}/.."
-KIND_VERSION="${KIND_VERSION:-v0.11.1}"
+KIND_VERSION="${KIND_VERSION:-v0.17.0}"
 
 # ------------------------------------------------------------------------------
 # Setup Tools - Docker
@@ -53,7 +53,7 @@ docker info 1>/dev/null
 # ensure kind command is accessible
 if ! command -v kind &> /dev/null
 then
-    go get -v sigs.k8s.io/kind@"${KIND_VERSION}"
+    go install sigs.k8s.io/kind@"${KIND_VERSION}"
 fi
 
 # ensure kind is functional
@@ -78,9 +78,9 @@ ktf 1>/dev/null
 # Create Testing Environment
 # ------------------------------------------------------------------------------
 
-ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma --kubernetes-version 1.24.4
+ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma --kubernetes-version 1.25.3
 
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.4.0" | kubectl apply -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1" | kubectl apply -f -
 
 echo "INFO: Updating helm dependencies"
 helm dependency update charts/kong/

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -67,12 +67,17 @@ then
     echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
     helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
         --set deployment.test.enabled=true \
-		--set ingressController.env.feature_gates="Gateway=true" \
-		charts/kong/
+        --set ingressController.env.feature_gates="GatewayAlpha=true" \
+        --set ingressController.env.anonymous_reports="false" \
+        charts/kong/
 else
     echo "INFO: installing chart as release ${RELEASE_NAME} with controller tag ${TAG} to namespace ${RELEASE_NAMESPACE}"
-    helm install --namespace "${RELEASE_NAMESPACE}" \
-        --set ingressController.image.tag="${TAG}" "${RELEASE_NAME}" --set deployment.test.enabled=true charts/kong/
+    helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
+        --set ingressController.image.tag="${TAG}" \
+        --set ingressController.env.feature_gates="GatewayAlpha=true" \
+        --set ingressController.env.anonymous_reports="false" \
+        --set deployment.test.enabled=true \
+        charts/kong/
 fi
 
 # ------------------------------------------------------------------------------

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -33,7 +33,9 @@ KUBERNETES_VERSION="$($KUBECTL version -o json | jq -r '.serverVersion.gitVersio
 
 echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
 helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
-    --set deployment.test.enabled=true charts/kong/
+    --set ingressController.env.anonymous_reports="false" \
+    --set deployment.test.enabled=true \
+    charts/kong/
 
 # ------------------------------------------------------------------------------
 # Test Chart - Kubernetes Ingress Controller
@@ -47,8 +49,12 @@ helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
 # ------------------------------------------------------------------------------
 
 echo "INFO: upgrading the helm chart to image tag ${TAG}"
-helm upgrade --namespace "${RELEASE_NAMESPACE}" --set ingressController.image.tag="${TAG}" "${RELEASE_NAME}" \
-    --set deployment.test.enabled=true --set ingressController.image.effectiveSemver="${EFFECTIVE_TAG}" charts/kong/
+helm upgrade --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
+    --set ingressController.image.tag="${TAG}" \
+    --set deployment.test.enabled=true \
+    --set ingressController.env.anonymous_reports="false" \
+    --set ingressController.image.effectiveSemver="${EFFECTIVE_TAG}" \
+    charts/kong/
 
 # ------------------------------------------------------------------------------
 # Test Upgraded Chart


### PR DESCRIPTION
#### What this PR does / why we need it:

- bump helm to 3.11
- bump python to 3.11
- bump kind to 0.17.0
- bump Gateway API CRDs to 0.5.1 experimental
- indentation fixes (putting each `--set` on a separate line)
- disable anonymous reporting in CI tests

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
