### PR TITLE
User definable annotations and labels for PodSecurityPolicy

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+* Enable users to specify their own labels and annotations to generated PodSecurityPolicy
+  [#721](https://github.com/Kong/charts/pull/721)
 
 ## 2.15.3
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -788,6 +788,8 @@ kong:
 | podDisruptionBudget.maxUnavailable | Represents the minimum number of Pods that can be unavailable (integer or percentage) | `50%`               |
 | podDisruptionBudget.minAvailable   | Represents the number of Pods that must be available (integer or percentage)          |                     |
 | podSecurityPolicy.enabled          | Enable podSecurityPolicy for Kong                                                     | `false`             |
+| podSecurityPolicy.labels           | Labels to add to podSecurityPolicy for Kong                                           | `{}`             |
+| podSecurityPolicy.annotations      | Annotations to add to podSecurityPolicy for Kong                                      | `{}`             |
 | podSecurityPolicy.spec             | Collection of [PodSecurityPolicy settings](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#what-is-a-pod-security-policy) | |
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | `""`                |
 | secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |

--- a/charts/kong/templates/psp.yaml
+++ b/charts/kong/templates/psp.yaml
@@ -5,6 +5,17 @@ metadata:
   name: {{ template "kong.serviceAccountName" . }}-psp
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
+  {{- with .Values.podSecurityPolicy.labels }}
+  {{- range $key, $value := . }}
+    {{ $key }}: {{ $value }}
+  {{- end }}
+  {{- end }}
+  {{- with .Values.podSecurityPolicy.annotations }}
+  annotations:
+  {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
 {{ .Values.podSecurityPolicy.spec | toYaml | indent 2 }}
 ---

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -801,6 +801,8 @@ podDisruptionBudget:
 
 podSecurityPolicy:
   enabled: false
+  labels: {}
+  annotations: {}
   spec:
     privileged: false
     fsGroup:


### PR DESCRIPTION
#### What this PR does / why we need it:

Add the ability to specify additional annotations and labels to the PodSecurityPolicy generated by the helm chart.

This allows to specify seccomp annotations like `seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'`

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
