### PR TITLE
ci: add concurrency to pr workflows

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -1,4 +1,10 @@
-name: Release Charts
+name: PR tests
+
+concurrency:
+  # Run only for most recent commit in PRs but for all tags and commits on main
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 on:
   pull_request:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) setting to PR workflow so that we only run for the very last commit on PR branch. (this should limit the queueing when multiple PRs are being updated in the same timeframe).

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
