### PR TITLE
chore(ci) test against older KIC/Kong versions

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -130,7 +130,6 @@ jobs:
       matrix:
         kic-version:
         - "2.10"
-        - "2.9"
         kong-version:
         - "3.3"
         - "3.2"

--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -121,6 +121,45 @@ jobs:
 
       - name: cleanup integration tests (cleanup)
         run: ./scripts/test-env.sh cleanup
+  oldversion-integration-test:
+    runs-on: ubuntu-latest
+    env:
+      # Specify this here because these tests rely on ktf to run kind for cluster creation.
+      KIND_VERSION: v0.20.0
+    strategy:
+      matrix:
+        kic-version:
+        - "2.10"
+        - "2.9"
+        kong-version:
+        - "3.3"
+        - "3.2"
+        chart-name:
+          - kong
+          - ingress
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: setup helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.11.0
+
+      - name: setup testing environment (kind-cluster)
+        run: ./scripts/test-env.sh
+
+      - name: run integration tests (integration)
+        env:
+          CHART_NAME: ${{ matrix.chart-name }}
+          KONG_VERSION: ${{ matrix.kong-version }}
+          KIC_VERSION: ${{ matrix.kic-version }}
+        run: ./scripts/test-run.sh
+
+      - name: cleanup integration tests (cleanup)
+        run: ./scripts/test-env.sh cleanup
 
   # Workaround to allow checking the matrix tests as required tests without adding the individual cases
   # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
@@ -130,6 +169,7 @@ jobs:
       - lint
       - lint-test
       - integration-test
+      - oldversion-integration-test
     if: always()
     steps:
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -28,6 +28,7 @@ KUBECTL="kubectl --context kind-${TEST_ENV_NAME}"
 KUBERNETES_VERSION="$($KUBECTL version -o json | jq -r '.serverVersion.gitVersion')"
 
 CONTROLLER_PREFIX=""
+GATEWAY_PREFIX=""
 ADDITIONAL_FLAGS=()
 
 # ------------------------------------------------------------------------------
@@ -35,6 +36,7 @@ ADDITIONAL_FLAGS=()
 # ------------------------------------------------------------------------------
 if [[ "${CHART_NAME}" == "ingress" ]]; then
   CONTROLLER_PREFIX="controller."
+  GATEWAY_PREFIX="gateway."
   # this is intentionally a no-op at present. this originally had a set that was
   # made obsolete by a values default change. it's now a placeholder showing an
   # example modification
@@ -88,6 +90,16 @@ fi
 ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.feature_gates=GatewayAlpha=true")
 # Tests should not show up in reporting
 ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.anonymous_reports=false")
+
+if [[ -n "${KONG_VERSION-}" ]]
+then
+ADDITIONAL_FLAGS+=("--set ${GATEWAY_PREFIX}image.tag=${KONG_VERSION}")
+fi
+
+if [[ -n "${KIC_VERSION-}" ]]
+then
+ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.image.tag=${KIC_VERSION}")
+fi
 
 echo "INFO: installing chart as release ${RELEASE_NAME} ${TAG_MESSAGE}to namespace ${RELEASE_NAMESPACE}"
 set -x


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds a second integration tests matrix for testing older versions.

#### Special notes for your reviewer:

Rather stuck because this is already broken due to the ingress chart incompatibility with KIC 2.10 and Kong 3.3 unless you override the readiness endpoint. Unless we can figure out a clever fix to that, this will just fail CI.

Ideally, this would avoid needing to set these versions manually and the duplicated integration KIND version setting. For the former two, it's unfortunately not fun to reach into the values.yaml and extract the current value and subtract from it, though sort of possible with YAML parsing and some sort of semver math tool (ignoring going below minor `x.0`).

Also, condensing the test list shown on the PR Actions preview would be nice. There are a lot of them now.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
