### PR TITLE
feat(certificates) add support for subject and privateKey

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -16,6 +16,8 @@
   [#746](https://github.com/Kong/charts/pull/746)
 * Added support for annotations on the admission webhook ValidatingWebhookConfiguration.
   [#760](https://github.com/Kong/charts/pull/760)
+* Added support for `subject` and `privateKey` properties on certificates.
+  [#762](https://github.com/Kong/charts/pull/762)
 
 ### Under the hood
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.17.0-rc.2
+version: 2.17.0-rc.3
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -462,7 +462,7 @@ should, however, migrate to an issuer using a CA your clients trust for actual
 usage.
 
 The `proxy`, `admin`, `portal`, and `cluster` subsections under `certificates`
-let you choose hostnames or override issuers on a per-certificate basis for the
+let you choose hostnames, override issuers, set `subject` or set `privateKey` on a per-certificate basis for the
 proxy, admin API and Manager, Portal and Portal API, and hybrid mode mTLS
 services, respectively.
 

--- a/charts/kong/templates/certificate.yaml
+++ b/charts/kong/templates/certificate.yaml
@@ -6,6 +6,8 @@
 {{- $_ := set $genericCertificateConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $genericCertificateConfig "globalIssuer" .Values.certificates.issuer -}}
 {{- $_ := set $genericCertificateConfig "globalClusterIssuer" .Values.certificates.clusterIssuer -}}
+{{- $_ := set $genericCertificateConfig "globalSubject" .Values.kong.certificates.subject -}}
+{{- $_ := set $genericCertificateConfig "globalPrivateKey" .Values.kong.certificates.privateKey -}}
 {{- $_ := set $genericCertificateConfig "defaultIssuer" (printf "%s-%s-%s" .Release.Name .Chart.Name "selfsigned-issuer") -}}
 
 {{- if .Values.certificates.admin.enabled }}
@@ -57,6 +59,20 @@ spec:
   renewBefore: 360h
   duration: 2160h
   isCA: false
+  {{ if .subject -}}
+  subject:
+    {{- toYaml .subject | nindent 4 }}
+  {{ else if .globalSubject -}}
+  subject:
+    {{- toYaml .globalSubject | nindent 4 }}
+  {{- end }}
+  {{ if .privateKey -}}
+  privateKey:
+    {{- toYaml .privateKey | nindent 4 }}
+  {{ else if .globalPrivateKey -}}
+  privateKey:
+    {{- toYaml .globalPrivateKey | nindent 4 }}
+  {{- end }}
   {{ if .clusterIssuer -}}
   issuerRef:
     name: {{ .clusterIssuer }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds support for `subject` and `privateKey` values on certificates.  Some organizations (like ours) enforce setting these properties on certificates when integrating with cert-manager.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
