### PR TITLE
chore: bump postgres to 13.11

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,23 +1,30 @@
 # Changelog
 
-## Unreleased
+## 2.24.0
 
 ### Improvements
 
 * Running `tpl` against user-supplied labels and annotations used in Deployment
-  #### example:
+  [#814](https://github.com/Kong/charts/pull/814)
+
+  Example:
   ```yaml
   podLabels:
     version: "{{ .Values.image.tag }}"  # Will render dynamically when overridden downstream
   ```
-  [#814](https://github.com/Kong/charts/pull/814)
+
 * Fail to render templates when PodSecurityPolicy was requested but cluster doesn't
   serve its API.
   [#823](https://github.com/Kong/charts/pull/823)
-* Fix Ingress and HPA API versions during capabilities checking
-  [#827](https://github.com/Kong/charts/pull/827)
 * Add support for multiple hosts and tls configurations for Kong proxy `Ingress`.
   [#813](https://github.com/Kong/charts/pull/813)
+* Bump postgres default tag to `13.11.0-debian-11-r20` which includes arm64 images.
+  [#834](https://github.com/Kong/charts/pull/834)
+
+### Fixed
+
+* Fix Ingress and HPA API versions during capabilities checking
+  [#827](https://github.com/Kong/charts/pull/827)
 
 ## 2.23.0
 
@@ -57,7 +64,7 @@
 
 ## 2.20.2
 
-### Fixed 
+### Fixed
 
 * Automatic license provisioning for Gateways managed by Ingress Controllers in Konnect mode
   is disabled by default.

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.23.0
+version: 2.24.0
 appVersion: "3.3"
 dependencies:
 - name: postgresql

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -691,7 +691,7 @@ postgresql:
   image:
     # use postgres < 14 until is https://github.com/Kong/kong/issues/8533 resolved and released
     # enterprise (kong-gateway) supports postgres 14
-    tag: 13.6.0-debian-10-r52
+    tag: 13.11.0-debian-11-r20
   service:
     ports:
       postgresql: "5432"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR bumps default default postgres tag to 13.11.

Why? To include most recent 13.X fixes and most importantly to by default use a version that has arm64 images: https://hub.docker.com/layers/bitnami/postgresql/13.11.0-debian-11-r20/images/sha256-2f4e684e911831a62cdabc214298b1dcb9a1c797bfdb8993dc28350c79b8a637?context=explore.

The reason for this is to allow people running on arm64 to have a working postgres setup with default values and also, transitively to have that in ktf where we don't (yet!) have an option to specify this.

Also release 2.24 chart version.