### PR TITLE
fix: re-add missing kong.ingressVersion template

### DIFF
--- a/charts/kong/ci/admin-api-service-clusterip.yaml
+++ b/charts/kong/ci/admin-api-service-clusterip.yaml
@@ -1,0 +1,6 @@
+admin:
+  enabled: true
+  type: ClusterIP
+
+ingressController:
+  enabled: false

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1581,3 +1581,13 @@ policy/v1beta1
 {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{- define "kong.ingressVersion" -}}
+{{- if (.Capabilities.APIVersions.Has "networking.k8s.io/v1") -}}
+networking.k8s.io/v1
+{{- else if (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1") -}}
+networking.k8s.io/v1beta1
+{{- else -}}
+extensions/v1beta1
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds `kong.ingressVersion` template which was removed in #813.

Additionally it adds a tests that uses that ( by exposing Admin API service ).

Without this patch the added test values.yaml file, yields:

```
Error: template: kong/templates/service-kong-admin.yaml:5:47: executing "kong/templates/service-kong-admin.yaml" at <include "kong.ingressVersion" .>: error calling include: template: no template "kong.ingressVersion" associated with template "gotpl"
```
