### PR TITLE
ingress: bump kong/kong dependencies and release 0.2.0

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
+
+### Improvements
+
+- Bumped dependencies on `kong/kong` chart to `>=2.23.0`.
+  [#817](https://github.com/Kong/charts/pull/817)
+
+## 0.1.0
 
 ### Improvements
 

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.22.0
+  version: 2.23.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.22.0
-digest: sha256:0634ed5a32efbf25a49b45b20b7482512fe647c6969b7db3954b4d88c5de1ce8
-generated: "2023-05-24T14:03:31.564788+01:00"
+  version: 2.23.0
+digest: sha256:bfc17662001d97f0cff9445495802d8d33561655415b53f6b02a49c1d16399d4
+generated: "2023-06-07T10:35:15.48719+02:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -9,16 +9,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 0.1.0
-appVersion: "3.2"
+version: 0.2.0
+appVersion: "3.3"
 dependencies:
   - name: kong
-    version: ">=2.22.0"
+    version: ">=2.23.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.22.0"
+    version: ">=2.23.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps dependencies on `kong/kong` to the latest version (that uses KIC 2.10 and Kong 3.3).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
