### PR TITLE
docs(hybrid): Add Hybrid mode w/ Cert Manager example

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -336,6 +336,9 @@ first and then upgrade the data plane release](https://docs.konghq.com/gateway/l
 
 #### Certificates
 
+> This example shows how to use Kong Hybrid mode with `cluster_mtls: shared`.
+> For an example of `cluster_mtls: pki` see the [hybrid-cert-manager example](https://github.com/Kong/charts/blob/main/charts/kong/example-values/hybrid-cert-manager/)
+
 Hybrid mode uses TLS to secure the CP/DP node communication channel, and
 requires certificates for it. You can generate these either using `kong hybrid
 gen_cert` on a local Kong installation or using OpenSSL:

--- a/charts/kong/example-values/hybrid-cert-manager/README.md
+++ b/charts/kong/example-values/hybrid-cert-manager/README.md
@@ -1,0 +1,83 @@
+This README explains how to install Kong in DB-backed mode with Postgres and Cert Manager
+
+# Install Postgres
+
+Use the bitnami chart to install Postgres. Read the output to understand how to connect to the database.
+
+```bash
+helm install postgres oci://registry-1.docker.io/bitnamicharts/postgresql -n db --create-namespace
+```
+
+Once connected, create a postgres user and database:
+
+```sql
+CREATE USER kong WITH PASSWORD 'super_secret'; CREATE DATABASE kong OWNER kong;
+```
+
+# Cert Manager
+
+Install Cert Manager in to your cluster:
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.11.0
+```
+
+Create a self signed CA + Issuer for future use:
+
+```yaml
+echo "
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-selfsigned-ca
+  namespace: kong
+spec:
+  isCA: true
+  commonName: my-selfsigned-ca
+  secretName: root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: my-ca-issuer
+  namespace: kong
+spec:
+  ca:
+    secretName: root-secret
+" | kaf -
+```
+
+# Kong
+
+Deploy Kong using the `cp-values.yaml` and `dp-values.yaml` in this folder:
+
+```bash
+helm install kong-cp kong/kong -n kong --values cp-values.yaml
+helm install kong-dp kong/kong -n kong --values dp-values.yaml
+```
+
+You should now have Kong running in hybrid mode

--- a/charts/kong/example-values/hybrid-cert-manager/cp-values.yaml
+++ b/charts/kong/example-values/hybrid-cert-manager/cp-values.yaml
@@ -1,0 +1,25 @@
+env:
+  role: control_plane
+  database: postgres
+  pg_host: postgres-postgresql.db.svc.cluster.local
+  pg_user: kong
+  pg_password: super_secret
+  cluster_mtls: pki
+
+cluster:
+  enabled: true
+  tls:
+    enabled: true
+
+certificates:
+  enabled: true
+  issuer: my-ca-issuer
+  cluster:
+    enabled: true
+
+proxy:
+  enabled: false
+
+ingressController:
+  env:
+    publish_service: kong/kong-cp-kong-proxy

--- a/charts/kong/example-values/hybrid-cert-manager/dp-values.yaml
+++ b/charts/kong/example-values/hybrid-cert-manager/dp-values.yaml
@@ -1,0 +1,22 @@
+env:
+  role: data_plane
+  database: "off"
+  cluster_control_plane: kong-cp-kong-cluster.kong.svc.cluster.local:8005
+  cluster_mtls: pki
+
+cluster:
+  enabled: true
+  tls:
+    enabled: true
+
+certificates:
+  enabled: true
+  issuer: my-ca-issuer
+  cluster:
+    enabled: true
+
+admin:
+  enabled: false
+
+ingressController:
+  enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

The existing README shows how to use hybrid mode with a shared certificate. When running with Cert Manager we need to switch to `pki` mode.

This PR adds example `values.yaml` files + a README for this specific use case as it's come up a few times.

#### Which issue this PR fixes

FTI-4396

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
