### PR TITLE
fix: fix autoscaling version detection

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## Unreleased
+## 2.16.5
 
+* Fix autoscaling version detection.
+  [#744](https://github.com/Kong/charts/pull/744)
 * Don't include a clear-stale-pid initContainer when kong gateway is not
   enabled in the deployment.
   [#744](https://github.com/Kong/charts/pull/744)

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.16.4
+version: 2.16.5
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/hpa.yaml
+++ b/charts/kong/templates/hpa.yaml
@@ -17,10 +17,10 @@ spec:
   behavior:
     {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
   {{- end }}
-  {{- if not (.Capabilities.APIVersions.Has "autoscaling/v2beta2") }}
-  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage | default 80 }}
-  {{- else }}
+  {{- if contains "autoscaling/v2" (include "kong.autoscalingVersion" . ) }}
   metrics:
     {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+  {{- else }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage | default 80 }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix autoscaling version detection.

1.26 doesn't offer `autoscaling/v2beta2` anymore (ref: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26) so on 1.26 and up incorrectly detects that we don't have v2 available because of `{{- if not (.Capabilities.APIVersions.Has "autoscaling/v2beta2") }}` where in fact we do.

The introduced check, via `contains` checks if the string returned via `"kong.autoscalingVersion"` contains `autoscaling/v2` (which is true for both `autoscaling/v2` and `autoscaling/v2beta2`).

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
