### PR TITLE
feat(kong): do not allow single-pod deployment with gw service discovery

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -14,7 +14,7 @@
   This feature is only available when deploying chart with Kong Ingress Controller in version 2.9 or higher.
   [#746](https://github.com/Kong/charts/pull/746)
 
-### Under the hood 
+### Under the hood
 
 * Add kube-linter to the CI pipeline to ensure produced manifests comply
   with community best practices.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -777,9 +777,10 @@ For admin API service discovery:
   The following admin API Service flags have to be provided in order for service
   discovery to work:
 
-  - `ingressController.serviceDiscovery.adminApiServie.name`
-  - `ingressController.serviceDiscovery.adminApiServie.namespace`
+  - `ingressController.serviceDiscovery.adminApiService.name`
+  - `ingressController.serviceDiscovery.adminApiService.namespace`
 
+Using this feature requires a split release installation of Gateways and Ingress Controller.
 For exemplar `values.yaml` files which use this feature please see: [examples README.md](./example-values/README.md).
 
 ### General Parameters

--- a/charts/kong/example-values/README.md
+++ b/charts/kong/example-values/README.md
@@ -55,12 +55,17 @@ common Kong deployment scenarios on Kubernetes.
 * [minimal-kong-sd-controller.yaml](minimal-kong-sd-controller.yaml) and
   [minimal-kong-sd-gateway.yaml](minimal-kong-sd-gateway.yaml) install a
   single controller and cluster of gateway instances. The controller release
-  configuration must specify the names of the gateway proxy and and admin
+  configuration must specify the names of the gateway proxy and admin
   Services. The examples use `gw` as the gateway release name. If you wish to
   use another name, set the controller configuration to match. For example, if
   you use `hydrogen` as your gateway release name, set
   `proxy.nameOverride=hydrogen-kong-proxy` and
   `ingressController.adminApiService.name=hydrogen-kong-admin`.
+
+* [minimal-kong-controller-konnect.yaml](minimal-kong-controller-konnect.yaml) installs Kong
+  open source with the ingress controller in DB-less mode, with Kong's Konnect sync feature
+  enabled. In order to make it work, `ingressController.konnect.runtimeGroupID` has to be
+  supplied.
 
 All Enterprise examples require some level of additional user configuration to
 install properly. Read the comments at the top of each file for instructions.

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -329,6 +329,10 @@ Return the admin API service name for service discovery
   {{- fail (printf "Admin API service discovery is available in controller versions 2.9 and up. Detected %s" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
   {{- end }}
 
+  {{- if .Values.deployment.kong.enabled }}
+  {{- fail "deployment.kong.enabled and ingressController.serviceDiscovery.enabled are mutually exclusive and cannot be enabled at once. Admin API service discovery requires a split release installation of Gateways and Ingress Controller." }}
+  {{- end }}
+
   {{- $namespace := $adminApiService.namespace | default ( include "kong.namespace" . ) -}}
   {{- $name := $adminApiService.name -}}
   {{- $_ := required ".ingressController.serviceDiscovery.adminApiService.name has to be provided when .Values.ingressController.serviceDiscovery.enabled is set to true"  $name -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a validation rule that ensures that `deployment.kong.enabled` and `ingressController.serviceDiscovery.enabled` are not set to `true` at once as they're mutually exclusive. Admin API service discovery requires a split release installation of Gateways and Ingress Controller.

#### Which issue this PR fixes

Should fix https://github.com/Kong/kubernetes-ingress-controller/issues/3582.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
