### PR TITLE
fix(semver) trim -redhat from KIC tags

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.17.1
+
+### Fixed
+
+* The `-redhat` suffix on official KIC images is no longer considered part of
+  the semver string for version checks.
+  [#779](https://github.com/Kong/charts/pull/779)
+
 ## 2.17.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.17.0
+version: 2.17.1
 appVersion: "3.2"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -704,7 +704,7 @@ The name of the service used for the ingress controller's validation webhook
 {{- if .effectiveSemver -}}
 {{- .effectiveSemver -}}
 {{- else -}}
-{{- .tag -}}
+{{- (trimSuffix "-redhat" .tag) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Strip -redhat suffix from KIC tags if present.

We use this to indicate Docker image variants. It is not actually a semver pre-release, but the semver functions can't tell the difference.

Release 2.17.1.

#### Which issue this PR fixes

  - fixes #778 

#### Special notes for your reviewer:

Compare, with the change:

```
15:12:10-0700 esenin $ helm template ct /tmp/symkong --set ingressController.image.tag=2.9.0-redhat | grep cmetrics -A1
        - name: cmetrics
          containerPort: 10255

15:12:14-0700 esenin $ helm template ct /tmp/symkong --set ingressController.image.tag=2.9.0-other | grep cmetrics -A1 

15:12:23-0700 esenin $
```
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
