### PR TITLE
Allow custom CommonName when `cluster_mtls: pki`

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 2.22.0
+
 ### Improvements
 
 * Removed redundant RBAC permissions for non-existing subresources `secrets/status`
@@ -10,7 +12,9 @@
 * For Kong Ingress Controller in version >= 2.10, RBAC permissions for `Endpoints`
   are not configured anymore (because it uses `EndpointSlices`).
   [#798](https://github.com/Kong/charts/pull/798)
-
+* Added support for setting `certificates.cluster.commonName`. This allows a custom
+  certificate `CommonName` to be provided when deploying Kong Gateway in hybrid
+  mode using Cert Manager [#804](https://github.com/Kong/charts/pull/804)
 
 ## 2.21.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.21.0
+version: 2.22.0
 appVersion: "3.2"
 dependencies:
 - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -336,6 +336,9 @@ first and then upgrade the data plane release](https://docs.konghq.com/gateway/l
 
 #### Certificates
 
+> This example shows how to use Kong Hybrid mode with `cluster_mtls: shared`.
+> For an example of `cluster_mtls: pki` see the [hybrid-cert-manager example](https://github.com/Kong/charts/blob/main/charts/kong/example-values/hybrid-cert-manager/)
+
 Hybrid mode uses TLS to secure the CP/DP node communication channel, and
 requires certificates for it. You can generate these either using `kong hybrid
 gen_cert` on a local Kong installation or using OpenSSL:

--- a/charts/kong/example-values/hybrid-cert-manager/README.md
+++ b/charts/kong/example-values/hybrid-cert-manager/README.md
@@ -1,0 +1,83 @@
+This README explains how to install Kong in DB-backed mode with Postgres and Cert Manager
+
+# Install Postgres
+
+Use the bitnami chart to install Postgres. Read the output to understand how to connect to the database.
+
+```bash
+helm install postgres oci://registry-1.docker.io/bitnamicharts/postgresql -n db --create-namespace
+```
+
+Once connected, create a postgres user and database:
+
+```sql
+CREATE USER kong WITH PASSWORD 'super_secret'; CREATE DATABASE kong OWNER kong;
+```
+
+# Cert Manager
+
+Install Cert Manager in to your cluster:
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.crds.yaml
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --version v1.11.0
+```
+
+Create a self signed CA + Issuer for future use:
+
+```yaml
+echo "
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-selfsigned-ca
+  namespace: kong
+spec:
+  isCA: true
+  commonName: my-selfsigned-ca
+  secretName: root-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: my-ca-issuer
+  namespace: kong
+spec:
+  ca:
+    secretName: root-secret
+" | kubectl apply -f -
+```
+
+# Kong
+
+Deploy Kong using the `cp-values.yaml` and `dp-values.yaml` in this folder:
+
+```bash
+helm install kong-cp kong/kong -n kong --values cp-values.yaml
+helm install kong-dp kong/kong -n kong --values dp-values.yaml
+```
+
+You should now have Kong running in hybrid mode

--- a/charts/kong/example-values/hybrid-cert-manager/cp-values.yaml
+++ b/charts/kong/example-values/hybrid-cert-manager/cp-values.yaml
@@ -1,0 +1,25 @@
+env:
+  role: control_plane
+  database: postgres
+  pg_host: postgres-postgresql.db.svc.cluster.local
+  pg_user: kong
+  pg_password: super_secret
+
+cluster:
+  enabled: true
+  tls:
+    enabled: true
+
+certificates:
+  enabled: true
+  issuer: my-ca-issuer
+  cluster:
+    enabled: true
+    commonName: custom.example.com
+
+proxy:
+  enabled: false
+
+ingressController:
+  env:
+    publish_service: kong/kong-cp-kong-proxy

--- a/charts/kong/example-values/hybrid-cert-manager/dp-values.yaml
+++ b/charts/kong/example-values/hybrid-cert-manager/dp-values.yaml
@@ -1,0 +1,22 @@
+env:
+  role: data_plane
+  database: "off"
+  cluster_control_plane: kong-cp-kong-cluster.kong.svc.cluster.local:8005
+
+cluster:
+  enabled: true
+  tls:
+    enabled: true
+
+certificates:
+  enabled: true
+  issuer: my-ca-issuer
+  cluster:
+    enabled: true
+    commonName: custom.example.com
+
+admin:
+  enabled: false
+
+ingressController:
+  enabled: false

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -867,6 +867,8 @@ the template that it itself is using form the above sections.
 
 {{- if and ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) .Values.certificates.enabled -}}
   {{- if (and .Values.certificates.cluster.enabled .Values.cluster.enabled) -}}
+    {{- $_ := set $autoEnv "KONG_CLUSTER_MTLS" "pki" -}}
+    {{- $_ := set $autoEnv "KONG_CLUSTER_SERVER_NAME" .Values.certificates.cluster.commonName -}}
     {{- $_ := set $autoEnv "KONG_CLUSTER_CA_CERT" "/etc/cert-manager/cluster/ca.crt" -}}
     {{- $_ := set $autoEnv "KONG_CLUSTER_CERT" "/etc/cert-manager/cluster/tls.crt" -}}
     {{- $_ := set $autoEnv "KONG_CLUSTER_CERT_KEY" "/etc/cert-manager/cluster/tls.key" -}}

--- a/charts/kong/templates/certificate.yaml
+++ b/charts/kong/templates/certificate.yaml
@@ -30,10 +30,7 @@
 
 {{- if .Values.certificates.cluster.enabled }}
 {{- $certificateConfig := dict -}}
-{{- $certificateConfig = mustMerge (mustDeepCopy $genericCertificateConfig) $certificateConfig -}}
-{{- $_ := set $certificateConfig "dnsNames" (list) -}}
-{{- $_ := set $certificateConfig "commonName" "kong_cluster" -}}
-{{- $certificateConfig = (mustMerge $certificateConfig .Values.certificates.cluster) -}}
+{{- $certificateConfig = mustMerge (mustDeepCopy $genericCertificateConfig) .Values.certificates.cluster -}}
 {{- $_ := set $certificateConfig "serviceName" "cluster" -}}
 {{- include "kong.certificate" $certificateConfig -}}
 {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -728,8 +728,8 @@ certificates:
     # Issuers used by the control and data plane releases must match for this certificate.
     issuer: ""
     clusterIssuer: ""
-    # commonName: "kong_cluster"
-    # dnsNames: []
+    commonName: "kong_clustering"
+    dnsNames: []
 
 # -----------------------------------------------------------------------------
 # Miscellaneous parameters


### PR DESCRIPTION
#### What this PR does / why we need it:

The `CommonName` for the cluster certificate _must_ be set to `kong_clustering` when running in `cluster_mtls: shared` mode. When running in `cluster_mtls: pki` mode it can be any value that a CA will accept.

I've also added some additional documentation. The existing README shows how to use hybrid mode with a shared certificate. When running with Cert Manager we need to switch to `pki` mode.

This PR adds example `values.yaml` files + a README for this specific use case as it's come up a few times.

#### Which issue this PR fixes

FTI-4396

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
