### PR TITLE
fix(hpa) properly detect hpa capabilities, release 2.16.4

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
+## 2.16.4
+
+### Fixed
+
+* HorizontalPodAutoscaler's API version is detected properly.
+  [#744](https://github.com/Kong/charts/pull/744)
+
 ## 2.16.3
+
+### Fixed
 
 * Fix template issue preventing custom dblessconfig volume from being mounted.
   [#741](https://github.com/Kong/charts/pull/741)

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.16.3
+version: 2.16.4
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1398,9 +1398,9 @@ extensions/v1beta1
 {{- end -}}
 
 {{- define "kong.autoscalingVersion" -}}
-{{- if (.Capabilities.APIVersions.Has "autoscaling/v2") -}}
+{{- if (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") -}}
 autoscaling/v2
-{{- else if (.Capabilities.APIVersions.Has "autoscaling/v2beta2") -}}
+{{- else if (.Capabilities.APIVersions.Has "autoscaling/v2beta2/HorizontalPodAutoscaler") -}}
 autoscaling/v2beta2
 {{- else -}}
 autoscaling/v1


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

When using ArgoCD to deploy Kong gateway using this Helm chart, the HorizontalPodAutoscaler api version is not well detected : on k8s 1.22, Argocd tries to use the autoscaling/v2 but it is not available, so it fails to deploy.
This fix is similar to this one: https://github.com/elastic/helm-charts/pull/1684
This bug seems to have been introduced by https://github.com/Kong/charts/pull/679

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
