### PR TITLE
feat: add RBAC for watching CRDs by controller

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.21.0
 
 ### Improvements
 
@@ -9,6 +9,8 @@
   [#792](https://github.com/Kong/charts/pull/792)
 * Customize Admission Webhook namespaceSelectors and compose them from values.
   [#794](https://github.com/Kong/charts/pull/794)
+* Added `CustomResourceDefinition` `list` and `watch` permissions to controller's ClusterRole.
+  [#796](https://github.com/Kong/charts/pull/796)
 
 ## 2.20.2
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.20.2
+version: 2.21.0
 appVersion: "3.2"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1488,6 +1488,15 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   - get
   - patch
   - update
+{{- if (semverCompare ">= 2.10.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+{{- end }}
 {{- if or (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") }}
 - apiGroups:
   - gateway.networking.k8s.io


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `watch` and `list` permissions for `apiextensions.k8s.io.customresourcedefinitions` to controller's `ClusterRole` to enable watching CRDs and start reconcilers dynamically once they get installed implemented in https://github.com/Kong/kubernetes-ingress-controller/pull/3996.

#### Which issue this PR fixes

Closes https://github.com/Kong/kubernetes-ingress-controller/issues/3029.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
