### PR TITLE
feat(kong): Switch to new `/status/ready` endpoint for readiness check

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -14,8 +14,10 @@
 * Fail to render templates when PodSecurityPolicy was requested but cluster doesn't
   serve its API.
   [#823](https://github.com/Kong/charts/pull/823)
-* Fix Ingress and HPA API versions during capabilities checking 
+* Fix Ingress and HPA API versions during capabilities checking
   [#827](https://github.com/Kong/charts/pull/827)
+* Changed `readinessProbe` to use new Status API endpoint `/status/ready` to prevent pods from becoming ready before the it can serve traffic. See [Readiness Check](https://docs.konghq.com/gateway/latest/production/monitoring/readiness-check/).
+  [#829](https://github.com/Kong/charts/pull/829).
 
 ## 2.23.0
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -771,10 +771,10 @@ resources: {}
 # readinessProbe for Kong pods
 readinessProbe:
   httpGet:
-    path: "/status"
+    path: "/status/ready"
     port: status
     scheme: HTTP
-  initialDelaySeconds: 5
+  initialDelaySeconds: 10
   timeoutSeconds: 5
   periodSeconds: 10
   successThreshold: 1


### PR DESCRIPTION
#### What this PR does / why we need it:
In Kong 3.3.0 the Status API has been enhanced with the addition of the /status/ready API for monitoring Kong Gateway’s health. https://docs.konghq.com/gateway/changelog/#3300

#### Which issue this PR fixes
none

#### Special notes for your reviewer:
The documentation https://github.com/Kong/docs.konghq.com/edit/main/app/_src/gateway/production/monitoring/readiness-check.md needs to be updated since the note about the Helm chart is the default after this PR.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
