### PR TITLE
feat(migrations) add Argo CD lifecycle policies

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Use the Kong 3.3 `/status/ready` endpoint for readiness probes by default if
   available. If not available, use the old `/status` default.
   [#844](https://github.com/Kong/charts/pull/844)
+* Add ArgoCD `Sync` and `BeforeHookCreation` [hook policies](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/)
+  to the the init and pre-upgrade migrations Jobs.
 
 ## 2.25.0
 

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -13,6 +13,8 @@ metadata:
   annotations:
     helm.sh/hook: "pre-upgrade"
     helm.sh/hook-delete-policy: "before-hook-creation"
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
   {{- range $key, $value := .Values.migrations.jobAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -21,6 +21,8 @@ metadata:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: init-migrations
   annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
   {{- range $key, $value := .Values.migrations.jobAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Set both the init-migrations and pre-upgrade-migrations Jobs to the Argo CD Sync policy. This appears to be the best option for working around the lack of distinct install and upgrade lifecycle phases in Argo CD.

Add a blurb to docs about Argo-specific chart features.

#### Which issue this PR fixes
  - fixes #763

#### Special notes for your reviewer:

I have [some notes and test resources](https://gist.github.com/rainest/ee9c75c901de6f101ffd171cd5fa35d9) I used with a KTF build that includes https://github.com/Kong/kubernetes-testing-framework/commit/c097dbd2008cb5fea7c6269ca7ddb3af0aa003ec (not released yet) via `./build/ktf.linux.amd64 env create --addon argocd --addon metallb`

The policies in this PR successfully deployed and upgraded a database instance 

The short version is:

PreSync is more appropriate for upgrade migrations, but in Argo land this is functionally equivalent to pre-install (first install has no special status) and comes with its usual chicken before egg problems, where everything fails because the Job relies on resources that won't exist until the main sync phase.

Sync for `migrations up` may cause the main Deployment to enter crashloop if the migrations take a very long time, but Kubernetes can sort that out. It will eventually recover.

A minor edge case temporary failure feels preferable to the alternatives:

- We use documentation to instruct users to manually toggle jobs on or off, or add Argo policies to them. This will avoid potential temporary backoff, but requires that users read docs and manually apply configuration, which is unreliable.
- We apply sync wave values to all resources, so that Argo will first apply prereq resources, then run migrations, then start the main Deployment. This may avoid temporary bad states (I didn't try it and can't say for certain if it won't come with issues of its own) but requires a lot more work.

Forcibly applying the override Argo hook policies in templates seems like a good enough solution that doesn't require additional user configuration, so I'd like to try it in the wild and see if there are unexpected problems. If there are, we can work on a more complex solution.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
