### PR TITLE
fix(manager): enable service/ingress for kong manager oss

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Nothing yet.
 
+## 2.26.3
+
+### Fixed 
+
+* Enabled Service and Ingress in Kong Manager for non enterprise users.
+
 ## 2.26.2
 
 ### Fixed 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.26.2
+version: 2.26.3
 appVersion: "3.3"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/service-kong-manager.yaml
+++ b/charts/kong/templates/service-kong-manager.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.deployment.kong.enabled }}
-{{- if .Values.enterprise.enabled }}
 {{- if and .Values.manager.enabled (or .Values.manager.http.enabled .Values.manager.tls.enabled) -}}
 {{- $serviceConfig := dict -}}
 {{- $serviceConfig := merge $serviceConfig .Values.manager -}}
@@ -13,7 +12,6 @@
 {{ if .Values.manager.ingress.enabled }}
 ---
 {{ include "kong.ingress" $serviceConfig }}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
What this PR does / why we need it:
Enable Kong Manager Service/Ingress creation without enabling enterprise, since kong manager has been open sourced recently.

Which issue this PR fixes
Resolves https://github.com/Kong/charts/issues/866

Special notes for your reviewer:

fix(manager): enable service/ingress for kong manager oss.

Recently Kong Manager was open-sourced, so the existing chart needed some updates to let user create Service/Ingress for manager without enabling the enterprise.

Fix #866