### PR TITLE
chore: bump default kong version to 3.2

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -22,6 +22,8 @@
   [#767](https://github.com/Kong/charts/pull/767)
 * Added support for `GRPCRoute`s.
   [#772](https://github.com/Kong/charts/pull/772)
+* Default Kong version is bumped to 3.2.
+  [#773](https://github.com/Kong/charts/pull/773)
 
 ### Under the hood
 

--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -146,7 +146,7 @@ extraLabels:
   konghq.com/component: quickstart
 image:
   repository: kong/kong-gateway
-  tag: "3.1"
+  tag: "3.2"
 ingressController:
   enabled: true
   env:

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.1"
+  tag: "3.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.1"
+  tag: "3.2"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-controller.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: kong
-  tag: "3.1"
+  tag: "3.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.1"
+  tag: "3.2"
 
 enterprise:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
@@ -14,7 +14,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.1"
+  tag: "3.2"
 
 env:
   database: postgres

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.1"
+  tag: "3.2"
 
 env:
   role: data_plane

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "3.1"
+  tag: "3.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -11,7 +11,7 @@
 
 image:
   repository: kong
-  tag: "3.1"
+  tag: "3.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "3.1"
+  tag: "3.2"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -121,10 +121,10 @@ extraLabels: {}
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "3.1"
+  tag: "3.2"
   # Kong Enterprise
   # repository: kong/kong-gateway
-  # tag: "3.1"
+  # tag: "3.2"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Bump kong version in default values and example values to the latest 3.2 (`kong:3.2` for OSS and `kong/kong-gateway:3.2` for enterprise version)

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #765 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
