### PR TITLE
fix: fix for comparing semver for enterprise versions

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Nothing yet.
 
+## 2.26.1
+
+### Fixed
+
+* Fix parsing enterprise tags (like e.g. `3.4.0.0`)
+  [#857](https://github.com/Kong/charts/pull/857)
+
 ## 2.26.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.26.0
+version: 2.26.1
 appVersion: "3.3"
 dependencies:
 - name: postgresql

--- a/charts/kong/ci/test-enterprise-version-3.4.0.0-values.yaml
+++ b/charts/kong/ci/test-enterprise-version-3.4.0.0-values.yaml
@@ -1,0 +1,14 @@
+ingressController:
+  enabled: false
+
+image:
+  repository: kong/kong-gateway
+  tag: "3.4.0.0"
+
+readinessProbe:
+  httpGet:
+    path: "/status"
+    port: status
+    scheme: HTTP
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/test-enterprise-version-3.4.0.0-values.yaml
+++ b/charts/kong/ci/test-enterprise-version-3.4.0.0-values.yaml
@@ -1,6 +1,9 @@
 ingressController:
   enabled: false
 
+proxy:
+  type: NodePort
+
 image:
   repository: kong/kong-gateway
   tag: "3.4.0.0"

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -786,10 +786,22 @@ The name of the service used for the ingress controller's validation webhook
 
 {{/* effectiveVersion takes an image dict from values.yaml. if .effectiveSemver is set, it returns that, else it returns .tag */}}
 {{- define "kong.effectiveVersion" -}}
+{{- /* Because Kong Gateway enterprise uses versions with 4 segments and not 3 */ -}}
+{{- /* as semver does, we need to account for that here by extracting */ -}}
+{{- /* first 3 segments for comparison */ -}}
 {{- if .effectiveSemver -}}
-{{- .effectiveSemver -}}
+  {{- if regexMatch "^[0-9]+.[0-9]+.[0-9]+" .effectiveSemver -}}
+  {{- regexFind "^[0-9]+.[0-9]+.[0-9]+" .effectiveSemver -}}
+  {{- else -}}
+  {{- .effectiveSemver -}}
+  {{- end -}}
 {{- else -}}
-{{- (trimSuffix "-redhat" .tag) -}}
+  {{- $tag := (trimSuffix "-redhat" .tag) -}}
+  {{- if regexMatch "^[0-9]+.[0-9]+.[0-9]+" .tag -}}
+  {{- regexFind "^[0-9]+.[0-9]+.[0-9]+" .tag -}}
+  {{- else -}}
+  {{- .tag -}}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes an issue where an enterprise version (like e.g. `3.4.0.0`) wouldn't be allowed to be provided.

#### Which issue this PR fixes

Fixes #856 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
