### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @kong/team-k8s
+ * @Kong/k8s-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:

We recently added contributor/maintainer/admin levels to `team-k8s`. This PR updates CODEOWNERS to ensure that only `k8s-maintainers` can merge PRs
