### PR TITLE
fix(ingress): make admin api service headless

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+### Fixes
+
+- Changed default `gateway.admin` service from `NodePort` to headless `ClusterIP`
+  which is expected for Gateway Discovery to work.
+  [#835](https://github.com/Kong/charts/pull/835)
+
 ## 0.2.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.23.0
+  version: 2.24.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.23.0
-digest: sha256:bfc17662001d97f0cff9445495802d8d33561655415b53f6b02a49c1d16399d4
-generated: "2023-06-07T10:35:15.48719+02:00"
+  version: 2.24.0
+digest: sha256:ba896c6e8690635eb398e6c1d12ada44cf7878fc7a44ee45b2311ff5a0e4c8c7
+generated: "2023-07-07T11:01:06.255154+02:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 0.2.0
+version: 0.3.0
 appVersion: "3.3"
 dependencies:
   - name: kong

--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -28,6 +28,8 @@ gateway:
 
   admin:
     enabled: true
+    type: ClusterIP
+    clusterIP: None
 
   ingressController:
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

The default deployment type for `kong/ingress` is Gateway Discovery. It should create a headless service for the admin API.

#### Which issue this PR fixes

It was spotted when debugging KIC+Konnect setup in Mesh.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
