### PR TITLE
chore: CI verisons bump

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -82,6 +82,9 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
+    env:
+      # Specify this here because these tests rely on ktf to run kind for cluster creation.
+      KIND_VERSION: v0.19.0
     strategy:
       matrix:
         kubernetes-version:
@@ -91,8 +94,9 @@ jobs:
         - "1.22.15"
         - "1.23.13"
         - "1.24.7"
-        - "1.25.3"
-        - "1.26.0"
+        - "1.25.9"
+        - "1.26.4"
+        - "1.27.1"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -30,8 +30,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}/.."
-KIND_VERSION="${KIND_VERSION:-v0.17.0}"
-KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.26.0}"
+KIND_VERSION="${KIND_VERSION:-v0.19.0}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.27.1}"
 
 # ------------------------------------------------------------------------------
 # Setup Tools - Docker
@@ -81,7 +81,7 @@ ktf 1>/dev/null
 
 ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma --kubernetes-version "${KUBERNETES_VERSION}"
 
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1" | kubectl apply -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl apply -f -
 
 echo "INFO: Updating helm dependencies"
 helm dependency update charts/kong/


### PR DESCRIPTION
#### What this PR does / why we need it:

- Bump kind versions used in integration tests
- Include k8s v1.27.1 in CI matrix
- Bump default kind version to v0.19.0
- Bump Gateway API manifests installed in env to v0.6.1

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- ~[ ] Changes are documented under the "Unreleased" header in CHANGELOG.md~
- ~[ ] New or modified sections of values.yaml are documented in the README.md~
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
