### PR TITLE
chore: don't enable clear-stale-pid initContainer when kong isn't deployed

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Don't include a clear-stale-pid initContainer when kong gateway is not
+  enabled in the deployment.
+  [#744](https://github.com/Kong/charts/pull/744)
+
 ## 2.16.4
 
 ### Fixed

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -83,6 +83,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.deployment.kong.enabled }}
       initContainers:
       - name: clear-stale-pid
         image: {{ include "kong.getRepoTag" .Values.image }}
@@ -105,6 +106,7 @@ spec:
         {{- if (and (not (eq .Values.env.database "off")) .Values.waitImage.enabled) }}
         {{- include "kong.wait-for-db" . | nindent 6 }}
         {{- end }}
+      {{- end }}
       {{- if .Values.deployment.hostAliases }}
       hostAliases:
         {{- toYaml .Values.deployment.hostAliases | nindent 6 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

No need to clear the pid if Kong isn't deployed so this PR adds a condition around adding this initContainer.

#### Special notes for your reviewer:

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
