### PR TITLE
fix(template) custom dblessconfig volume

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Unreleased
+## 2.16.3
 
 * Fix template issue preventing custom dblessconfig volume from being mounted.
+  [#741](https://github.com/Kong/charts/pull/741)
 
 ## 2.16.2
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix template issue preventing custom dblessconfig volume from being mounted.
+
 ## 2.16.2
 
 ### Fixed 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.16.2
+version: 2.16.3
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -478,8 +478,9 @@ The name of the service used for the ingress controller's validation webhook
 
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
   {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
-    {{- if gt $dblessSourceCount 1 -}}
-      {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
+  {{- if gt $dblessSourceCount 1 -}}
+    {{- fail "Ambiguous configuration: only one of of .Values.dblessConfig.configMap, .Values.dblessConfig.secret, and .Values.dblessConfig.config can be set." -}}
+  {{- else if eq $dblessSourceCount 1 }}
 - name: kong-custom-dbless-config-volume
     {{- if .Values.dblessConfig.configMap }}
   configMap:
@@ -552,7 +553,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 {{- end }}
 {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
-  {{- if gt $dblessSourceCount 1 -}}
+  {{- if eq $dblessSourceCount 1 -}}
     {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 - name: kong-custom-dbless-config-volume
   mountPath: /kong_dbless/
@@ -914,7 +915,7 @@ the template that it itself is using form the above sections.
 
 {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off")) }}
 {{- $dblessSourceCount := (add (.Values.dblessConfig.configMap | len | min 1) (.Values.dblessConfig.secret | len | min 1) (.Values.dblessConfig.config | len | min 1)) -}}
-{{- if gt $dblessSourceCount 1 -}}
+{{- if eq $dblessSourceCount 1 -}}
   {{- $_ := set $autoEnv "KONG_DECLARATIVE_CONFIG" "/kong_dbless/kong.yml" -}}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Fix template issue preventing custom dblessconfig volume from being mounted.

The helpers are supposed to expect exactly one between `dblessConfig.secret` and `dblessConfig.configMap`.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
