### PR TITLE
fix(manager): updated kong service location hint var

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Nothing yet.
 
+## 2.26.4
+
+### Fixed 
+
+* updated `admin_api_uri` to `admin_gui_api_url` as per [kong documentation](https://docs.konghq.com/gateway/3.4.x/reference/configuration/#admin_api_uri). 
+
 ## 2.26.3
 
 ### Fixed 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.26.3
+version: 2.26.4
 appVersion: "3.3"
 dependencies:
 - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -1046,7 +1046,7 @@ must know where other Kong services (namely the admin and files APIs) can be
 accessed in order to function properly. Kong's default behavior for attempting
 to locate these absent configuration is unlikely to work in common Kubernetes
 environments. Because of this, you should set each of `admin_gui_url`,
-`admin_api_uri`, `proxy_url`, `portal_api_url`, `portal_gui_host`, and
+`admin_gui_api_url`, `proxy_url`, `portal_api_url`, `portal_gui_host`, and
 `portal_gui_protocol` under the `.env` key in values.yaml to locations where
 each of their respective services can be accessed to ensure that Kong services
 can locate one another and properly set CORS headers. See the

--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -88,7 +88,7 @@ enterprise:
     enabled: true
 env:
   admin_access_log: /dev/stdout
-  admin_api_uri: https://kong.127-0-0-1.nip.io/api
+  admin_gui_api_url: https://kong.127-0-0-1.nip.io/api
   admin_error_log: /dev/stdout
   admin_gui_access_log: /dev/stdout
   admin_gui_error_log: /dev/stdout

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -965,6 +965,7 @@ the template that it itself is using form the above sections.
 
 {{- if .Values.admin.ingress.enabled }}
   {{- $_ := set $autoEnv "KONG_ADMIN_GUI_API_URL" (include "kong.ingress.serviceUrl" .Values.admin.ingress) -}}
+  {{- $_ := set $autoEnv "KONG_ADMIN_API_URI" (include "kong.ingress.serviceUrl" .Values.admin.ingress) -}}
 {{- end -}}
 
 {{- $_ := set $autoEnv "KONG_PROXY_LISTEN" (include "kong.listen" .Values.proxy) -}}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -964,7 +964,7 @@ the template that it itself is using form the above sections.
 {{- end -}}
 
 {{- if .Values.admin.ingress.enabled }}
-  {{- $_ := set $autoEnv "KONG_ADMIN_API_URI" (include "kong.ingress.serviceUrl" .Values.admin.ingress) -}}
+  {{- $_ := set $autoEnv "KONG_ADMIN_GUI_API_URL" (include "kong.ingress.serviceUrl" .Values.admin.ingress) -}}
 {{- end -}}
 
 {{- $_ := set $autoEnv "KONG_PROXY_LISTEN" (include "kong.listen" .Values.proxy) -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
As per the latest [Kong documentation](https://docs.konghq.com/gateway/3.4.x/reference/configuration/#admin_api_uri) `admin_api_uri` has been updated to `admin_gui_api_url`. This PR contains the updates related to the renaming of this variable wherever required.

#### Which issue this PR fixes
- This PR will fix issue #869 where Kong Manager is unable to connect to admin api.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
