### PR TITLE
chore(ci) add passed job

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -130,3 +130,18 @@ jobs:
 
       - name: cleanup integration tests (cleanup)
         run: ./scripts/test-env.sh cleanup
+
+  # Workaround to allow checking the matrix tests as required tests without adding the individual cases
+  # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
+  passed:
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - lint-test
+      - integration-test
+    if: always()
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "Some jobs failed or were cancelled."
+          exit 1


### PR DESCRIPTION
#### What this PR does / why we need it:
Copies the `passed` job from KIC, but with the charts CI jobs in its required list.

From retro, we need this to let the protection rules require integration tests, as Github doesn't handle matrix jobs well in branch required job rules.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- ~Changes are documented under the "Unreleased" header in CHANGELOG.md~
- ~New or modified sections of values.yaml are documented in the README.md~
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
