### PR TITLE
feat(konnect): allow specifying api hostname in values, release 2.17.0-rc.2

### DIFF
--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.17.0-rc.1
+version: 2.17.0-rc.2
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -730,7 +730,7 @@ section of `values.yaml` file:
 | gatewayDiscovery.adminApiService.name      | The name of the Kong admin API service (for more details see [gatewayDiscovery section][gd_section])                                                     | ""                                 |
 | konnect.enabled                            | Enable synchronisation of data plane configuration with Konnect Runtime Group                                                                            | false                              |
 | konnect.runtimeGroupID                     | Konnect Runtime Group's unique identifier.                                                                                                               |                                    |
-| konnect.region                             | Konnect account's region. One of `us`, `eu`.                                                                                                             | us                                 |
+| konnect.apiHostname                        | Konnect API hostname. Defaults to a production US-region.                                                                                                | us.kic.api.konghq.com              |
 | konnect.tlsClientCertSecretName            | Name of the secret that contains Konnect Runtime Group's client TLS certificate.                                                                         | konnect-client-tls                 |
 
 [gd_section]: #the-gatewayDiscovery-section

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -436,7 +436,7 @@ The name of the service used for the ingress controller's validation webhook
 
   {{- $_ = set $autoEnv "CONTROLLER_KONNECT_SYNC_ENABLED" true -}}
   {{- $_ = set $autoEnv "CONTROLLER_KONNECT_RUNTIME_GROUP_ID" $konnect.runtimeGroupID -}}
-  {{- $_ = set $autoEnv "CONTROLLER_KONNECT_ADDRESS" (printf "https://%s.kic.api.konghq.com" $konnect.region) -}}
+  {{- $_ = set $autoEnv "CONTROLLER_KONNECT_ADDRESS" (printf "https://%s" .Values.ingressController.konnect.apiHostname) -}}
 
   {{- $tlsCert := include "secretkeyref" (dict "name" $konnect.tlsClientCertSecretName "key" "tls.crt") -}}
   {{- $tlsKey := include "secretkeyref" (dict "name" $konnect.tlsClientCertSecretName "key" "tls.key") -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -579,8 +579,10 @@ ingressController:
     # Specifies a Konnect Runtime Group's ID that the controller will push its data-plane config to.
     runtimeGroupID: ""
 
-    # Specifies Konnect's account region. One of `us`, `eu`.
-    region: "us"
+    # Specifies a Konnect API hostname that the controller will use to push its data-plane config to.
+    # By default, this is set to US region's production API hostname.
+    # If you are using a different region, you can set this to the appropriate hostname (e.g. "eu.kic.api.konghq.com").
+    apiHostname: "us.kic.api.konghq.com"
 
     # Specifies a secret that contains a client TLS certificate that the controller
     # will use to authenticate against Konnect APIs.


### PR DESCRIPTION
#### What this PR does / why we need it:

Allows specifying a full API hostname for the Konnect integration instead of just a region. It's to easily and uniformly switch not only between regions but also between environments. 

#### Which issue this PR fixes

Part of #740.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
