### PR TITLE
fix(docs): Fix Hybrid mode database value

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -432,7 +432,7 @@ admin:
 ```yaml
 env:
   role: data_plane
-  database: off
+  database: "off"
   cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
   cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
   lua_ssl_trusted_certificate: /etc/secrets/kong-cluster-cert/tls.crt


### PR DESCRIPTION
#### What this PR does / why we need it:

I received the following error whilst trying to deploy a hybrid mode node:

```
Error: INSTALLATION FAILED: template: kong/templates/migrations.yaml:14:29: executing "kong/templates/migrations.yaml" at <eq .Values.env.database "off">: error calling eq: incompatible types for comparison
```

This is due to `off` being a boolean in yaml. Switching to `"off"` resolves the issue

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
