### PR TITLE
ci: remove k8s 1.19 and 1.20 from tests matrix

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -90,8 +90,6 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-        - "1.19.16"
-        - "1.20.15"
         - "1.21.14"
         - "1.22.15"
         - "1.23.13"


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove kubernetes 1.19 and 1.20 from testing matrix.

Those are unsupported upstream at this time by https://kubernetes.io/releases/patch-releases/#non-active-branch-history

- 1.19 has reached end of life 2021-10-28
- 1.20 has reached end of life 2022-02-28

Why do we need this? 

KIC implemented Gateway Discovery using discovery API v1 which is available since kubernetes 1.21.

We need this now because https://github.com/Kong/charts/pull/844 introduced `/status/ready` endpoint in Gateway and in order to make this work we need KIC to use Gateway discovery (as implemented in 2.11) to discover Gateways that are not yet ready to serve traffic due to empty config.

Otherwise (in k8s 1.20 or older) we get this error in KIC

> Error: unable to build kong api client(s): failed to get API group resources: unable to retrieve the complete list of server APIs: discovery.k8s.io/v1: the server could not find the requested resource
