### PR TITLE
remove quickstart update strategy

### DIFF
--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -278,8 +278,4 @@ status:
   tls:
     containerPort: 8543
     enabled: false
-updateStrategy:
-  rollingUpdate:
-    maxSurge: 100%
-    maxUnavailable: 100%
-  type: RollingUpdate
+


### PR DESCRIPTION


#### What this PR does / why we need it:
remove updateStrategy from quickstart-enterprise-licensed-aio.yaml (use k8s default values)

#### Which issue this PR fixes
  - fixes #831 

#### Special notes for your reviewer:

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines
