### PR TITLE
feat(konnect): allow enabling konnect sync in ingress controller

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -10,8 +10,7 @@
   For more information on this please see
   [the corresponding README.md section][kic_service_discovery_readme]
   [#747](https://github.com/Kong/charts/pull/747)
-* Experimental support for the ingress controller's Konnect sync feature was added. One can enable that
-  by setting `ingressController.konnect.*` values.
+* Added experimental support for the ingress controller's Konnect sync feature via `ingressController.konnect.*` values.
   [#746](https://github.com/Kong/charts/pull/746)
 
 [kic_service_discovery_readme]: ./README.md#the-servicediscovery-section

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Experimental support for the ingress controller's Konnect sync feature was added. One can enable that
+  by setting `ingressController.konnect.*` values.
+  [#746](https://github.com/Kong/charts/pull/746)
+
 ## 2.16.4
 
 ### Fixed

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -728,10 +728,10 @@ section of `values.yaml` file:
 | serviceDiscovery.enabled                | Enables Kong instance service discovery (for more details see [serviceDiscovery section][sd_section])                                                    |  false                             |
 | serviceDiscovery.adminApiService.namespace | The namespace of the Kong admin API service (for more details see [serviceDiscovery section][sd_section])                                             |  `.Release.Namespace`              |
 | serviceDiscovery.adminApiService.name   | The name of the Kong admin API service (for more details see [serviceDiscovery section][sd_section])                                                     |  ""                                |
-| konnect.enabled                         | Enable synchronisation of data-plane configuration with Konnect Runtime Group                                                                            | false                              |
+| konnect.enabled                         | Enable synchronisation of data plane configuration with Konnect Runtime Group                                                                            | false                              |
 | konnect.runtimeGroupID                  | Konnect Runtime Group's unique identifier.                                                                                                               |                                    |
 | konnect.region                          | Konnect account's region. One of `us`, `eu`.                                                                                                             | us                                 |
-| konnect.tlsClientCertSecretName         | Name of a secret that contains Konnect Runtime Group's client TLS certificate.                                                                           | konnect-client-tls                 |
+| konnect.tlsClientCertSecretName         | Name of the secret that contains Konnect Runtime Group's client TLS certificate.                                                                           | konnect-client-tls                 |
 
 [sd_section]: #the-servicediscovery-section
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -725,6 +725,10 @@ section of `values.yaml` file:
 | userDefinedVolumes                      | Create volumes. Please go to Kubernetes doc for the spec of the volumes                                                                                  |                                    |
 | userDefinedVolumeMounts                 | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts                                                                        |                                    |
 | terminationGracePeriodSeconds           | Sets the [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for Deployment pod | 30                                 |
+| konnect.enabled                         | Enable synchronisation of data-plane configuration with Konnect Runtime Group                                                                            | false                              |
+| konnect.runtimeGroupID                  | Konnect Runtime Group's unique identifier.                                                                                                               |                                    |
+| konnect.region                          | Konnect account's region. One of `us`, `eu`.                                                                                                             | us                                 |
+| konnect.tlsClientCertSecretName         | Name of a secret that contains Konnect Runtime Group's client TLS certificate.                                                                           | konnect-client-tls                 |
 
 #### The `env` section
 For a complete list of all configuration values you can set in the

--- a/charts/kong/example-values/minimal-kong-controller-konnect.yaml
+++ b/charts/kong/example-values/minimal-kong-controller-konnect.yaml
@@ -11,7 +11,6 @@ env:
 ingressController:
   enabled: true
 
-
   konnect:
     enabled: true
-    runtimeGroupID: "523f592f-9828-48a2-ab2e-cf113276369d"
+    runtimeGroupID: "00000000-0000-0000-0000-000000000000" # CHANGEME

--- a/charts/kong/example-values/minimal-kong-controller-konnect.yaml
+++ b/charts/kong/example-values/minimal-kong-controller-konnect.yaml
@@ -11,10 +11,6 @@ env:
 ingressController:
   enabled: true
 
-  image:
-    repository: kong/nightly-ingress-controller
-    tag: "2023-02-15"
-    effectiveSemver: "2.9.0"
 
   konnect:
     enabled: true

--- a/charts/kong/example-values/minimal-kong-controller-konnect.yaml
+++ b/charts/kong/example-values/minimal-kong-controller-konnect.yaml
@@ -1,0 +1,21 @@
+# Basic values.yaml configuration for Kong for Kubernetes with the ingress controller
+# and the controller's Konnect integration enabled.
+
+image:
+  repository: kong
+  tag: "3.1"
+
+env:
+  database: "off"
+
+ingressController:
+  enabled: true
+
+  image:
+    repository: kong/nightly-ingress-controller
+    tag: "2023-02-15"
+    effectiveSemver: "2.9.0"
+
+  konnect:
+    enabled: true
+    runtimeGroupID: "523f592f-9828-48a2-ab2e-cf113276369d"

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -383,6 +383,24 @@ The name of the service used for the ingress controller's validation webhook
 {{- end }}
 
 {{/*
+    ====== KONNECT ENVIRONMENT VARIABLES ======
+*/}}
+
+{{- if .Values.ingressController.konnect.enabled }}
+  {{- $konnect := .Values.ingressController.konnect -}}
+  {{- $_ := required "ingressController.konnect.runtimeGroupID is required when ingressController.konnect.enabled" $konnect.runtimeGroupID -}}
+
+  {{- $_ = set $autoEnv "CONTROLLER_KONNECT_SYNC_ENABLED" true -}}
+  {{- $_ = set $autoEnv "CONTROLLER_KONNECT_RUNTIME_GROUP_ID" $konnect.runtimeGroupID -}}
+  {{- $_ = set $autoEnv "CONTROLLER_KONNECT_ADDRESS" (printf "https://%s.kic.api.konghq.com" $konnect.region) -}}
+
+  {{- $tlsCert := include "secretkeyref" (dict "name" $konnect.tlsClientCertSecretName "key" "tls.crt") -}}
+  {{- $tlsKey := include "secretkeyref" (dict "name" $konnect.tlsClientCertSecretName "key" "tls.key") -}}
+  {{- $_ = set $autoEnv "CONTROLLER_KONNECT_TLS_CLIENT_CERT" $tlsCert -}}
+  {{- $_ = set $autoEnv "CONTROLLER_KONNECT_TLS_CLIENT_KEY" $tlsKey -}}
+{{- end }}
+
+{{/*
     ====== USER-SET ENVIRONMENT VARIABLES ======
 */}}
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -565,6 +565,19 @@ ingressController:
   #     cpu: 50m
   #     memory: 128Mi
 
+  konnect:
+    enabled: false
+
+    # Specifies a Konnect Runtime Group's ID that the controller will push its data-plane config to.
+    runtimeGroupID: ""
+
+    # Specifies Konnect's account region. One of `us`, `eu`.
+    region: "us"
+
+    # Specifies a secret that contains a client TLS certificate that the controller
+    # will use to authenticate against Konnect APIs.
+    tlsClientCertSecretName: "konnect-client-tls"
+
 # -----------------------------------------------------------------------------
 # Postgres sub-chart parameters
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows enabling Konnect sync mode in ingress controller by configuring all required environment variables in the controller's container. 

It won't work as expected until KIC 2.9.0 is released.

#### Which issue this PR fixes

Fixes #740.

#### Special notes for your reviewer:

Can be tested with following `values.yaml`:
```yaml
image:
  repository: kong
  tag: "3.1"

env:
  database: "off"

ingressController:
  enabled: true

  image:
    repository: kong/nightly-ingress-controller
    tag: "2023-02-15"
    effectiveSemver: "2.9.0"

  konnect:
    enabled: true
    runtimeGroupID: "523f592f-9828-48a2-ab2e-cf113276369d" # this has to be set to your RG ID
```

Requires having a `konnect-client-tls` secret created with TLS certificate generated by Konnect and a runtime group created in Konnect.

There's also a bonus I'd like to bring some attention to while adding this:[ a draft PR](https://github.com/Kong/charts/pull/748) adding a golden test that I found useful while extending the helm chart. 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
