### PR TITLE
chore(doc) fix changelog header following release

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.17.0
 
 ### Improvements
 


### PR DESCRIPTION
We forgot to update the changelog header during the 2.17 release earlier.