### PR TITLE
fix(admission) disable when KIC is disabled and release 2.16.2

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.16.2
+
+### Fixed 
+
+* The admission webhook is disabled when the ingress controller is disabled, as
+  the admission webhook requires a service provided by the ingress controller.
+
 ## 2.16.1
 
 ### Fixed 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.16.1
+version: 2.16.2
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressController.admissionWebhook.enabled }}
+{{- if (and .Values.ingressController.admissionWebhook.enabled .Values.ingressController.enabled) }}
 {{- $certCert := "" -}}
 {{- $certKey := "" -}}
 {{- $caCert := "" -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Now that the webhook is enabled by default, the chart will create it by default even if KIC is disabled. Requests from the webhook will then fail consistently, as KIC provides the admission webhook service.

This change adds an `and` clause that disables the webhook when KIC is not enabled, and releases a patch.

#### Which issue this PR fixes

Reported in chat.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
