### PR TITLE
feat(template) only allow strings in environment variables

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,7 +8,7 @@
   `.Values.ingressController.env.*` (to set environment variables of ingress
   controller container) only allow strings. Specifying values with other types
   (bool, int) will raise error in rendering the template.
-  If you want to set an enviroment varialble to a numerical value or keywords
+  If you want to set an environment variable to a numerical value or keywords
   for boolean values  (like `true`,`yes`,`off`) via helm command, please use 
   `--set-string` flag.
   [#728](https://github.com/Kong/charts/pull/728)

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+* `.Values.env.*` (to set environment variables of Kong proxy container) and 
+  `.Values.ingressController.env.*` (to set environment variables of ingress
+  controller container) only allow strings. Specifying values with other types
+  (bool, int) will raise error in rendering the template.
+  [#728](https://github.com/Kong/charts/pull/728)
+
 ### Improvements
 
 * Enable users to specify their own labels and annotations to generated PodSecurityPolicy

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,6 +8,9 @@
   `.Values.ingressController.env.*` (to set environment variables of ingress
   controller container) only allow strings. Specifying values with other types
   (bool, int) will raise error in rendering the template.
+  If you want to set an enviroment varialble to a numerical value or keywords
+  for boolean values  (like `true`,`yes`,`off`) via helm command, please use 
+  `--set-string` flag.
   [#728](https://github.com/Kong/charts/pull/728)
 
 ### Improvements

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -17,7 +17,7 @@ postgresql:
     password: kong
   service:
     ports:
-      postgresql: 5432
+      postgresql: "5432"
 env:
   anonymous_reports: "off"
   database: "postgres"

--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -151,7 +151,7 @@ ingressController:
   enabled: true
   env:
     kong_admin_filter_tag: ingress_controller_default
-    kong_admin_tls_skip_verify: true
+    kong_admin_tls_skip_verify: "true"
     kong_admin_token:
       valueFrom:
         secretKeyRef:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -370,7 +370,7 @@ The name of the service used for the ingress controller's validation webhook
 */}}
 
 {{- $autoEnv := dict -}}
-{{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" true -}}
+{{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" "true" -}}
 {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" (printf "%s/%s-proxy" ( include "kong.namespace" . ) (include "kong.fullname" .)) -}}
 {{- $_ := set $autoEnv "CONTROLLER_INGRESS_CLASS" .Values.ingressController.ingressClass -}}
 {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}
@@ -974,8 +974,7 @@ Environment variables are sorted alphabetically
   value: {{ $val | quote }}
 {{- end }}
 {{- else }}
-- name: {{ . }}
-  value: {{ $val | quote }}
+{{ fail (printf "Invalid type: required string or map[string]interface {}, actual %s" $valueType)}}
 {{- end }}
 {{- end -}}
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -493,7 +493,7 @@ ingressController:
     # The controller disables TLS verification by default because Kong
     # generates self-signed certificates by default. Set this to false once you
     # have installed CA-signed certificates.
-    kong_admin_tls_skip_verify: true
+    kong_admin_tls_skip_verify: "true"
     # If using Kong Enterprise with RBAC enabled, uncomment the section below
     # and specify the secret/key containing your admin token.
     # kong_admin_token:

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -68,14 +68,14 @@ then
     helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
         --set deployment.test.enabled=true \
         --set ingressController.env.feature_gates="GatewayAlpha=true" \
-        --set ingressController.env.anonymous_reports="false" \
+        --set-string ingressController.env.anonymous_reports="false" \
         charts/kong/
 else
     echo "INFO: installing chart as release ${RELEASE_NAME} with controller tag ${TAG} to namespace ${RELEASE_NAMESPACE}"
     helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
         --set ingressController.image.tag="${TAG}" \
         --set ingressController.env.feature_gates="GatewayAlpha=true" \
-        --set ingressController.env.anonymous_reports="false" \
+        --set-string ingressController.env.anonymous_reports="false" \
         --set deployment.test.enabled=true \
         charts/kong/
 fi

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -33,7 +33,7 @@ KUBERNETES_VERSION="$($KUBECTL version -o json | jq -r '.serverVersion.gitVersio
 
 echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
 helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
-    --set ingressController.env.anonymous_reports="false" \
+    --set-string ingressController.env.anonymous_reports="false" \
     --set deployment.test.enabled=true \
     charts/kong/
 
@@ -52,7 +52,7 @@ echo "INFO: upgrading the helm chart to image tag ${TAG}"
 helm upgrade --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
     --set ingressController.image.tag="${TAG}" \
     --set deployment.test.enabled=true \
-    --set ingressController.env.anonymous_reports="false" \
+    --set-string ingressController.env.anonymous_reports="false" \
     --set ingressController.image.effectiveSemver="${EFFECTIVE_TAG}" \
     charts/kong/
 


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

only allow strings(not `int` or `bool`) in environment variables to avoid unwanted modifications on the values, like `off` (without quotes, meaning boolean `false`) changed to `"false"` in envs. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #701 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
