### PR TITLE
Fix Ingress and HPA API versions during capabilities checking

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -15,7 +15,7 @@
   serve its API.
   [#823](https://github.com/Kong/charts/pull/823)
 * Fix Ingress and HPA API versions during capabilities checking 
-  [#823](https://github.com/Kong/charts/pull/827)
+  [#827](https://github.com/Kong/charts/pull/827)
 
 ## 2.23.0
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Fail to render templates when PodSecurityPolicy was requested but cluster doesn't
   serve its API.
   [#823](https://github.com/Kong/charts/pull/823)
+* Fix Ingress and HPA API versions during capabilities checking 
+  [#823](https://github.com/Kong/charts/pull/827)
 
 ## 2.23.0
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1516,9 +1516,9 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
 {{- end -}}
 
 {{- define "kong.ingressVersion" -}}
-{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress") -}}
+{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1") -}}
 networking.k8s.io/v1
-{{- else if (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") -}}
+{{- else if (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") -}}
 networking.k8s.io/v1beta1
 {{- else -}}
 extensions/v1beta1
@@ -1526,9 +1526,9 @@ extensions/v1beta1
 {{- end -}}
 
 {{- define "kong.autoscalingVersion" -}}
-{{- if (.Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler") -}}
+{{- if (.Capabilities.APIVersions.Has "autoscaling/v2") -}}
 autoscaling/v2
-{{- else if (.Capabilities.APIVersions.Has "autoscaling/v2beta2/HorizontalPodAutoscaler") -}}
+{{- else if (.Capabilities.APIVersions.Has "autoscaling/v2beta2") -}}
 autoscaling/v2beta2
 {{- else -}}
 autoscaling/v1


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Helm templating for Ingress and HPA since apiversions ending with /Ingress and /HorizontalPodAutoscaler doesn't exist 

#### Which issue this PR fixes
  - fixes: 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
