### PR TITLE
chore(rbac): adjust permissions for Endpoints and remove for secrets/status

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+* Removed redundant RBAC permissions for non-existing subresources `secrets/status`
+  and `endpoints/status`.
+  [#798](https://github.com/Kong/charts/pull/798)
+* For Kong Ingress Controller in version >= 2.10, RBAC permissions for `Endpoints`
+  are not configured anymore (because it uses `EndpointSlices`).
+  [#798](https://github.com/Kong/charts/pull/798)
+
+
 ## 2.21.0
 
 ### Improvements

--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -448,8 +448,8 @@ spec:
             type: object
           upstream:
             description: Upstream represents a virtual hostname and can be used to
-              loadbalance incoming requests over multiple targets (e.g. Kubernetes
-              `Services` can be a target, OR `Endpoints` can be targets).
+              load balance incoming requests over multiple targets (e.g. Kubernetes
+              Services can be a target, or URLs can be targets).
             properties:
               algorithm:
                 description: Algorithm is the load balancing algorithm to use.

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -494,10 +494,10 @@ The name of the service used for the ingress controller's validation webhook
 
 {{- define "kong.volumes" -}}
 - name: {{ template "kong.fullname" . }}-prefix-dir
-  emptyDir: 
+  emptyDir:
     sizeLimit: {{ .Values.deployment.prefixDir.sizeLimit }}
 - name: {{ template "kong.fullname" . }}-tmp
-  emptyDir: 
+  emptyDir:
     sizeLimit: {{ .Values.deployment.tmpDir.sizeLimit }}
 {{- if and ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) .Values.certificates.enabled -}}
 {{- if .Values.certificates.cluster.enabled }}
@@ -1142,6 +1142,7 @@ role sets used in the charts. Updating these requires separating out cluster
 resource roles into their separate templates.
 */}}
 {{- define "kong.kubernetesRBACRules" -}}
+{{- if (semverCompare "< 2.10.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
 - apiGroups:
   - ""
   resources:
@@ -1149,14 +1150,7 @@ resource roles into their separate templates.
   verbs:
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - endpoints/status
-  verbs:
-  - get
-  - patch
-  - update
+{{- end }}
 - apiGroups:
   - ""
   resources:
@@ -1186,14 +1180,6 @@ resource roles into their separate templates.
   verbs:
   - list
   - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets/status
-  verbs:
-  - get
-  - patch
-  - update
 - apiGroups:
   - ""
   resources:

--- a/charts/kong/templates/controller-rbac-resources.yaml
+++ b/charts/kong/templates/controller-rbac-resources.yaml
@@ -35,12 +35,14 @@ rules:
       - configmaps
     verbs:
       - create
+{{- if (semverCompare "< 2.10.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
   - apiGroups:
       - ""
     resources:
       - endpoints
     verbs:
       - get
+{{- end }}
   # Begin KIC 2.x leader permissions
   - apiGroups:
       - ""
@@ -67,7 +69,6 @@ rules:
       - ""
     resources:
       - services
-      - endpoints
     verbs:
       - get
 ---


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

- PR https://github.com/Kong/kubernetes-ingress-controller/pull/3997 that targets KIC release 2.10 gets rid of CoreV1 Endpoints entirely, thus permissions are no longer needed - make them conditional
- RBAC permissions for [secrets/status](https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/secret-v1/) and [endpoints/status](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/endpoints-v1/) subresource are redundant. According to docs they don't have such filed.
- improve description in `charts/kong/crds/custom-resource-definitions.yaml` about upstreams to not use vague "Endpoints"

#### Which issue this PR fixes

  - fixes #795 (a leftover from https://github.com/Kong/kubernetes-ingress-controller/issues/3916)

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] ~New or modified sections of values.yaml are documented in the README.md~
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
