### PR TITLE
fix: fix webhook-cert being mounted regardles of controller being enabled

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.19.1
+
+### Fixed
+
+* Fix `webhook-cert` being mounted regardless if `.Values.ingressController.enabled`
+  is set.
+  [#779](https://github.com/Kong/charts/pull/779)
+
 ## 2.19.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.19.0
+version: 2.19.1
 appVersion: "3.2"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -565,7 +565,7 @@ The name of the service used for the ingress controller's validation webhook
   {{- end }}
 {{- end }}
 
-{{- if .Values.ingressController.admissionWebhook.enabled }}
+{{- if and .Values.ingressController.enabled .Values.ingressController.admissionWebhook.enabled }}
 - name: webhook-cert
   secret:
     {{- if .Values.ingressController.admissionWebhook.certificate.provided }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Found in local testing. `webhook-cert` was being mounted regardless of `.Values.ingressController.enabled`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
