### PR TITLE
Update README with info about both charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ environment. It is the recommended chart for new installations. To use it:
 helm install kong/ingress --generate-name
 ```
 
+`kong/ingress` is an umbrella chart using two instances of the `kong/kong`
+chart with some pre-configured values.yaml settings. The `controller` and
+`gateway` subsections support additional settings available in the `kong/kong`
+values.yaml.
+
 `kong/kong` is a flexible building block for supporting a wide variety of
 environment configurations not supported by `kong/ingress`, such as hybrid mode
 or unmanaged (no controller) Kong instances. To use it:

--- a/README.md
+++ b/README.md
@@ -4,21 +4,32 @@ This is the official Helm Charts repository for installing Kong on Kubernetes.
 
 ## Setup
 
+Add the repo on your machine:
+
 ```bash
-$ helm repo add kong https://charts.konghq.com
-$ helm repo update
+helm repo add kong https://charts.konghq.com
+helm repo update
+```
 
-# Helm 2
-$ helm install kong/kong
+If you plan to use the Kong Ingress Controller, use the `kong/ingress` chart:
 
-# Helm 3
-$ helm install kong/kong --generate-name --set ingressController.installCRDs=false
+```bash
+helm install kong/ingress --generate-name
+```
+
+If you plan to install Kong on Kubernetes in Hybrid or Traditional mode use the `kong/kong` chart:
+
+```bash
+helm install kong/kong --generate-name
 ```
 
 ## Documentation
 
-The documentation for Kong's Helm Chart is available at
-[here](https://github.com/Kong/charts/blob/main/charts/kong/README.md).
+The documentation for Kong's Helm Charts is available on GitHub:
+
+* [kong/ingress](https://github.com/Kong/charts/blob/main/charts/ingress/README.md)
+* [kong/kong](https://github.com/Kong/charts/blob/main/charts/kong/README.md)
+
 
 ## Seeking help
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,26 @@ helm repo add kong https://charts.konghq.com
 helm repo update
 ```
 
-If you plan to use the Kong Ingress Controller, use the `kong/ingress` chart:
+There are two available charts.
+
+`kong/ingress` provides an opinionated ingress controller-managed DB-less
+environment. It is the recommended chart for new installations. To use it:
 
 ```bash
 helm install kong/ingress --generate-name
 ```
 
-If you plan to install Kong on Kubernetes in Hybrid or Traditional mode use the `kong/kong` chart:
+`kong/kong` is a flexible building block for supporting a wide variety of
+environment configurations not supported by `kong/ingress`, such as hybrid mode
+or unmanaged (no controller) Kong instances. To use it:
 
 ```bash
 helm install kong/kong --generate-name
 ```
+
+For more details about the configuration required to support various
+environments, see the "Deployment Options" subsection of the `kong/kong`
+documentation's table of contents.
 
 ## Documentation
 


### PR DESCRIPTION
It's like https://github.com/Kong/charts/pull/864 with the additional context mentioned in https://github.com/Kong/charts/pull/864#pullrequestreview-1583405496. Left out the Konnect bit since I figure that's covered in the Konnect documentation. Also gets rid of the Helm 2 stuff and explicit installCRDs, since that's ancient.

I don't know if we want to mention the umbrella chart stuff, since that's (maybe) kinda intentionally omitted for `kong/ingress`. However, I expect many users will need to use some of the additional values.yaml settings, and as-is I'm not sure we mention that the `kong/kong` values work in those subsections.

This PR goes to main, which will update the main repo README. Apparently the `gh-pages` branch does _not_ get updated by chart-releaser, which is annoying. Attempting to cherry-pick those commits directly on top of main broke, since they were based on a very old version.

I don't actually know if we expect many people to hit https://charts.konghq.com's landing page, but if so we need to mirror that manually for now. I don't know offhand how to mirror a single file.