### PR TITLE
feat: add Admin API TLS client verification support

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.18.0
+
+### Improvements
+
+* Added support for the Admin API service TLS client verification.
+  [#780](https://github.com/Kong/charts/pull/780
+
 ## 2.17.1
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.17.1
+version: 2.18.0
 appVersion: "3.2"
 dependencies:
 - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -804,13 +804,14 @@ When using `gatewayDiscovery`, you should consider configuring the Admin service
 this interface secure. Without that, anyone who can access the Admin API from inside the cluster can configure the Gateway
 instances.
 
-On the controller release side, that can be achieved by setting `ingressController.adminApi.tls.client.enabled` to `true`
-(Helm will generate certificates automatically), or by setting `ingressController.adminApi.tls.client.certProvided` to
-`true` and providing your own certificates via `ingressController.adminApi.tls.client.secretName` and
-`ingressController.adminApi.tls.client.caSecretName`.
+On the controller release side, that can be achieved by setting `ingressController.adminApi.tls.client.enabled` to `true`.
+By default, Helm will generate a certificate Secret named `<release name>-admin-api-keypair` and
+a CA Secret named `<release name>-admin-api-ca-keypair` for you.
 
-On the Gateway release side, `admin.tls.client.secretName` or `admin.tls.client.caBundle` have to be set to actually
-enable mTLS client verification and use the provided CA certificate for that.
+To provide your own cert, set `ingressController.adminApi.tls.client.certProvided` to
+`true`, `ingressController.adminApi.tls.client.secretName` to the name of the Secret containing your client cert, and `ingressController.adminApi.tls.client.caSecretName` to the name of the Secret containing your CA cert.
+
+On the Gateway release side, set either `admin.tls.client.secretName` to the name of your CA Secret or set `admin.tls.client.caBundle` to the CA certificate string.
 
 ### General Parameters
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -52,6 +52,7 @@ $ helm install kong/kong --generate-name
 - [Configuration](#configuration)
   - [Kong parameters](#kong-parameters)
     - [Kong Service Parameters](#kong-service-parameters)
+    - [Admin Service mTLS](#admin-service-mtls)
     - [Stream listens](#stream-listens)
   - [Ingress Controller Parameters](#ingress-controller-parameters)
     - [The `env` section](#the-env-section)
@@ -683,6 +684,17 @@ or `ingress` sections, as it is used only for stream listens.
 | SVC.annotations                    | Service annotations                                                                   | `{}`                     |
 | SVC.labels                         | Service labels                                                                        | `{}`                     |
 
+#### Admin Service mTLS
+
+On top of the common parameters listed above, the `admin` service supports parameters for mTLS client verification. 
+If any of `admin.tls.client.caBundle` or `admin.tls.client.secretName` are set, the admin service will be configured to
+require mTLS client verification. If both are set, `admin.tls.client.caBundle` will take precedence.
+
+| Parameter                   | Description                                                                                 | Default |
+|-----------------------------|---------------------------------------------------------------------------------------------|---------|
+| admin.tls.client.caBundle   | CA certificate to use for TLS verification of the Admin API client (PEM-encoded).           | `""`    |
+| admin.tls.client.secretName | CA certificate secret name - must contain a `tls.crt` key with the PEM-encoded certificate. | `""`    |
+
 #### Stream listens
 
 The proxy configuration additionally supports creating stream listens. These
@@ -719,8 +731,8 @@ section of `values.yaml` file:
 | watchNamespaces                            | List of namespaces to watch. Watches all namespaces if empty                                                                                             | []                                 |
 | admissionWebhook.enabled                   | Whether to enable the validating admission webhook                                                                                                       | true                               |
 | admissionWebhook.failurePolicy             | How unrecognized errors from the admission endpoint are handled (Ignore or Fail)                                                                         | Ignore                             |
-| admissionWebhook.port                      | The port the ingress controller will listen on for admission webhooks                                                                                     | 8080                               |
-| admissionWebhook.annotations               | Annotations for the Validation Webhook Configuration                                                                                                    |                                    |
+| admissionWebhook.port                      | The port the ingress controller will listen on for admission webhooks                                                                                    | 8080                               |
+| admissionWebhook.annotations               | Annotations for the Validation Webhook Configuration                                                                                                     |                                    |
 | admissionWebhook.certificate.provided      | Use a provided certificate. When set to false, the chart will automatically generate a certificate.                                                      | false                              |
 | admissionWebhook.certificate.secretName    | Name of the TLS secret for the provided webhook certificate                                                                                              |                                    |
 | admissionWebhook.certificate.caBundle      | PEM encoded CA bundle which will be used to validate the provided webhook certificate                                                                    |                                    |
@@ -734,6 +746,10 @@ section of `values.yaml` file:
 | konnect.runtimeGroupID                     | Konnect Runtime Group's unique identifier.                                                                                                               |                                    |
 | konnect.apiHostname                        | Konnect API hostname. Defaults to a production US-region.                                                                                                | us.kic.api.konghq.com              |
 | konnect.tlsClientCertSecretName            | Name of the secret that contains Konnect Runtime Group's client TLS certificate.                                                                         | konnect-client-tls                 |
+| adminApi.tls.client.enabled                | Enable TLS client verification for the Admin API. By default, Helm will generate certificates automatically.                                             | false                              |
+| adminApi.tls.client.certProvided           | Use user-provided certificates. If set to false, Helm will generate certificates.                                                                        | false                              |
+| adminApi.tls.client.secretName             | Client TLS certificate/key pair secret name. Can be also set when `certProvided` is false to enforce a generated secret's name.                          | ""                                 |
+| adminApi.tls.client.caSecretName           | CA TLS certificate/key pair secret name. Can be also set when `certProvided` is false to enforce a generated secret's name.                              | ""                                 |
 
 [gd_section]: #the-gatewayDiscovery-section
 
@@ -783,6 +799,18 @@ You'll be able to configure this feature through configuration section under
 
 Using this feature requires a split release installation of Gateways and Ingress Controller.
 For exemplar `values.yaml` files which use this feature please see: [examples README.md](./example-values/README.md).
+
+When using `gatewayDiscovery`, you should consider configuring the Admin service to use mTLS client verification to make
+this interface secure. Without that, anyone who can access the Admin API from inside the cluster can configure the Gateway
+instances.
+
+On the controller release side, that can be achieved by setting `ingressController.adminApi.tls.client.enabled` to `true`
+(Helm will generate certificates automatically), or by setting `ingressController.adminApi.tls.client.certProvided` to
+`true` and providing your own certificates via `ingressController.adminApi.tls.client.secretName` and
+`ingressController.adminApi.tls.client.caSecretName`.
+
+On the Gateway release side, `admin.tls.client.secretName` or `admin.tls.client.caBundle` have to be set to actually
+enable mTLS client verification and use the provided CA certificate for that.
 
 ### General Parameters
 

--- a/charts/kong/example-values/minimal-kong-gd-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-gd-controller.yaml
@@ -18,3 +18,16 @@ ingressController:
       ## The Service name uses the pattern "<release name>-kong-admin".
       ## In this example, the companion gateway release is named "gw"
       name: gw-kong-admin
+
+  adminApi:
+    tls:
+      client:
+        # Enable TLS client authentication for the Admin API.
+        enabled: true
+        # We're specifying the name of the secret to have a static name that we
+        # will use in the gateway release.
+        caSecretName: "admin-api-ca-cert"
+
+  env:
+    # This must match the gateway release's proxy Service HTTPs port name.
+    kong_admin_svc_port_names: "kong-admin-tls"

--- a/charts/kong/example-values/minimal-kong-gd-gateway.yaml
+++ b/charts/kong/example-values/minimal-kong-gd-gateway.yaml
@@ -2,6 +2,9 @@ admin:
   enabled: true
   type: ClusterIP
   clusterIP: None
+  tls:
+    client:
+      secretName: "admin-api-ca-cert"
 
 ingressController:
   enabled: false

--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -15,3 +15,99 @@
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "adminApiService.certSecretName" -}}
+  {{- default (printf "%s-admin-api-keypair" (include "kong.fullname" .)) .Values.ingressController.adminApi.tls.client.secretName -}}
+{{- end -}}
+
+{{- define "adminApiService.caSecretName" -}}
+  {{- default (printf "%s-admin-api-ca-keypair" (include "kong.fullname" .)) .Values.ingressController.adminApi.tls.client.caSecretName -}}
+{{- end -}}
+
+{{- $clientVerifyEnabled := .Values.ingressController.adminApi.tls.client.enabled -}}
+{{- $clientCertProvided := .Values.ingressController.adminApi.tls.client.certProvided -}}
+
+{{/* If the client verification is enabled but no secret was provided by the user, let's generate certificates. */ -}}
+{{- if and $clientVerifyEnabled (not $clientCertProvided) }}
+{{- $certCert := "" -}}
+{{- $certKey := "" -}}
+
+{{- $cn := printf "admin.%s.svc" ( include "kong.namespace" . ) -}}
+{{- $ca := genCA "admin-api-ca" 3650 -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 3650 $ca -}}
+
+{{- $certCert = $cert.Cert -}}
+{{- $certKey = $cert.Key -}}
+{{/* Verify whether a secret with a given name already exists. If it does, let's use its cert and key data. */}}
+{{- $certSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (include "adminApiService.certSecretName" .)) -}}
+{{- if $certSecret }}
+{{- $certCert = (b64dec (get $certSecret.data "tls.crt")) -}}
+{{- $certKey = (b64dec (get $certSecret.data "tls.key")) -}}
+{{- end }}
+
+{{- $caCert := $ca.Cert -}}
+{{- $caKey := $ca.Key -}}
+{{/* Verify whether a secret with a given name already exists. If it does, let's use its cert and key data. */ -}}
+{{- $caSecret := (lookup "v1" "Secret" (include "kong.namespace" .) (include "adminApiService.caSecretName" .))}}
+{{- if $caSecret }}
+{{- $caCert = (b64dec (get $caSecret.data "tls.crt")) -}}
+{{- $caKey = (b64dec (get $caSecret.data "tls.key")) -}}
+{{- end }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "adminApiService.certSecretName" . }}
+  namespace:  {{ template "kong.namespace" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ b64enc $certCert }}
+  tls.key: {{ b64enc $certKey }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "adminApiService.caSecretName" . }}
+  namespace:  {{ template "kong.namespace" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ b64enc $caCert }}
+  tls.key: {{ b64enc $caKey }}
+{{- end }}
+
+{{- /* Create a CA ConfigMap for Kong. */ -}}
+{{- $secretProvided := $.Values.admin.tls.client.secretName -}}
+{{- $bundleProvided := $.Values.admin.tls.client.caBundle -}}
+
+{{- if or $secretProvided $bundleProvided -}}
+{{- $cert := "" -}}
+
+{{- if $secretProvided -}}
+{{- $certSecret := (lookup "v1" "Secret" (include "kong.namespace" .) $.Values.admin.tls.client.secretName) -}}
+{{- if $certSecret }}
+{{- $cert = (b64dec (get $certSecret.data "tls.crt")) -}}
+{{- else -}}
+{{- fail (printf "%s/%s secret not found" (include "kong.namespace" .) $.Values.admin.tls.client.secretName) -}}
+{{- end }}
+{{- end }}
+
+{{- if $bundleProvided -}}
+{{- $cert = $.Values.admin.tls.client.caBundle -}}
+{{- end }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "kong.fullname" . }}-admin-client-ca
+  namespace: {{ template "kong.namespace" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+data:
+  tls.crt: {{ $cert | quote }}
+{{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -173,6 +173,14 @@ admin:
     parameters:
     - http2
 
+    # Specify the CA certificate to use for TLS verification of the Admin API client by:
+    # - secretName - the secret must contain a key named "tls.crt" with the PEM-encoded certificate.
+    # - caBundle (PEM-encoded certificate string).
+    # If both are set, caBundle takes precedence.
+    client:
+      caBundle: ""
+      secretName: ""
+
   # Kong admin ingress settings. Useful if you want to expose the Admin
   # API of Kong outside the k8s cluster.
   ingress:
@@ -594,6 +602,27 @@ ingressController:
     # Specifies a secret that contains a client TLS certificate that the controller
     # will use to authenticate against Konnect APIs.
     tlsClientCertSecretName: "konnect-client-tls"
+
+  adminApi:
+    tls:
+      client:
+        # Enable TLS client authentication for the Admin API.
+        enabled: false
+
+        # If set to false, Helm will generate certificates for you.
+        # If set to true, you are expected to provide your own secret (see secretName, caSecretName).
+        certProvided: false
+
+        # Client TLS certificate/key pair secret name that Ingress Controller will use to authenticate with Kong Admin API.
+        # If certProvided is set to false, it is optional (can be specified though if you want to force Helm to use
+        # a specific secret name).
+        secretName: ""
+
+        # CA TLS certificate/key pair secret name that the client TLS certificate is signed by.
+        # If certProvided is set to false, it is optional (can be specified though if you want to force Helm to use
+        # a specific secret name).
+        caSecretName: ""
+
 
 # -----------------------------------------------------------------------------
 # Postgres sub-chart parameters


### PR DESCRIPTION
#### What this PR does / why we need it:

To make the connection between the controller and the gateways secure, we should allow configuring client verification. 

#### Which issue this PR fixes
Part of https://github.com/Kong/kubernetes-ingress-controller/issues/3833.

#### Special notes for your reviewer:

I tried to follow a similar pattern that we use for webhook certs.

The modified examples were tested locally. I also verified that providing the `caBundle` as a blob works as well.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
