### PR TITLE
chore(deps): bump KIC to 2.9 and release 2.17.0

### DIFF
--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.17.0-rc.5
+version: 2.17.0
 appVersion: "3.1"
 dependencies:
 - name: postgresql

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -12,7 +12,7 @@ name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
 version: 2.17.0
-appVersion: "3.1"
+appVersion: "3.2"
 dependencies:
 - name: postgresql
   version: 11.9.13

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -476,7 +476,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "2.8"
+    tag: "2.9"
     # Optionally set a semantic version for version-gated features. This can normally
     # be left unset. You only need to set this if your tag is not a semver string,
     # such as when you are using a "next" tag. Set this to the effective semantic


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump KIC to the latest 2.9 and cuts the 2.17.0 release.

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3672

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
