### PR TITLE
chore(ingress): bump chart deps and release 0.6.0

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
+## 0.6.0
+
+### Improvements
+
+- Bumped dependency `kong/kong` to `2.26.2`.
+  [#862](https://github.com/Kong/charts/pull/862)
+
 ## 0.5.0
 
 ### Improvements
 
 - Bumped dependencies on `kong/kong` chart to `>=2.26.0`.
-  [#855](https://github.com/Kong/charts/pull/855
+  [#855](https://github.com/Kong/charts/pull/855)
 
 ## 0.4.0
 

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.26.0
+  version: 2.26.2
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.26.0
-digest: sha256:ee22dc7b138656d6ca72e578774013251634a29e5d2f448b13d5696f4885adaf
-generated: "2023-08-10T10:20:48.499357+02:00"
+  version: 2.26.2
+digest: sha256:1f2ab6c8758b1575ede9814fbc634eddac43b9a831fe506c758f2532d4c20cce
+generated: "2023-08-15T19:03:24.569526+02:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 0.5.0
+version: 0.6.0
 appVersion: "3.3"
 dependencies:
   - name: kong


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Enforce using the newest [kong/kong 2.26.2](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#2262) that includes required fixes - `KongConsumerGroup` CRD and extended subresource `Status` 

#### Which issue this PR fixes

continuation of https://github.com/Kong/charts/pull/861


#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
