### PR TITLE
feat(kong): fail to render templates when PodSecurityPolicy is requested but cluster doesn't serve it

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Improvements
+
 * Running `tpl` against user-supplied labels and annotations used in Deployment
   #### example:
   ```yaml
@@ -10,6 +11,9 @@
     version: "{{ .Values.image.tag }}"  # Will render dynamically when overridden downstream
   ```
   [#814](https://github.com/Kong/charts/pull/814)
+* Fail to render templates when PodSecurityPolicy was requested but cluster doesn't
+  serve its API.
+  [#823](https://github.com/Kong/charts/pull/823)
 
 ## 2.23.0
 

--- a/charts/kong/ci/test1-values.yaml
+++ b/charts/kong/ci/test1-values.yaml
@@ -28,9 +28,6 @@ ingressController:
 podLabels:
   app: kong
   environment: test
-# - podSecurityPolicies are enabled
-podSecurityPolicy:
-  enabled: true
 # - ingress resources are created with hosts
 admin:
   type: NodePort

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1535,6 +1535,14 @@ autoscaling/v1
 {{- end -}}
 {{- end -}}
 
+{{- define "kong.policyVersion" -}}
+{{- if (.Capabilities.APIVersions.Has "policy/v1beta1" ) -}}
+policy/v1beta1
+{{- else -}}
+{{- fail (printf "Cluster doesn't have policy/v1beta1 API." ) }}
+{{- end -}}
+{{- end -}}
+
 {{- define "kong.renderTpl" -}}
     {{- if typeIs "string" .value }}
 {{- tpl .value .context }}

--- a/charts/kong/templates/psp.yaml
+++ b/charts/kong/templates/psp.yaml
@@ -1,5 +1,5 @@
-{{- if and (.Values.podSecurityPolicy.enabled) (.Capabilities.APIVersions.Has "policy/v1beta1") }}
-apiVersion: policy/v1beta1
+{{- if and (.Values.podSecurityPolicy.enabled) }}
+apiVersion: {{ include "kong.policyVersion" . }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kong.serviceAccountName" . }}-psp


### PR DESCRIPTION
#### What this PR does / why we need it:

When PSP is requested via `.Values.podSecurityPolicy` but cluster cannot serve it then fail to render instead of silently ignoring.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
