### PR TITLE
fix(proxy) fix volumes and environement when using dblessConfig

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Enable users to specify their own labels and annotations to generated PodSecurityPolicy
   [#721](https://github.com/Kong/charts/pull/721)
 
+### Fixed
+
+* Fix volumes and environment when using `dblessConfig`.
+
 ## 2.15.3
 
 ### Fixed

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -478,19 +478,19 @@ The name of the service used for the ingress controller's validation webhook
 
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
   {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
-    {{- if gt $dblessSourceCount 1 -}}
-      {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
+  {{- if gt $dblessSourceCount 1 -}}
+    {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
+  {{- end }}
 - name: kong-custom-dbless-config-volume
-    {{- if .Values.dblessConfig.configMap }}
+  {{- if .Values.dblessConfig.configMap }}
   configMap:
     name: {{ .Values.dblessConfig.configMap }}
-    {{- else if .Values.dblessConfig.secret }}
+  {{- else if .Values.dblessConfig.secret }}
   secret:
     secretName: {{ .Values.dblessConfig.secret }}
-    {{- else }}
+  {{- else }}
   configMap:
     name: {{ template "kong.dblessConfig.fullname" . }}
-    {{- end }}
   {{- end }}
 {{- end }}
 
@@ -551,13 +551,13 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- end }}
 {{- end }}
-{{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
-  {{- if gt $dblessSourceCount 1 -}}
-    {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+{{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
+  {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
+  {{- if eq $dblessSourceCount 1 }}
 - name: kong-custom-dbless-config-volume
   mountPath: /kong_dbless/
-    {{- end }}
   {{- end }}
+{{- end }}
 {{- range .Values.secretVolumes }}
 - name:  {{ . }}
   mountPath: /etc/secrets/{{ . }}
@@ -913,10 +913,10 @@ the template that it itself is using form the above sections.
 {{- end }}
 
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
-{{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
-{{- if gt $dblessSourceCount 1 -}}
-  {{- $_ := set $autoEnv "KONG_DECLARATIVE_CONFIG" "/kong_dbless/kong.yml" -}}
-{{- end }}
+  {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
+  {{- if eq $dblessSourceCount 1 -}}
+    {{- $_ := set $autoEnv "KONG_DECLARATIVE_CONFIG" "/kong_dbless/kong.yml" -}}
+  {{- end }}
 {{- end }}
 
 {{- $_ := set $autoEnv "KONG_PLUGINS" (include "kong.plugins" .) -}}


### PR DESCRIPTION
Fixed conditions for kong.volumes, kong.volumeMounts and KUBE_DECLARATIVE_CONFIG so that they are correctly defined when dblessConfig is sued.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
