### PR TITLE
feat: add support for single controller deployments

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+* Added support for single controller deployments.
+  With `deployment.singleControler.enabled` set to `true` you can instruct helm
+  to produce separate deployments for Kong Gateway and Kong Ingress Controller.
+  [#744](https://github.com/Kong/charts/pull/744)
+
 ## 2.16.4
 
 ### Fixed

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -97,7 +97,9 @@ spec:
     targetPort: webhook
   selector:
     {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: app
+    {{- if .Values.deployment.singleController.enabled -}}
+    {{- include "kong.selectorLabels.component" (dict "component" "controller" ) | nindent 4 }}
+    {{- end -}}
 {{- if not .Values.ingressController.admissionWebhook.certificate.provided }}
 ---
 apiVersion: v1

--- a/charts/kong/templates/deployment-single-controller.yaml
+++ b/charts/kong/templates/deployment-single-controller.yaml
@@ -1,16 +1,13 @@
-{{- if (and (or .Values.deployment.kong.enabled .Values.ingressController.enabled) (not .Values.deployment.singleController.enabled)) }}
+
+{{- if (and (or .Values.deployment.kong.enabled .Values.ingressController.enabled) .Values.deployment.singleController.enabled) }}
 apiVersion: apps/v1
-{{- if .Values.deployment.daemonset }}
-kind: DaemonSet
-{{- else }}
 kind: Deployment
-{{- end }}
 metadata:
-  name: {{ template "kong.fullname" . }}
+  name: {{ include "kong.deployment.controller.fullname" . }}
   namespace:  {{ template "kong.namespace" . }}
   labels:
     {{- include "kong.metaLabels" . | nindent 4 }}
-    app.kubernetes.io/component: app
+    {{- include "kong.selectorLabels.controller" . | nindent 4 }}
   {{- if .Values.deploymentAnnotations }}
   annotations:
   {{- range $key, $value := .Values.deploymentAnnotations }}
@@ -19,19 +16,13 @@ metadata:
   {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  {{- if not .Values.deployment.daemonset }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
+  replicas: {{ include "kong.deployment.controller.replicaCount" . }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "kong.selectorLabels" . | nindent 6 }}
+      {{- include "kong.selectorLabels.controller" . | nindent 6 }}
   {{- if .Values.updateStrategy }}
-  {{- if .Values.deployment.daemonset }}
-  updateStrategy:
-  {{- else }}
   strategy:
-  {{- end }}
 {{ toYaml .Values.updateStrategy | indent 4 }}
   {{- end }}
   {{- if .Values.deployment.minReadySeconds }}
@@ -56,7 +47,157 @@ spec:
         {{- end }}
       labels:
         {{- include "kong.metaLabels" . | nindent 8 }}
-        app.kubernetes.io/component: app
+        {{- include "kong.selectorLabels.component" (dict "component" "controller" ) | nindent 8 }}
+        app: {{ template "kong.fullname" . }}
+        version: {{ .Chart.AppVersion | quote }}
+        {{- if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.deployment.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+      {{- end }}
+      {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
+      serviceAccountName: {{ template "kong.serviceAccountName" . }}
+      {{- end }}
+      {{- if (and (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name) .Values.deployment.serviceAccount.automountServiceAccountToken) }}
+      automountServiceAccountToken: true
+      {{- else }}
+      automountServiceAccountToken: false
+      {{ end }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.deployment.hostAliases }}
+      hostAliases:
+        {{- toYaml .Values.deployment.hostAliases | nindent 6 }}
+      {{- end}}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- end }}
+      containers:
+      {{- if .Values.ingressController.enabled }}
+      {{- include "kong.controller-container" . | nindent 6 }}
+      {{ end }}
+      {{- if .Values.deployment.sidecarContainers }}
+      {{- toYaml .Values.deployment.sidecarContainers | nindent 6 }}
+      {{- end }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+    {{- end }}
+    {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml .Values.topologySpreadConstraints | indent 8 }}
+    {{- end }}
+      securityContext:
+      {{- include "kong.podsecuritycontext" . | nindent 8 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+    {{- end }}
+      volumes:
+      {{- include "kong.volumes" . | nindent 8 -}}
+      {{- include "kong.userDefinedVolumes" . | nindent 8 -}}
+      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+        - name: {{ template "kong.serviceAccountTokenName" . }}
+          {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
+          See the related documentation of semver module that Helm depends on for semverCompare:
+          https://github.com/Masterminds/semver#working-with-prerelease-versions
+          Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
+          {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+          projected:
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 3607
+                path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+          {{- else }}
+          secret:
+            secretName: {{ template "kong.serviceAccountTokenName" . }}
+            items:
+            - key: token
+              path: token
+            - key: ca.crt
+              path: ca.crt
+            - key: namespace
+              path: namespace
+          {{- end }}
+      {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kong.deployment.proxy.fullname" . }}
+  namespace:  {{ template "kong.namespace" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+    {{- include "kong.selectorLabels.proxy" . | nindent 4 }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+  {{- range $key, $value := .Values.deploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ include "kong.deployment.proxy.replicaCount" . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kong.selectorLabels.proxy" . | nindent 6 }}
+  {{- if .Values.updateStrategy }}
+  strategy:
+{{ toYaml .Values.updateStrategy | indent 4 }}
+  {{- end }}
+  {{- if .Values.deployment.minReadySeconds }}
+  minReadySeconds: {{ .Values.deployment.minReadySeconds }}
+  {{- end }}
+
+  template:
+    metadata:
+      annotations:
+        {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+        kuma.io/service-account-token-volume: {{ template "kong.serviceAccountTokenName" . }}
+        {{- end }}
+        {{- if (and (not .Values.ingressController.enabled) (eq .Values.env.database "off" )) }}
+        {{- if .Values.dblessConfig.config }}
+        checksum/dbless.config: {{ toYaml .Values.dblessConfig.config | sha256sum }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+      labels:
+        {{- include "kong.metaLabels" . | nindent 8 }}
+        {{- include "kong.selectorLabels.component" (dict "component" "proxy" ) | nindent 8 }}
         app: {{ template "kong.fullname" . }}
         version: {{ .Chart.AppVersion | quote }}
         {{- if .Values.podLabels }}
@@ -117,9 +258,6 @@ spec:
 {{ toYaml .Values.dnsConfig | indent 8 }}
       {{- end }}
       containers:
-      {{- if .Values.ingressController.enabled }}
-      {{- include "kong.controller-container" . | nindent 6 }}
-      {{ end }}
       {{- if .Values.deployment.sidecarContainers }}
       {{- toYaml .Values.deployment.sidecarContainers | nindent 6 }}
       {{- end }}
@@ -143,7 +281,7 @@ spec:
           protocol: TCP
         {{- end }}
         {{- if (and .Values.admin.tls.enabled .Values.admin.enabled) }}
-        - name: admin-tls
+        - name: admin # TODO
           containerPort: {{ .Values.admin.tls.containerPort }}
           {{- if .Values.admin.tls.hostPort }}
           hostPort: {{ .Values.admin.tls.hostPort }}

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -6,7 +6,7 @@
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
-{{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels.proxy" .) -}}
 {{- $_ := set $serviceConfig "serviceName" "admin" -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.admin.ingress.enabled }}

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -6,7 +6,7 @@
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
-{{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels.proxy" .) -}}
 {{- $_ := set $serviceConfig "serviceName" "proxy" -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.proxy.ingress.enabled }}

--- a/charts/kong/templates/service-kong-udp-proxy.yaml
+++ b/charts/kong/templates/service-kong-udp-proxy.yaml
@@ -6,7 +6,7 @@
 {{- $_ := set $serviceConfig "fullName" (include "kong.fullname" .) -}}
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
-{{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels.proxy" .) -}}
 {{- $_ := set $serviceConfig "serviceName" "udp-proxy" -}}
 {{- $_ := set $serviceConfig "tls" (dict "enabled" false) -}}
 {{- $_ := set $serviceConfig "http" (dict "enabled" false) -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -14,11 +14,27 @@
 # -----------------------------------------------------------------------------
 
 deployment:
+  # Single controller controlls if kong and controller are deployed in separate
+  # deployments.
+  # This allows independent scaling and separation of concerns.
+  singleController:
+    enabled: false
+
   kong:
     # Enable or disable Kong itself
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+
+    ## This is in effect only when deployment.singleController.enabled is true.
+    ## This sets the number of replicas for Kong's Gateway deployment.
+    replicaCount: 1
+
+  ## This is in effect only when deployment.singleController.enabled is true.
+  controller:
+    ## This sets the number of replicas for Kong's Ingress Controller deployment.
+    replicaCount: 1
+
   ## Minimum number of seconds for which a newly created pod should be ready without any of its container crashing,
   ## for it to be considered available.
   # minReadySeconds: 60


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR introduces support for single controller deployments through `deployment.singleController.enabled` setting.

#### Which issue this PR fixes

Closes #710

#### Special notes for your reviewer:

This is expected to not work (i.e. `deployment.singleController.enabled` set to `true` should install successfully but KIC's pods will fail) until KIC 2.9 gets released.

One can test it with the following values:

```yaml
admin:
  enabled: true
  type: ClusterIP
  clusterIP: None

deployment:
  singleController:
    enabled: true
  kong:
    replicaCount: 5

  controller:
    replicaCount: 2

ingressController:
  image:
    repository: kong/nightly-ingress-controller
    tag: nightly
    effectiveSemver: "2.8.1"
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
