### PR TITLE
chore(deps): bump default tags for Kong and KIC, release 2.23.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## Unreleased
+## 2.23.0
 
 ### Improvements
 
 * Add custom label configuration option for Kong proxy `Ingress`.
+  [#812](https://github.com/Kong/charts/pull/812)
+* Bump default `kong/kubernetes-ingress-controller` image tag to 2.10.
+  Bump default `kong` image tag to 3.3.
+  [#815](https://github.com/Kong/charts/pull/815)
 
 ## 2.22.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,8 +11,8 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.22.0
-appVersion: "3.2"
+version: 2.23.0
+appVersion: "3.3"
 dependencies:
 - name: postgresql
   version: 11.9.13

--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -146,7 +146,7 @@ extraLabels:
   konghq.com/component: quickstart
 image:
   repository: kong/kong-gateway
-  tag: "3.2"
+  tag: "3.3"
 ingressController:
   enabled: true
   env:
@@ -162,7 +162,7 @@ ingressController:
     publish_service: kong/quickstart-kong-proxy
   image:
     repository: docker.io/kong/kubernetes-ingress-controller
-    tag: "2.8"
+    tag: "2.10"
   ingressClass: default
   installCRDs: false
 manager:

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.2"
+  tag: "3.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.2"
+  tag: "3.3"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-controller.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: kong
-  tag: "3.2"
+  tag: "3.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.2"
+  tag: "3.3"
 
 enterprise:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
@@ -14,7 +14,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.2"
+  tag: "3.3"
 
 env:
   database: postgres

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.2"
+  tag: "3.3"
 
 env:
   role: data_plane
@@ -43,4 +43,3 @@ portal:
 
 portalapi:
   enabled: false
-

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "3.2"
+  tag: "3.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -11,7 +11,7 @@
 
 image:
   repository: kong
-  tag: "3.2"
+  tag: "3.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "3.2"
+  tag: "3.3"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -121,10 +121,10 @@ extraLabels: {}
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "3.2"
+  tag: "3.3"
   # Kong Enterprise
   # repository: kong/kong-gateway
-  # tag: "3.2"
+  # tag: "3.3"
 
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -486,7 +486,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "2.9"
+    tag: "2.10"
     # Optionally set a semantic version for version-gated features. This can normally
     # be left unset. You only need to set this if your tag is not a semver string,
     # such as when you are using a "next" tag. Set this to the effective semantic


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump KIC and Kong images to the latest ones and release 2.23.0.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
