### PR TITLE
deps(ingress): bump ingress kong/kong dep to 2.26.0

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.1
+
+### Improvements
+
+- Bumped dependencies on `kong/kong` chart to `>=2.26.0`.
+  [#859](https://github.com/Kong/charts/pull/859)
+
 ## 0.4.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.25.0
+  version: 2.26.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.25.0
-digest: sha256:a07ca2054a8ecc4d7a25d607ea214edd0ea4a4c2b6b1a664234a8b13d10b90fb
-generated: "2023-07-17T09:40:57.200737+01:00"
+  version: 2.26.0
+digest: sha256:ee22dc7b138656d6ca72e578774013251634a29e5d2f448b13d5696f4885adaf
+generated: "2023-08-10T21:28:41.727659+02:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -9,16 +9,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 0.4.0
+version: 0.4.1
 appVersion: "3.3"
 dependencies:
   - name: kong
-    version: ">=2.25.0"
+    version: ">=2.26.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.25.0"
+    version: ">=2.26.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump ingress kong/kong dependency to 2.26.0 and up.
