### PR TITLE
feat(kong): Generate Admin API service name if requested

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.25.0
+
+- Generate the `adminApiService.name` value from `.Release.Name` rather than
+  hardcoding to `kong`
+  [#839](https://github.com/Kong/charts/pull/839)
+
 ## 2.24.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.24.0
+version: 2.25.0
 appVersion: "3.3"
 dependencies:
 - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -805,8 +805,8 @@ You'll be able to configure this feature through configuration section under
   - `ingressController.gatewayDiscovery.adminApiService.name`
   - `ingressController.gatewayDiscovery.adminApiService.namespace`
 
-  If you set `ingressController.gatewayDiscovery.generateAdminApiService` to `true`
-  and the chart will generate values for `name` and `namespace` based on the current release name and
+  If you set `ingressController.gatewayDiscovery.generateAdminApiService` to `true`,
+  the chart will generate values for `name` and `namespace` based on the current release name and
   namespace. This is useful when consuming the `kong` chart as a subchart.
 
 Using this feature requires a split release installation of Gateways and Ingress Controller.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -746,6 +746,7 @@ section of `values.yaml` file:
 | userDefinedVolumeMounts                    | Create volumeMounts. Please go to Kubernetes doc for the spec of the volumeMounts                                                                        |                                    |
 | terminationGracePeriodSeconds              | Sets the [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for Deployment pod | 30                                 |
 | gatewayDiscovery.enabled                   | Enables Kong instance service discovery (for more details see [gatewayDiscovery section][gd_section])                                                    | false                              |
+| gatewayDiscovery.generateAdminApiService   | Generate the admin API service name based on the release name (for more details see [gatewayDiscovery section][gd_section])                                                    | false                              |
 | gatewayDiscovery.adminApiService.namespace | The namespace of the Kong admin API service (for more details see [gatewayDiscovery section][gd_section])                                                | `.Release.Namespace`               |
 | gatewayDiscovery.adminApiService.name      | The name of the Kong admin API service (for more details see [gatewayDiscovery section][gd_section])                                                     | ""                                 |
 | konnect.enabled                            | Enable synchronisation of data plane configuration with Konnect Runtime Group                                                                            | false                              |
@@ -798,11 +799,15 @@ You'll be able to configure this feature through configuration section under
   service.
   (provided under the hood via `CONTROLLER_KONG_ADMIN_SVC` environment variable).
 
-  The following admin API Service flags have to be provided in order for gateway
+  The following admin API Service flags have to be present in order for gateway
   discovery to work:
 
   - `ingressController.gatewayDiscovery.adminApiService.name`
   - `ingressController.gatewayDiscovery.adminApiService.namespace`
+
+  If you set `ingressController.gatewayDiscovery.generateAdminApiService` to `true`
+  and the chart will generate values for `name` and `namespace` based on the current release name and
+  namespace. This is useful when consuming the `kong` chart as a subchart.
 
 Using this feature requires a split release installation of Gateways and Ingress Controller.
 For exemplar `values.yaml` files which use this feature please see: [examples README.md](./example-values/README.md).

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -525,6 +525,7 @@ ingressController:
 
   gatewayDiscovery:
     enabled: false
+    generateAdminApiService: false
     adminApiService:
       namespace: ""
       name: ""


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a `generateAdminApiService` option to use `.Release.name` rather than hardcoding to `kong`. We specify the release name as `kong` in demos, but don't always make it clear that there's an implicit dependency here. Instead if documenting the implicitness, let's generate an accurate service name in the chart.

#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md <- Added as 0.4.0 as when the PR is merged it'll auto-release
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
