### PR TITLE
Correct proxy.streams comment on how name of the stream is generated

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -297,7 +297,7 @@ proxy:
 
   # Define stream (TCP) listen
   # To enable, remove "[]", uncomment the section below, and select your desired
-  # ports and parameters. Listens are dynamically named after their servicePort,
+  # ports and parameters. Listens are dynamically named after their containerPort,
   # e.g. "stream-9000" for the below.
   # Note: although you can select the protocol here, you cannot set UDP if you
   # use a LoadBalancer Service due to limitations in current Kubernetes versions.


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Comment on `proxy.stream` states `Listens are dynamically named after their servicePort...` when in reality judging by [_helpers.tpl](https://github.com/Kong/charts/blob/4c593425afb655d10b855fe10332cdf149a7d5ef/charts/kong/templates/_helpers.tpl#L195) its generated with `containerPort`.

Assuming that `_helpers.tpl` has correct functionality, updating comment:
- Updating `values.yaml` to reflect what `_helpers.tpl` does.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- N/A Changes are documented under the "Unreleased" header in CHANGELOG.md
- N/A New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
