### PR TITLE
Add opinionated KIC + Gateway Discovery chart

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -49,8 +49,10 @@ jobs:
         with:
           version: v3.11.0
 
-      - name: Add Bitnami
-        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+      - name: Add Helm repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add kong https://charts.konghq.com
 
       - uses: actions/setup-python@v4
         with:
@@ -78,7 +80,7 @@ jobs:
         # always is fine
 
       - name: Run chart-testing (install)
-        run: ct install --all
+        run: ct install --charts charts/kong
 
   integration-test:
     runs-on: ubuntu-latest
@@ -97,6 +99,9 @@ jobs:
         - "1.25.9"
         - "1.26.4"
         - "1.27.1"
+        chart-name:
+          - kong
+          - ingress
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -114,9 +119,13 @@ jobs:
         run: ./scripts/test-env.sh
 
       - name: run integration tests (integration)
+        env:
+          CHART_NAME: ${{ matrix.chart-name }}
         run: ./scripts/test-run.sh
 
       - name: run upgrade integration tests (integration-upgrade)
+        env:
+          CHART_NAME: ${{ matrix.chart-name }}
         run: ./scripts/test-upgrade.sh
 
       - name: cleanup integration tests (cleanup)

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 charts/kong/charts
+charts/ingress/charts

--- a/charts/ingress/.helmignore
+++ b/charts/ingress/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+
+### Improvements
+
+- Created opinionated KIC + Gateway Discovery chart with predefined `values.yaml`
+  [#806](https://github.com/Kong/charts/pull/806)

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: kong
+  repository: https://charts.konghq.com
+  version: 2.22.0
+- name: kong
+  repository: https://charts.konghq.com
+  version: 2.22.0
+digest: sha256:0634ed5a32efbf25a49b45b20b7482512fe647c6969b7db3954b4d88c5de1ce8
+generated: "2023-05-24T14:03:31.564788+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+description: Deploy Kong Ingress Controller and Kong Gateway
+engine: gotpl
+home: https://konghq.com/
+icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
+maintainers:
+  - name: mheap
+    email: michael.heap@konghq.com
+name: ingress
+sources:
+  - https://github.com/Kong/charts/tree/main/charts/kong
+version: 0.1.0
+appVersion: "3.2"
+dependencies:
+  - name: kong
+    version: ">=2.22.0"
+    repository: https://charts.konghq.com
+    alias: controller
+    condition: controller.enabled
+  - name: kong
+    version: ">=2.22.0"
+    repository: https://charts.konghq.com
+    alias: gateway
+    condition: gateway.enabled

--- a/charts/ingress/README.md
+++ b/charts/ingress/README.md
@@ -1,0 +1,19 @@
+## Kong Ingress Controller
+
+[Kong for Kubernetes](https://github.com/Kong/kubernetes-ingress-controller)
+is an open-source Ingress Controller for Kubernetes that offers
+API management capabilities with a plugin architecture.
+
+This is a meta chart that deploys an opinionated Kong Ingress Controller with
+Kong Gateway using [Helm](https://helm.sh) package manager.
+
+## Usage
+
+```bash
+$ helm repo add kong https://charts.konghq.com
+$ helm repo update
+
+$ helm install kong kong/ingress -n kong
+```
+
+If you need more control over what is deployed, see the [kong/kong chart](https://github.com/Kong/charts/blob/main/charts/kong/README.md). Any `values.yaml` setting can be specified in the `controller` or `proxy` section of your `values.yaml` using this chart.

--- a/charts/ingress/example-values/kic-konnect.yaml
+++ b/charts/ingress/example-values/kic-konnect.yaml
@@ -1,0 +1,23 @@
+controller:
+  ingressController:
+    konnect:
+      enabled: true
+      runtimeGroupID: "dd74208f-7eff-47d0-a286-ba6df3db278b"
+      tlsClientSecretName: konnect-client-tls
+      apiHostname: "us.kic.api.konghq.com"
+
+gateway:
+  image:
+    name: kong/kong-gateway
+  env:
+    konnect_mode: "on"
+    vitals: "off"
+    cluster_mtls: pki
+    cluster_telemetry_endpoint: "8c9700866b.us.tp0.konghq.com:443"
+    cluster_telemetry_server_name: "8c9700866b.us.tp0.konghq.com"
+    cluster_cert: /etc/secrets/konnect-client-tls/tls.crt
+    cluster_cert_key: /etc/secrets/konnect-client-tls/tls.key
+    lua_ssl_trusted_certificate: system
+
+  secretVolumes:
+    - konnect-client-tls

--- a/charts/ingress/templates/tests/test-jobs.yaml
+++ b/charts/ingress/templates/tests/test-jobs.yaml
@@ -1,0 +1,17 @@
+{{- if  .Values.deployment.test.enabled }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-ingress"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: "{{ .Release.Name }}-curl"
+      image: curlimages/curl
+      command:
+        - curl
+        - "http://{{ .Release.Name }}-gateway-proxy.{{ .Release.Namespace }}.svc.cluster.local/httpbin"
+{{- end }}

--- a/charts/ingress/templates/tests/test-resources.yaml
+++ b/charts/ingress/templates/tests/test-resources.yaml
@@ -1,0 +1,48 @@
+{{- if  .Values.deployment.test.enabled }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-httpbin"
+  labels:
+    app: httpbin
+spec:
+  containers:
+    - name: httpbin
+      image: kennethreitz/httpbin
+      ports:
+      - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Release.Name }}-httpbin"
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: httpbin
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ .Release.Name }}-httpbin"
+  annotations:
+    httpbin.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.class: "kong"
+    konghq.com/strip-path: "true"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /httpbin
+        pathType: Prefix
+        backend:
+          service:
+            name: "{{ .Release.Name }}-httpbin"
+            port:
+              number: 80
+{{- end }}

--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -1,0 +1,37 @@
+deployment:
+  test:
+    enabled: false
+
+controller:
+  proxy:
+    nameOverride: kong-gateway-proxy
+
+  enabled: true
+
+  deployment:
+    kong:
+      enabled: false
+
+  ingressController:
+    enabled: true
+
+    gatewayDiscovery:
+      enabled: true
+      adminApiService:
+        name: kong-gateway-admin
+
+gateway:
+  enabled: true
+  deployment:
+    kong:
+      enabled: true
+
+  admin:
+    enabled: true
+
+  ingressController:
+    enabled: false
+
+  env:
+    role: traditional
+    database: "off"

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -84,4 +84,6 @@ ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma -
 kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl apply -f -
 
 echo "INFO: Updating helm dependencies"
-helm dependency update charts/kong/
+for i in charts/*; do
+  helm dependency update "$i"
+done

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -22,10 +22,21 @@ cd "${SCRIPT_DIR}/.."
 
 TAG="${TAG:-default}"
 RELEASE_NAME="${RELEASE_NAME:-chart-tests}"
-RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-$(uuidgen)}"
+RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-$(uuidgen | tr "[:upper:]" "[:lower:]")}"
 TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
 KUBECTL="kubectl --context kind-${TEST_ENV_NAME}"
 KUBERNETES_VERSION="$($KUBECTL version -o json | jq -r '.serverVersion.gitVersion')"
+
+CONTROLLER_PREFIX=""
+ADDITIONAL_FLAGS=()
+
+# ------------------------------------------------------------------------------
+# Configure per-chart settings
+# ------------------------------------------------------------------------------
+if [[ "${CHART_NAME}" == "ingress" ]]; then
+  CONTROLLER_PREFIX="controller."
+  ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.gatewayDiscovery.adminApiService.name=${RELEASE_NAME}-gateway-admin ")
+fi
 
 # ------------------------------------------------------------------------------
 # Deploy Kuma configuration and test namespace
@@ -62,29 +73,33 @@ metadata:
 # Deploy Chart - Kubernetes Ingress Controller
 # ------------------------------------------------------------------------------
 
-if [[ "${TAG}" == "default" ]]
+TAG_MESSAGE=""
+if [[ "${TAG}" != "default" ]]
 then
-    echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
-    helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
-        --set deployment.test.enabled=true \
-        --set ingressController.env.feature_gates="GatewayAlpha=true" \
-        --set ingressController.env.anonymous_reports="false" \
-        charts/kong/
-else
-    echo "INFO: installing chart as release ${RELEASE_NAME} with controller tag ${TAG} to namespace ${RELEASE_NAMESPACE}"
-    helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
-        --set ingressController.image.tag="${TAG}" \
-        --set ingressController.env.feature_gates="GatewayAlpha=true" \
-        --set ingressController.env.anonymous_reports="false" \
-        --set deployment.test.enabled=true \
-        charts/kong/
+  TAG_MESSAGE="with controller tag ${TAG} "
+  ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.image.tag=${TAG} ");
 fi
+
+# Configure values for all tests
+# Enable Gateway API
+ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.feature_gates=GatewayAlpha=true")
+# Tests should not show up in reporting
+ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.anonymous_reports=false")
+
+echo "INFO: installing chart as release ${RELEASE_NAME} ${TAG_MESSAGE}to namespace ${RELEASE_NAMESPACE}"
+set -x
+# shellcheck disable=SC2048,SC2086
+helm install --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
+    --set deployment.test.enabled=true \
+    ${ADDITIONAL_FLAGS[*]} \
+    "charts/${CHART_NAME}"
+set +x
 
 # ------------------------------------------------------------------------------
 # Test Chart - Kubernetes Ingress Controller
 # ------------------------------------------------------------------------------
 
-echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
+echo "INFO: running helm tests for ${CHART_NAME} chart on Kubernetes ${KUBERNETES_VERSION}"
 helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
 
 # ------------------------------------------------------------------------------

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -20,23 +20,36 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}/.."
 
 TAG="${TAG:-next-railgun}"
-EFFECTIVE_TAG="2.0.0"
+EFFECTIVE_TAG="99.0.0"
 RELEASE_NAME="${RELEASE_NAME:-chart-tests-upgrade-compat}"
 RELEASE_NAMESPACE="${RELEASE_NAMESPACE:-$(uuidgen)}"
 TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
 KUBECTL="kubectl --context kind-${TEST_ENV_NAME}"
 KUBERNETES_VERSION="$($KUBECTL version -o json | jq -r '.serverVersion.gitVersion')"
 
+CONTROLLER_PREFIX=""
+ADDITIONAL_FLAGS=()
+
+# ------------------------------------------------------------------------------
+# Configure per-chart settings
+# ------------------------------------------------------------------------------
+if [[ "${CHART_NAME}" == "ingress" ]]; then
+  CONTROLLER_PREFIX="controller."
+  ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.gatewayDiscovery.adminApiService.name=\"${RELEASE_NAME}-gateway-admin\" ")
+fi
+
 # ------------------------------------------------------------------------------
 # Deploy Chart - Kubernetes Ingress Controller
 # ------------------------------------------------------------------------------
 
 echo "INFO: installing chart as release ${RELEASE_NAME} to namespace ${RELEASE_NAMESPACE}"
+set -x
+# shellcheck disable=SC2048,SC2086
 helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
-    --set ingressController.env.anonymous_reports="false" \
-    --set deployment.test.enabled=true \
-    charts/kong/
-
+    --set ${CONTROLLER_PREFIX}ingressController.env.anonymous_reports="false" \
+    --set deployment.test.enabled=true ${ADDITIONAL_FLAGS[*]} \
+    "charts/${CHART_NAME}"
+set +x
 # ------------------------------------------------------------------------------
 # Test Chart - Kubernetes Ingress Controller
 # ------------------------------------------------------------------------------
@@ -49,18 +62,20 @@ helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
 # ------------------------------------------------------------------------------
 
 echo "INFO: upgrading the helm chart to image tag ${TAG}"
+set -x
+# shellcheck disable=SC2048,SC2086
 helm upgrade --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
-    --set ingressController.image.tag="${TAG}" \
-    --set deployment.test.enabled=true \
-    --set ingressController.env.anonymous_reports="false" \
-    --set ingressController.image.effectiveSemver="${EFFECTIVE_TAG}" \
-    charts/kong/
-
+    --set ${CONTROLLER_PREFIX}ingressController.image.tag="${TAG}" \
+    --set deployment.test.enabled=true ${ADDITIONAL_FLAGS[*]} \
+    --set ${CONTROLLER_PREFIX}ingressController.env.anonymous_reports="false" \
+    --set ${CONTROLLER_PREFIX}ingressController.image.effectiveSemver="${EFFECTIVE_TAG}" \
+    "charts/${CHART_NAME}"
+set +x
 # ------------------------------------------------------------------------------
 # Test Upgraded Chart
 # ------------------------------------------------------------------------------
 
-echo "INFO: running helm tests for all charts on Kubernetes ${KUBERNETES_VERSION}"
+echo "INFO: running helm tests for ${CHART_NAME} chart on Kubernetes ${KUBERNETES_VERSION}"
 helm test --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}"
 
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a wrapper chart that will deploy a standalone KIC with Gateway Discovery enabled.

#### Special notes for your reviewer:

This is a brand new chart. I've tested locally with KIC/Konnect and KIC+Gateway without Konnect. Traffic is proxied as expected + 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
