### PR TITLE
feat(ports): add extra ports feature in kong chart

### DIFF
--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.25.0
+version: 2.26.0
 appVersion: "3.3"
 dependencies:
 - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -670,6 +670,12 @@ or `ingress` sections, as it is used only for stream listens.
 | SVC.tls.hostPort                   | Host port to use for TLS                                                              |                          |
 | SVC.tls.overrideServiceTargetPort  | Override service port to use for TLS without touching Kong containerPort              |                          |
 | SVC.tls.parameters                 | Array of additional listen parameters                                                 | `["http2"]`              |
+| SVC.extraPorts                     | Array of additional listen ports                                                      | `[]`                     |
+| SVC.extraPorts.[].containerPort    | Container port to use for the additional lister                                       |                          |
+| SVC.extraPorts.[].servicePort      | Service port to use for the additional lister                                         |                          |
+| SVC.extraPorts.[].nodePort         | Node port to use for the additional lister                                            |                          |
+| SVC.extraPorts.[].hostPort         | Host port to use for the additional lister                                            |                          |
+| SVC.extraPorts.[].parameters       | Array of additional listen parameters                                                 | `[]`                     |
 | SVC.type                           | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          |                          |
 | SVC.clusterIP                      | k8s service clusterIP                                                                 |                          |
 | SVC.loadBalancerClass              | loadBalancerClass to use for LoadBalancer provisionning                               |                          |

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -176,6 +176,14 @@ spec:
           {{- end}}
           protocol: {{ .protocol }}
         {{- end }}
+        {{- range .Values.proxy.extraPorts }}
+        - name: extra{{ if (eq (default "TCP" .protocol) "UDP") }}udp{{ end }}-{{ .containerPort }}
+          containerPort: {{ .containerPort }}
+          {{- if .hostPort }}
+          hostPort: {{ .hostPort }}
+          {{- end}}
+          protocol: {{ .protocol }}
+        {{- end }}
         {{- range .Values.udpProxy.stream }}
         - name: streamudp-{{ .containerPort }}
           containerPort: {{ .containerPort }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -306,6 +306,27 @@ proxy:
     parameters:
     - http2
 
+  # Define extra ports
+  # To enable, remove "[]", uncomment the section below, and select your desired
+  # ports and parameters. Listens are dynamically named after their containerPort,
+  # e.g. "extra-9080" for the below.
+  # Note: although you can select the protocol here, you cannot set UDP if you
+  # use a LoadBalancer Service due to limitations in current Kubernetes versions.
+  # To proxy both TCP and UDP with LoadBalancers, you must enable the udpProxy Service
+  # in the next section and place all UDP stream listen configuration under it.
+  extraPorts: []
+    #   # Set the container (internal) and service (external) ports for this extra port.
+    #   # These values should normally be the same. If your environment requires they
+    #   # differ, note that Kong will match routes based on the containerPort only.
+    # - servicePort: 4432
+    #   containerPort: 9080
+    #   protocol: TCP
+    #   # Optionally set a static nodePort if the service type is NodePort
+    #   # nodePort: 33443
+    #   # Additional listen parameters, e.g. "ssl", "reuseport", "backlog=16384"
+    #   # "ssl" is required for SNI-based routes. It is not supported on versions <2.0
+    #   parameters: []
+
   # Define stream (TCP) listen
   # To enable, remove "[]", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their containerPort,


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

This PR adds the possibility of including new ports for the proxy and mapping it to the service.
We need to be able to expose another port to the proxy with different parameter settings, for example, one for http1.1 and another for http2.

#### Special notes for your reviewer:

It's the first time I contribute, if there's something wrong with the patterns, I'm happy if you can help me.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
