### PR TITLE
feat(conf): add label configuration option when Kong is exposed via ingress

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+* Add custom label configuration option for Kong proxy `Ingress`.
+
 ## 2.22.0
 
 ### Improvements

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -684,6 +684,7 @@ or `ingress` sections, as it is used only for stream listens.
 | SVC.ingress.path                   | Ingress path.                                                                         | `/`                      |
 | SVC.ingress.pathType               | Ingress pathType. One of `ImplementationSpecific`, `Exact` or `Prefix`                | `ImplementationSpecific` |
 | SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                     |
+| SVC.ingress.labels                 | Ingress labels. Additional custom labels to add to the ingress.                       | `{}`                     |
 | SVC.annotations                    | Service annotations                                                                   | `{}`                     |
 | SVC.labels                         | Service labels                                                                        | `{}`                     |
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -85,6 +85,9 @@ metadata:
   namespace: {{ .namespace }}
   labels:
   {{- .metaLabels | nindent 4 }}
+  {{- range $key, $value := .ingress.labels }}
+    {{- $key | nindent 4 }}: {{ $value | quote }}
+  {{- end }}
   {{- if .ingress.annotations }}
   annotations:
     {{- range $key, $value := .ingress.annotations }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -338,8 +338,10 @@ proxy:
     # TLS secret name.
     # tls: kong-proxy.example.com-tls
     hostname:
-    # Map of ingress annotations.
+    # To specify annotations or labels for the ingress, add them to the respective
+    # "annotations" or "labels" dictionaries below.
     annotations: {}
+    labels: {}
     # Ingress path.
     path: /
     # Each path in an Ingress is required to have a corresponding path type. (ImplementationSpecific/Exact/Prefix)


### PR DESCRIPTION
#### What this PR does / why we need it:

Sometimes labels are used for filtering/configuring other resources. This PR adds support for adding custom labels to an ingress when Kong is exposed using an ingress controller.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
