### PR TITLE
chore(ingress): bump chart deps and release 0.5.0

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.0
+
+### Improvements
+
+- Bumped dependencies on `kong/kong` chart to `>=2.26.0`.
+  [#855](https://github.com/Kong/charts/pull/855
+
 ## 0.4.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.25.0
+  version: 2.26.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.25.0
-digest: sha256:a07ca2054a8ecc4d7a25d607ea214edd0ea4a4c2b6b1a664234a8b13d10b90fb
-generated: "2023-07-17T09:40:57.200737+01:00"
+  version: 2.26.0
+digest: sha256:ee22dc7b138656d6ca72e578774013251634a29e5d2f448b13d5696f4885adaf
+generated: "2023-08-10T10:20:48.499357+02:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -9,16 +9,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 0.4.0
+version: 0.5.0
 appVersion: "3.3"
 dependencies:
   - name: kong
-    version: ">=2.25.0"
+    version: ">=2.26.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.25.0"
+    version: ">=2.26.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps `kong/ingress` dependencies to latest `kong/kong` and triggers `kong/ingress` 0.5.0 release.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
