### PR TITLE
chore(docs) add breaking change info

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.5.0
 
+### Breaking changes
+
+The new `kong/kong` chart requires manual changes to values.yaml if using this
+chart with controller versions <=2.10 and Kong versions >=3.3. See the 
+[the kong/kong 2.26 upgrade instructions](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#2260)
+for details.
+
 ### Improvements
 
 - Bumped dependencies on `kong/kong` chart to `>=2.26.0`.

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -19,6 +19,17 @@ Nothing yet.
 
 ## 2.26.0
 
+### Breaking changes
+
+2.26 changes the default proxy readiness endpoint for newer Kong versions. This
+causes an issue in a narrow edge case. If all of the following are true:
+
+* You use Kong 3.3 or newer.
+* You use controller 2.10 or older.
+* You run the controller and proxy in separate Deployments.
+
+you are affected and should review [the 2.26 upgrade instructions](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md#2260).
+
 ### Improvements
 
 * Use the Kong 3.3 `/status/ready` endpoint for readiness probes by default if

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -101,7 +101,7 @@ This section goes under the `gateway` section when using the `ingress` chart.
 2.26 changes the default proxy readiness endpoint to the `/status/ready`
 endpoint introduced in Kong 3.3. This endpoint reports true when Kong has
 configuration available, whereas the previous `/status` endpoint returned true
-immediately after start, and could result in proxy instances attemtpting to
+immediately after start, and could result in proxy instances attempting to
 serve requests before they had configuration.
 
 The chart has logic to fall back to the older endpoint if the proxy and

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -17,7 +17,8 @@ upgrading from a previous version.
 ## Table of contents
 
 - [Upgrade considerations for all versions](#upgrade-considerations-for-all-versions)
-- [2.17.0](#2170)
+- [2.26.0](#2260)
+- [2.19.0](#2190)
 - [2.13.0](#2130)
 - [2.8.0](#280)
 - [2.7.0](#270)
@@ -82,6 +83,35 @@ https://raw.githubusercontent.com/Kong/charts/kong-<version>/charts/kong/crds/cu
 
 For example, if your release is 2.6.4, you would apply
 `https://raw.githubusercontent.com/Kong/charts/kong-2.6.4/charts/kong/crds/custom-resource-definitions.yaml`.
+
+## 2.26.0
+
+If you are using controller version 2.10 or lower and proxy version 3.3 or
+higher in separate Deployments (such as when using the `ingress` chart), proxy
+Pods will not become ready unless you override the default readiness endpoint:
+
+```
+readinessProbe:
+  httpGet:
+    path: /status
+```
+
+This section goes under the `gateway` section when using the `ingress` chart.
+
+2.26 changes the default proxy readiness endpoint to the `/status/ready`
+endpoint introduced in Kong 3.3. This endpoint reports true when Kong has
+configuration available, whereas the previous `/status` endpoint returned true
+immediately after start, and could result in proxy instances attemtpting to
+serve requests before they had configuration.
+
+The chart has logic to fall back to the older endpoint if the proxy and
+controller versions do not work well with the new endpoint. However, the chart
+detection cannot determine the controller version when the controller is in a
+separate Deployment, and will always use the new endpoint if the Kong image
+version is 3.3 or higher.
+
+Kong recommends Kong 3.3 and higher users update to controller 2.11 at their
+earliest convenience to take advantage of the improved readiness behavior.
 
 ## 2.19.0
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds 2.26 breaking change documentation. Controller versions older than 2.10 must still use the old readiness endpoint, and we cannot automatically detect this when the Kong instance is separately deployed.

Also fixes a bad ToC in UPGRADE.md.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] ~Changes are documented under the "Unreleased" header in CHANGELOG.md~
- [ ] ~New or modified sections of values.yaml are documented in the README.md~
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
