### PR TITLE
tests(kong): add -values suffixes to ct test values.yaml files

### DIFF
--- a/charts/kong/ci/custom-labels.yaml
+++ b/charts/kong/ci/custom-labels.yaml
@@ -1,6 +1,3 @@
-
 # install chart with some extra labels
-
 extraLabels:
   acme.com/some-key: some-value
-

--- a/charts/kong/ci/kong-ingress-1-values.yaml
+++ b/charts/kong/ci/kong-ingress-1-values.yaml
@@ -14,3 +14,8 @@ extraObjects:
   metadata:
     name: kong.proxy.example.secret
   type: kubernetes.io/tls
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/kong-ingress-2-values.yaml
+++ b/charts/kong/ci/kong-ingress-2-values.yaml
@@ -15,3 +15,8 @@ extraObjects:
   metadata:
     name: kong.proxy.example.secret
   type: kubernetes.io/tls
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/kong-ingress-3-values.yaml
+++ b/charts/kong/ci/kong-ingress-3-values.yaml
@@ -8,3 +8,8 @@ proxy:
       paths:
       - path: /
         pathType: ImplementationSpecific
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/kong-ingress-4-values.yaml
+++ b/charts/kong/ci/kong-ingress-4-values.yaml
@@ -41,3 +41,8 @@ extraObjects:
   metadata:
     name: kong.proxy.example.secret2
   type: kubernetes.io/tls
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/service-account.yaml
+++ b/charts/kong/ci/service-account.yaml
@@ -1,4 +1,3 @@
-
 # install chart with a service account
 deployment:
   serviceAccount:
@@ -9,3 +8,8 @@ deployment:
 ingressController:
   serviceAccount:
     create: false
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/single-image-default.yaml
+++ b/charts/kong/ci/single-image-default.yaml
@@ -13,3 +13,8 @@ ingressController:
     anonymous_reports: "false"
   image:
     unifiedRepoTag: kong/kubernetes-ingress-controller:2.0.2
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/test1-values.yaml
+++ b/charts/kong/ci/test1-values.yaml
@@ -69,3 +69,8 @@ deployment:
   userDefinedVolumeMounts:
   - name: "tmpdir"
     mountPath: "/tmp/foo"
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -64,3 +64,8 @@ deployment:
         requests:
           cpu: "100m"
           memory: "64Mi"
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -41,3 +41,8 @@ dblessConfig:
         - name: example
           paths:
           - "/example"
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -34,3 +34,8 @@ dblessConfig:
         - name: example
           paths:
           - "/example"
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -48,3 +48,8 @@ updateStrategy:
   rollingUpdate:
     maxSurge: 1
     maxUnavailable: 0
+
+# For the sake of getting the test results from CI faster
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1


### PR DESCRIPTION
#### What this PR does / why we need it:

It seems that we have missed some of the `-values.yaml` suffixes in `kong` chart ct tests.

As per `ct install --help`:

```
$ ct install --help
Run 'helm install', 'helm test', and optionally 'helm upgrade' on

...

Charts may have multiple custom values files matching the glob pattern
'*-values.yaml' in a directory named 'ci' in the root of the chart's
directory. The chart is installed and tested for each of these files.
If no custom values file is present, the chart is installed and
tested with defaults.

```

This PR adds those so that the tests are run.

It also sets the readiness probe period to 1 second to speed up the tests.