### PR TITLE
Reject boolean log envvars

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,17 +2,6 @@
 
 ## Unreleased
 
-### Breaking Changes
-
-* `.Values.env.*` (to set environment variables of Kong proxy container) and
-  `.Values.ingressController.env.*` (to set environment variables of ingress
-  controller container) only allow strings. Specifying values with other types
-  (bool, int) will raise error in rendering the template.
-  If you want to set an environment variable to a numerical value or keywords
-  for boolean values  (like `true`,`yes`,`off`) via helm command, please use
-  `--set-string` flag.
-  [#728](https://github.com/Kong/charts/pull/728)
-
 ### Improvements
 
 * Enable users to specify their own labels and annotations to generated PodSecurityPolicy

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,9 +8,8 @@
   [#721](https://github.com/Kong/charts/pull/721)
 * Replaced static secret with projected volume in deployment.
   [#722](https://github.com/Kong/charts/pull/722)
-
-### Updates
-
+* Reject invalid log config values.
+  [#733](https://github.com/Kong/charts/pull/733)
 * Update custom resource definitions to latest v2.8.1 from
   kong/kubernetes-ingress-controller
   [#730](https://github.com/Kong/charts/pull/730)

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -17,7 +17,7 @@ postgresql:
     password: kong
   service:
     ports:
-      postgresql: "5432"
+      postgresql: 5432
 env:
   anonymous_reports: "off"
   database: "postgres"

--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -151,7 +151,7 @@ ingressController:
   enabled: true
   env:
     kong_admin_filter_tag: ingress_controller_default
-    kong_admin_tls_skip_verify: "true"
+    kong_admin_tls_skip_verify: true
     kong_admin_token:
       valueFrom:
         secretKeyRef:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -370,7 +370,7 @@ The name of the service used for the ingress controller's validation webhook
 */}}
 
 {{- $autoEnv := dict -}}
-{{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" "true" -}}
+{{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" true -}}
 {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" (printf "%s/%s-proxy" ( include "kong.namespace" . ) (include "kong.fullname" .)) -}}
 {{- $_ := set $autoEnv "CONTROLLER_INGRESS_CLASS" .Values.ingressController.ingressClass -}}
 {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}
@@ -974,7 +974,8 @@ Environment variables are sorted alphabetically
   value: {{ $val | quote }}
 {{- end }}
 {{- else }}
-{{ fail (printf "Invalid type: required string or map[string]interface {}, actual %s" $valueType)}}
+- name: {{ . }}
+  value: {{ $val | quote }}
 {{- end }}
 {{- end -}}
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -927,6 +927,11 @@ the template that it itself is using form the above sections.
 
 {{- $userEnv := dict -}}
 {{- range $key, $val := .Values.env }}
+  {{- if (contains "_log" $key) -}}
+    {{- if (eq (typeOf $val) "bool") -}}
+      {{- fail (printf "env.%s must use string 'off' to disable. Without quotes, YAML will coerce the value to a boolean and Kong will reject it" $key) -}}
+	{{- end -}}
+  {{- end -}}
   {{- $upper := upper $key -}}
   {{- $var := printf "KONG_%s" $upper -}}
   {{- $_ := set $userEnv $var $val -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -493,7 +493,7 @@ ingressController:
     # The controller disables TLS verification by default because Kong
     # generates self-signed certificates by default. Set this to false once you
     # have installed CA-signed certificates.
-    kong_admin_tls_skip_verify: "true"
+    kong_admin_tls_skip_verify: true
     # If using Kong Enterprise with RBAC enabled, uncomment the section below
     # and specify the secret/key containing your admin token.
     # kong_admin_token:

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -68,14 +68,14 @@ then
     helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
         --set deployment.test.enabled=true \
         --set ingressController.env.feature_gates="GatewayAlpha=true" \
-        --set-string ingressController.env.anonymous_reports="false" \
+        --set ingressController.env.anonymous_reports="false" \
         charts/kong/
 else
     echo "INFO: installing chart as release ${RELEASE_NAME} with controller tag ${TAG} to namespace ${RELEASE_NAMESPACE}"
     helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
         --set ingressController.image.tag="${TAG}" \
         --set ingressController.env.feature_gates="GatewayAlpha=true" \
-        --set-string ingressController.env.anonymous_reports="false" \
+        --set ingressController.env.anonymous_reports="false" \
         --set deployment.test.enabled=true \
         charts/kong/
 fi

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -33,7 +33,7 @@ KUBERNETES_VERSION="$($KUBECTL version -o json | jq -r '.serverVersion.gitVersio
 
 echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
 helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
-    --set-string ingressController.env.anonymous_reports="false" \
+    --set ingressController.env.anonymous_reports="false" \
     --set deployment.test.enabled=true \
     charts/kong/
 
@@ -52,7 +52,7 @@ echo "INFO: upgrading the helm chart to image tag ${TAG}"
 helm upgrade --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
     --set ingressController.image.tag="${TAG}" \
     --set deployment.test.enabled=true \
-    --set-string ingressController.env.anonymous_reports="false" \
+    --set ingressController.env.anonymous_reports="false" \
     --set ingressController.image.effectiveSemver="${EFFECTIVE_TAG}" \
     charts/kong/
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Checks the type of any environment variable containing `_log`. If it is a boolean, emit a failure instructing users to add quotes.

Reverts https://github.com/Kong/charts/commit/2edf22d989508dc53ffbcb144879b9262a96538d, which previously addressed this by enforcing string types for all variables.

#### Which issue this PR fixes
  - fixes #701 

#### Special notes for your reviewer:

In general, we don't care if YAML's stupid type coercion nonsense changes `off` to `false`: Pod envvars are ultimately all treated as strings by Kubernetes, and Kong [accepts either value](https://github.com/Kong/kong/blob/5fc84a94f5e9d8b1ec1042b6e45e6731e7b09711/kong.conf.default#L15) for boolean config values.

The various `_log` variables are a special case: these are not booleans, and the literal string `off` is [a special value that disables logging](http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log). YAML nonsense converting _these_ to booleans (and then Kubernetes converting them back to strings) _is_ a problem, since `false` is valid value for the non-special case of this of setting, where it's instead interpreted as a file path. I'm not entirely sure why using `<prefix dir>/false` breaks the container (it's a valid path and Kong should be able to write to it fine), but in any case, it's something we can check special for these.

#### Manual testing

Dunno why `--set` doesn't work to set the boolean of this for me, so these are in values.yaml files instead. With this change:

```
17:24:29-0800 esenin $ cat /tmp/values_string_off.yaml
env:
  proxy_access_log: "off"

17:24:34-0800 esenin $ cat /tmp/values_raw_off.yaml   
env:
  proxy_access_log: off

17:24:36-0800 esenin $ helm template --debug bread /tmp/symkong -f /tmp/values_string_off.yaml | grep -A1 PROXY_ACCESS
        - name: KONG_PROXY_ACCESS_LOG
          value: "off"
--
        - name: KONG_PROXY_ACCESS_LOG
          value: "off"

17:25:01-0800 esenin $ helm template --debug bread /tmp/symkong -f /tmp/values_raw_off.yaml                        
Error: execution error at (kong/templates/deployment.yaml:99:12): env.proxy_access_log must use string 'off' to disable. Without quotes, YAML will coerce the value to a boolean and Kong will reject it
helm.go:84: [debug] execution error at (kong/templates/deployment.yaml:99:12): env.proxy_access_log must use string 'off' to disable. Without quotes, YAML will coerce the value to a boolean and Kong will reject it
```
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
