### PR TITLE
fix(ci): migrate from deprecated set-output to using GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -64,7 +64,7 @@ jobs:
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Run chart-testing (lint)


### PR DESCRIPTION
#### What this PR does / why we need it:

Don't use `set-output` which got deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
