### PR TITLE
fix(ci) update test to agree with new defaults

### DIFF
--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -35,7 +35,10 @@ ADDITIONAL_FLAGS=()
 # ------------------------------------------------------------------------------
 if [[ "${CHART_NAME}" == "ingress" ]]; then
   CONTROLLER_PREFIX="controller."
-  ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.gatewayDiscovery.adminApiService.name=${RELEASE_NAME}-gateway-admin ")
+  # this is intentionally a no-op at present. this originally had a set that was
+  # made obsolete by a values default change. it's now a placeholder showing an
+  # example modification
+  # ADDITIONAL_FLAGS+=("<replace with a --set command>")
 fi
 
 # ------------------------------------------------------------------------------

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -35,7 +35,10 @@ ADDITIONAL_FLAGS=()
 # ------------------------------------------------------------------------------
 if [[ "${CHART_NAME}" == "ingress" ]]; then
   CONTROLLER_PREFIX="controller."
-  ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.gatewayDiscovery.adminApiService.name=\"${RELEASE_NAME}-gateway-admin\" ")
+  # this is intentionally a no-op at present. this originally had a set that was
+  # made obsolete by a values default change. it's now a placeholder showing an
+  # example modification
+  # ADDITIONAL_FLAGS+=("<replace with a --set command>")
 fi
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Do not set the admin API Service name for tests against the ingress chart.

5802d40a78eb9fb6eabcdf9acddf4c3f8e81a1fd added a new default for gatewayDiscovery.generateAdminApiService. This setting is incompatible with specifying an admin Service name. The test was originally setting that name and failing, and the commit was merged to main despite in https://github.com/Kong/charts/pull/840.
