### PR TITLE
fix(release): Set up dependent chart repos

### DIFF
--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -31,6 +31,11 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.4.0
 
+      - name: Add dependency chart repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add kong https://charts.konghq.com
+
       - name: Run chart-testing (lint)
         run: ct lint --charts ${{ matrix.chart-name }}
         working-directory: charts


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixing the build, round two! I'm not sure why the dependency repos are now required when they weren't before.

Here's a test workflow run on a branch that does everything except publish the chart: https://github.com/Kong/charts/actions/runs/5079393562 (via https://github.com/Kong/charts/commit/da432922ada079d6623895e82820bb15233908c4)


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
