### PR TITLE
ci: use ktf for ct related tests

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -38,6 +38,9 @@ jobs:
 
   lint-test:
     runs-on: ubuntu-latest
+    env:
+      # Specify this here because these tests rely on ktf to run kind for cluster creation.
+      KIND_VERSION: v0.20.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,23 +64,13 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.4.0
 
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed)
-          if [[ -n "$changed" ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Run chart-testing (lint)
         run: ct lint --check-version-increment=false
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.8.0
-        # if: steps.list-changed.outputs.changed == 'true'
-        # TODO for some reason, the earlier chart-testing logic is never seeing any changes, though running it locally
-        # does show changes. This remains a mystery between a lack of any debug logging, but simply running tests
-        # always is fine
+      - name: setup testing environment (kind-cluster)
+        env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
+        run: ./scripts/test-env.sh
 
       - name: Run chart-testing (install)
         run: ct install --charts charts/kong
@@ -86,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Specify this here because these tests rely on ktf to run kind for cluster creation.
-      KIND_VERSION: v0.19.0
+      KIND_VERSION: v0.20.0
     strategy:
       matrix:
         kubernetes-version:

--- a/charts/kong/ci/admin-api-service-clusterip-values.yaml
+++ b/charts/kong/ci/admin-api-service-clusterip-values.yaml
@@ -1,0 +1,14 @@
+admin:
+  enabled: true
+  type: ClusterIP
+
+# Add /status readiness probe because without KIC there's nothing to make
+# Gateway ready by sending the config.
+readinessProbe:
+  httpGet:
+    path: "/status"
+    port: status
+    scheme: HTTP
+
+ingressController:
+  enabled: false

--- a/charts/kong/ci/admin-api-service-clusterip-values.yaml
+++ b/charts/kong/ci/admin-api-service-clusterip-values.yaml
@@ -2,13 +2,17 @@ admin:
   enabled: true
   type: ClusterIP
 
-# Add /status readiness probe because without KIC there's nothing to make
-# Gateway ready by sending the config.
-readinessProbe:
-  httpGet:
-    path: "/status"
-    port: status
-    scheme: HTTP
+# Stub config to make the instance become ready
+dblessConfig:
+  config: |
+    _format_version: "1.1"
+    services:
+    - name: example.com
+      url: http://example.com
+      routes:
+      - name: example
+        paths:
+        - "/example"
 
 ingressController:
   enabled: false

--- a/charts/kong/ci/admin-api-service-clusterip.yaml
+++ b/charts/kong/ci/admin-api-service-clusterip.yaml
@@ -1,6 +1,0 @@
-admin:
-  enabled: true
-  type: ClusterIP
-
-ingressController:
-  enabled: false

--- a/charts/kong/ci/custom-labels-values.yaml
+++ b/charts/kong/ci/custom-labels-values.yaml
@@ -1,6 +1,3 @@
-
 # install chart with some extra labels
-
 extraLabels:
   acme.com/some-key: some-value
-

--- a/charts/kong/ci/default-values.yaml
+++ b/charts/kong/ci/default-values.yaml
@@ -1,7 +1,4 @@
 # install chart with default values
-proxy:
-  type: NodePort
-
 env:
   anonymous_reports: "off"
 ingressController:

--- a/charts/kong/ci/kong-ingress-1-values.yaml
+++ b/charts/kong/ci/kong-ingress-1-values.yaml
@@ -1,6 +1,5 @@
 # CI test for empty hostname including tls secret using string
 proxy:
-  type: NodePort
   ingress:
     enabled: true
     tls: "kong.proxy.example.secret"

--- a/charts/kong/ci/kong-ingress-2-values.yaml
+++ b/charts/kong/ci/kong-ingress-2-values.yaml
@@ -1,6 +1,5 @@
 # CI test for hostname including tls secret using string
 proxy:
-  type: NodePort
   ingress:
     enabled: true
     hostname: "proxy.kong.example"

--- a/charts/kong/ci/kong-ingress-3-values.yaml
+++ b/charts/kong/ci/kong-ingress-3-values.yaml
@@ -1,6 +1,5 @@
 # CI test for using ingress hosts configuration
 proxy:
-  type: NodePort
   ingress:
     enabled: true
     hosts:

--- a/charts/kong/ci/kong-ingress-4-values.yaml
+++ b/charts/kong/ci/kong-ingress-4-values.yaml
@@ -1,6 +1,5 @@
 # CI test for testing combined ingress hostname and hosts configuration including tls configuraion using slice
 proxy:
-  type: NodePort
   ingress:
     enabled: true
     hostname: "proxy.kong.example"

--- a/charts/kong/ci/single-image-default-values.yaml
+++ b/charts/kong/ci/single-image-default-values.yaml
@@ -2,9 +2,7 @@
 # use single image strings instead of repository/tag
 
 image:
-  unifiedRepoTag: kong:2.6
-proxy:
-  type: NodePort
+  unifiedRepoTag: kong:3.3
 
 env:
   anonymous_reports: "off"
@@ -12,4 +10,4 @@ ingressController:
   env:
     anonymous_reports: "false"
   image:
-    unifiedRepoTag: kong/kubernetes-ingress-controller:2.0.2
+    unifiedRepoTag: kong/kubernetes-ingress-controller:2.11

--- a/charts/kong/ci/test-enterprise-version-3.4.0.0-values.yaml
+++ b/charts/kong/ci/test-enterprise-version-3.4.0.0-values.yaml
@@ -1,9 +1,6 @@
 ingressController:
   enabled: false
 
-proxy:
-  type: NodePort
-
 image:
   repository: kong/kong-gateway
   tag: "3.4.0.0"

--- a/charts/kong/ci/test1-values.yaml
+++ b/charts/kong/ci/test1-values.yaml
@@ -30,14 +30,12 @@ podLabels:
   environment: test
 # - ingress resources are created with hosts
 admin:
-  type: NodePort
   ingress:
     enabled: true
     hostname: admin.kong.example
     annotations: {}
     path: /
 proxy:
-  type: NodePort
   ingress:
     enabled: true
     hostname: proxy.kong.example

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -21,13 +21,11 @@ env:
   database: "postgres"
 # - ingress resources are created without hosts
 admin:
-  type: NodePort
   ingress:
     enabled: true
     hosts: []
     path: /
 proxy:
-  type: NodePort
   ingress:
     enabled: true
     hostname: proxy.kong.example

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -8,8 +8,6 @@ env:
   database: "off"
 postgresql:
   enabled: false
-proxy:
-  type: NodePort
 deployment:
   initContainers:
     - name: "bash"

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -12,7 +12,6 @@ env:
 postgresql:
   enabled: false
 proxy:
-  type: NodePort
 # - add stream listens
   stream:
   - containerPort: 9000

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -26,13 +26,11 @@ customEnv:
   client_id: "exampleId"
 # - ingress resources are created without hosts
 admin:
-  type: NodePort
   ingress:
     enabled: true
     hosts: []
     path: /
 proxy:
-  type: NodePort
   ingress:
     enabled: true
     hostname: proxy.kong.example


### PR DESCRIPTION
#### What this PR does / why we need it:

Use ktf for ct related tests.

This will install metallb which will assign IPs to LoadBalancer services and this will allow testing without usage of `proxy.type` set to `NodePort`.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
