### PR TITLE
Release 2.15.3 to fix volume mount issue

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+
+## 2.15.3
+
 ### Fixed
 
 * Changed `ingressController.readinessProbe` to use `/readyz` to prevent pods from becoming ready and serving 404s prior to the `ingress-controller` first syncing config to the `proxy` [#716](https://github.com/Kong/charts/pull/716).
+* Fixed incorrect `if` block order in volume mount templates.
 
 ## 2.15.2
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.15.2
+version: 2.15.3
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -477,22 +477,23 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
-{{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
-{{- if gt $dblessSourceCount 1 -}}
-    {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
+  {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
+    {{- if gt $dblessSourceCount 1 -}}
+      {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
 - name: kong-custom-dbless-config-volume
-  {{- if .Values.dblessConfig.configMap }}
+    {{- if .Values.dblessConfig.configMap }}
   configMap:
     name: {{ .Values.dblessConfig.configMap }}
-  {{- else if .Values.dblessConfig.secret }}
+    {{- else if .Values.dblessConfig.secret }}
   secret:
     secretName: {{ .Values.dblessConfig.secret }}
-  {{- else }}
+    {{- else }}
   configMap:
     name: {{ template "kong.dblessConfig.fullname" . }}
+    {{- end }}
   {{- end }}
 {{- end }}
-{{- end }}
+
 {{- if .Values.ingressController.admissionWebhook.enabled }}
 - name: webhook-cert
   secret:
@@ -551,15 +552,15 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- end }}
 {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
-{{- if gt $dblessSourceCount 1 -}}
-{{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+  {{- if gt $dblessSourceCount 1 -}}
+    {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 - name: kong-custom-dbless-config-volume
   mountPath: /kong_dbless/
-{{- end }}
+    {{- end }}
+  {{- end }}
 {{- range .Values.secretVolumes }}
 - name:  {{ . }}
   mountPath: /etc/secrets/{{ . }}
-{{- end }}
 {{- end }}
 {{- range .Values.plugins.configMaps }}
 {{- $mountPath := printf "/opt/kong/plugins/%s" .pluginName }}


### PR DESCRIPTION
#### What this PR does / why we need it:

DB-less config stuff accidentally started chopping off volume mounts because YAML template if blocks are pain. This makes the volumes and their mounts not disappear if you don't have a particular configuration, and tries to make the template whitespace a bit clearer.

#### Which issue this PR fixes

  - fixes #717 

#### Special notes for your reviewer:

Significant whitespace within templates that have complex nest if blocks because YAML was a mistake. Supplemental reports from @ahuffman.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the ~"Unreleased"~ (patch release, adds its own section and new unreleased section) header in CHANGELOG.md
- ~New or modified sections of values.yaml are documented in the README.md~ none
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
