### PR TITLE
feat(values) add default security context

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+* Security context enforces read-only root filesystem by default. This is not
+  expected to affect most configurations, but [will afffect custom plugins that
+  write to the container filesystem](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#2170).
+  [#770](https://github.com/Kong/charts/pull/770)
+
 ## 2.18.0
 
 ### Improvements

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## Unreleased
+## 2.19.0
 
 ### Improvements
 
 * Security context enforces read-only root filesystem by default. This is not
-  expected to affect most configurations, but [will afffect custom plugins that
+  expected to affect most configurations, but [will affect custom plugins that
   write to the container filesystem](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#2170).
   [#770](https://github.com/Kong/charts/pull/770)
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.18.0
+version: 2.19.0
 appVersion: "3.2"
 dependencies:
 - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -861,7 +861,7 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | `""`                |
 | secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
 | securityContext                    | Set the securityContext for Kong Pods                                                 | `{}`                |
-| containerSecurityContext           | Set the securityContext for Containers                                                | `{}`                |
+| containerSecurityContext           | Set the securityContext for Containers                                                | `{"readOnlyRootFilesystem": true}`                |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | `false`             |
 | serviceMonitor.interval            | Scraping interval                                                                     | `30s`               |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -17,6 +17,7 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
+- [2.17.0](#2170)
 - [2.13.0](#2130)
 - [2.8.0](#280)
 - [2.7.0](#270)
@@ -81,6 +82,26 @@ https://raw.githubusercontent.com/Kong/charts/kong-<version>/charts/kong/crds/cu
 
 For example, if your release is 2.6.4, you would apply
 `https://raw.githubusercontent.com/Kong/charts/kong-2.6.4/charts/kong/crds/custom-resource-definitions.yaml`.
+
+## 2.19.0
+
+2.19 sets a default [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+that declares a read-only root filesystem for Kong containers. The base Kong and KIC
+images are compatible with this setting. The chart mounts temporary writeable
+emptyDir filesystems for locations that require writeable files (`/tmp` and
+`/kong_prefix/`).
+
+This setting limit attack surface and should be compatible with most
+installations. However, if you use custom plugins that write to disk, you must
+either mount a writeable emptyDir for them or override the new defaults by
+setting:
+
+```
+containerSecurityContext:
+  readOnlyRootFilesystem: false
+```
+
+in your values.yaml.
 
 ## 2.13.0
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -894,7 +894,8 @@ priorityClassName: ""
 securityContext: {}
 
 # securityContext for containers.
-containerSecurityContext: {}
+containerSecurityContext:
+  readOnlyRootFilesystem: true
 
 ## Optional DNS configuration for Kong pods
 # dnsPolicy: ClusterFirst


### PR DESCRIPTION
#### What this PR does / why we need it:

Sets a default security context that ~disallows running as root~ and makes the root FS read-only.

#### Special notes for your reviewer:

We haven't set these in the past, but they are common settings to reduce attack surface and are compatible with the standard chart configuration and standard Kong images.

Originally set non-root, which we technically comply with, but since our images only use a named user and not a specific non-0 UID, Kubernetes can't actually verify that the standard `kong` user isn't root (see the initial failed test run), so removed that.

Additional testing that hacks this in via KTF changes: https://github.com/Kong/kubernetes-ingress-controller/actions/runs/4451318454

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
