### PR TITLE
feat(konnect): enable automatic gateway licensing

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.20.0
+
+### Improvements
+
+* Added support for automatic license provisioning for Gateways managed by
+  Ingress Controllers in Konnect mode (`.Values.ingressController.konnect.enabled=true`).
+  [#787](https://github.com/Kong/charts/pull/787)
+
 ## 2.19.1
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.19.1
+version: 2.20.0
 appVersion: "3.2"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -443,6 +443,7 @@ The name of the service used for the ingress controller's validation webhook
   {{- $_ := required "ingressController.konnect.runtimeGroupID is required when ingressController.konnect.enabled" $konnect.runtimeGroupID -}}
 
   {{- $_ = set $autoEnv "CONTROLLER_KONNECT_SYNC_ENABLED" true -}}
+  {{- $_ = set $autoEnv "CONTROLLER_KONNECT_LICENSING_ENABLED" true -}}
   {{- $_ = set $autoEnv "CONTROLLER_KONNECT_RUNTIME_GROUP_ID" $konnect.runtimeGroupID -}}
   {{- $_ = set $autoEnv "CONTROLLER_KONNECT_ADDRESS" (printf "https://%s" .Values.ingressController.konnect.apiHostname) -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Enables KIC's `CONTROLLER_KONNECT_LICENSING_ENABLED` flag when `.Values.ingressController.konnect.enabled` is `true`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
