### PR TITLE
fix(ci): fix ktf install

### DIFF
--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -32,6 +32,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}/.."
 KIND_VERSION="${KIND_VERSION:-v0.19.0}"
 KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.27.1}"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
+KTF_URL=https://github.com/Kong/kubernetes-testing-framework/releases/latest/download/ktf.${OS}.${ARCH}
 
 # ------------------------------------------------------------------------------
 # Setup Tools - Docker
@@ -68,7 +71,10 @@ kind version 1>/dev/null
 if ! command -v ktf 1>/dev/null
 then
     mkdir -p "${HOME}"/.local/bin
-    GOBIN="${HOME}"/.local/bin go install github.com/kong/kubernetes-testing-framework/cmd/ktf@latest
+    echo "Downloading KTF from ${KTF_URL}"
+    # grep location header to show the actual URL
+    curl -vL -o "${HOME}"/.local/bin/ktf ${KTF_URL} 2>&1 | grep "location: https://github.com/Kong/kubernetes-testing-framework/releases/download/"
+    chmod +x "${HOME}"/.local/bin/ktf
     export PATH="${HOME}/.local/bin:$PATH"
 fi
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Because of the ktf's `exclude` in https://github.com/Kong/kubernetes-testing-framework/blob/fb40daf53a894a2d1b41538bbff181848dc4acee/go.mod#L5-L8 we can't build it via `go install` anymore:

https://github.com/Kong/charts/actions/runs/5081563443/jobs/9130111751#step:8:15

```
	The go.mod file for the module providing named packages contains one or
	more exclude directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

Because of this let's just use the assets attached to ktf releases. This will fix the issue at hand and save us some time compiling it.
