### PR TITLE
Adding template rendering to labels

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 * Add custom label configuration option for Kong proxy `Ingress`.
+* Running `tpl` against user-supplied labels
 
 ## 2.22.0
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Add custom label configuration option for Kong proxy `Ingress`.
 * Running `tpl` against user-supplied labels and annotations used in Deployment
+  #### example:
+  ```yaml
+  podLabels: 
+    version: "{{ .Values.image.tag }}"  # Will render dynamically when overridden downstream
+  ```
 
 ## 2.22.0
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,16 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+* Running `tpl` against user-supplied labels and annotations used in Deployment
+  #### example:
+  ```yaml
+  podLabels:
+    version: "{{ .Values.image.tag }}"  # Will render dynamically when overridden downstream
+  ```
+  [#814](https://github.com/Kong/charts/pull/814)
+
 ## 2.23.0
 
 ### Improvements
 
 * Add custom label configuration option for Kong proxy `Ingress`.
-* Running `tpl` against user-supplied labels and annotations used in Deployment
-  #### example:
-  ```yaml
-  podLabels: 
-    version: "{{ .Values.image.tag }}"  # Will render dynamically when overridden downstream
-  ```
   [#812](https://github.com/Kong/charts/pull/812)
 * Bump default `kong/kubernetes-ingress-controller` image tag to 2.10.
   Bump default `kong` image tag to 3.3.

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Improvements
 
 * Add custom label configuration option for Kong proxy `Ingress`.
-* Running `tpl` against user-supplied labels
+* Running `tpl` against user-supplied labels and annotations used in Deployment
 
 ## 2.22.0
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -32,7 +32,7 @@ app.kubernetes.io/instance: "{{ .Release.Name }}"
 app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- range $key, $value := .Values.extraLabels }}
-{{ $key }}: {{ $value | quote }}
+{{ $key }}: {{ include "kong.renderTpl" (dict "value" $value "context" $) | quote }}
 {{- end }}
 {{- end -}}
 
@@ -1533,4 +1533,12 @@ autoscaling/v2beta2
 {{- else -}}
 autoscaling/v1
 {{- end -}}
+{{- end -}}
+
+{{- define "kong.renderTpl" -}}
+    {{- if typeIs "string" .value }}
+{{- tpl .value .context }}
+    {{- else }}
+{{- tpl (.value | toYaml) .context }}
+    {{- end }}
 {{- end -}}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- if .Values.deploymentAnnotations }}
   annotations:
   {{- range $key, $value := .Values.deploymentAnnotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{ $key }}: {{ include "kong.renderTpl" (dict "value" $value "context" $) | quote }}
   {{- end }}
   {{- end }}
 spec:
@@ -51,7 +51,7 @@ spec:
         {{- end }}
         {{- if .Values.podAnnotations }}
         {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+        {{ $key }}: {{ include "kong.renderTpl" (dict "value" $value "context" $) | quote }}
         {{- end }}
         {{- end }}
       labels:
@@ -60,7 +60,7 @@ spec:
         app: {{ template "kong.fullname" . }}
         version: {{ .Chart.AppVersion | quote }}
         {{- if .Values.podLabels }}
-        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{ include "kong.renderTpl" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.deployment.hostNetwork }}


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR runs `tpl` against user-supplied labels that are supplied via:

* `.Values.extraLabels`
* `.Values.podAnnotations`
* `.Values.podLabels`

This allows downstream users to build labels dynamically based on the current helm context. One such case for this is to dynamically build a "version" label that's based on the image tag supplied to the helm installation. i.e.:

```yaml
podLabels: 
  version: "{{ .Values.image.tag }}"  # Will render dynamically when overridden downstream
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
