### PR TITLE
feat(ingress): Generate Admin API service name if requested

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0
+
+### Improvements
+
+- Generate the `adminApiService.name` value from `.Release.Name` rather than
+  hardcoding to `kong`
+  [#840](https://github.com/Kong/charts/pull/840)
+
 ## 0.3.0
 
 ### Fixes

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.24.0
+  version: 2.25.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.24.0
-digest: sha256:ba896c6e8690635eb398e6c1d12ada44cf7878fc7a44ee45b2311ff5a0e4c8c7
-generated: "2023-07-07T11:01:06.255154+02:00"
+  version: 2.25.0
+digest: sha256:a07ca2054a8ecc4d7a25d607ea214edd0ea4a4c2b6b1a664234a8b13d10b90fb
+generated: "2023-07-17T09:40:57.200737+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -9,16 +9,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 0.3.0
+version: 0.4.0
 appVersion: "3.3"
 dependencies:
   - name: kong
-    version: ">=2.23.0"
+    version: ">=2.25.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.23.0"
+    version: ">=2.25.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled

--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -17,8 +17,7 @@ controller:
 
     gatewayDiscovery:
       enabled: true
-      adminApiService:
-        name: kong-gateway-admin
+      generateAdminApiService: true
 
 gateway:
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the dependency on the `kong` chart to 2.25.0 (see #839) and preps `ingress` for a release

#### Which issue this PR fixes


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
