### PR TITLE
fix: make semverCompare handle GKE versions and release 2.16.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Unreleased
+## 2.16.1
 
-Nothing yet.
+### Fixed 
+
+* serviceAccount projected volume is properly provisioned for GKE clusters >= 1.20.
+  [#735](https://github.com/Kong/charts/pull/735)
 
 ## 2.16.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.16.0
+version: 2.16.1
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -298,7 +298,11 @@ spec:
       {{- include "kong.userDefinedVolumes" . | nindent 8 -}}
       {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
         - name: {{ template "kong.serviceAccountTokenName" . }}
-          {{- if semverCompare ">=1.20" .Capabilities.KubeVersion.Version }}
+          {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
+          See the related documentation of semver module that Helm depends on for semverCompare:
+          https://github.com/Masterminds/semver#working-with-prerelease-versions
+          Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
+          {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
           projected:
             sources:
             - serviceAccountToken:

--- a/charts/kong/templates/secret-sa-token.yaml
+++ b/charts/kong/templates/secret-sa-token.yaml
@@ -1,4 +1,8 @@
-{{- if and (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name) (semverCompare "<1.20" .Capabilities.KubeVersion.Version) }}
+{{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
+See the related documentation of semver module that Helm depends on for semverCompare:
+https://github.com/Masterminds/semver#working-with-prerelease-versions
+Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
+{{- if and (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name) (semverCompare "<1.20.0-0" .Capabilities.KubeVersion.Version) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes `semverCompare` call that decides whether to create a projected volumeMount for the service account. It didn't work on GKE where the expected version format is `vX.Y.Z-gke.N`. It was resulting in:
- using a reference to secret in the deployment volume (`deployment.yaml`)
- not creating a secret (`secret-sa-token.yaml`)

which made deployment fail to become ready because of the missing secret to be mounted.

Regression was introduced in https://github.com/Kong/charts/pull/722.

See related upstream issues: 
- https://github.com/Masterminds/semver#working-with-prerelease-versions
- https://github.com/helm/helm/issues/3810

#### Which issue this PR fixes

Fixes bug discovered in KTF CI run: https://github.com/Kong/kubernetes-testing-framework/actions/runs/4102865692/jobs/7076352608

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- ~[ ] New or modified sections of values.yaml are documented in the README.md~
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
