### PR TITLE
fix(migrations) add Kuma compatibility

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Nothing yet.
 
+## 2.26.5
+
+### Fixed 
+
+* Kuma ServiceAccount Token hints and volumes are also available in migrations
+  Pods.
+  [#877](https://github.com/Kong/charts/pull/877)
+
 ## 2.26.4
 
 ### Fixed 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.26.4
+version: 2.26.5
 appVersion: "3.3"
 dependencies:
 - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -552,6 +552,41 @@ The name of the service used for the ingress controller's validation webhook
 - name: {{ template "kong.fullname" . }}-tmp
   emptyDir:
     sizeLimit: {{ .Values.deployment.tmpDir.sizeLimit }}
+{{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+- name: {{ template "kong.serviceAccountTokenName" . }}
+  {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
+  See the related documentation of semver module that Helm depends on for semverCompare:
+  https://github.com/Masterminds/semver#working-with-prerelease-versions
+  Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
+  {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+  projected:
+    sources:
+    - serviceAccountToken:
+        expirationSeconds: 3607
+        path: token
+    - configMap:
+        items:
+        - key: ca.crt
+          path: ca.crt
+        name: kube-root-ca.crt
+    - downwardAPI:
+        items:
+        - fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.namespace
+          path: namespace
+  {{- else }}
+  secret:
+    secretName: {{ template "kong.serviceAccountTokenName" . }}
+    items:
+    - key: token
+      path: token
+    - key: ca.crt
+      path: ca.crt
+    - key: namespace
+      path: namespace
+  {{- end }}
+{{- end }}
 {{- if and ( .Capabilities.APIVersions.Has "cert-manager.io/v1" ) .Values.certificates.enabled -}}
 {{- if .Values.certificates.cluster.enabled }}
 - name: {{ include "kong.fullname" . }}-cluster-cert

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -302,39 +302,4 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 8 -}}
       {{- include "kong.userDefinedVolumes" . | nindent 8 -}}
-      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
-        - name: {{ template "kong.serviceAccountTokenName" . }}
-          {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
-          See the related documentation of semver module that Helm depends on for semverCompare:
-          https://github.com/Masterminds/semver#working-with-prerelease-versions
-          Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
-          {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
-          projected:
-            sources:
-            - serviceAccountToken:
-                expirationSeconds: 3607
-                path: token
-            - configMap:
-                items:
-                - key: ca.crt
-                  path: ca.crt
-                name: kube-root-ca.crt
-            - downwardAPI:
-                items:
-                - fieldRef:
-                    apiVersion: v1
-                    fieldPath: metadata.namespace
-                  path: namespace
-          {{- else }}
-          secret:
-            secretName: {{ template "kong.serviceAccountTokenName" . }}
-            items:
-            - key: token
-              path: token
-            - key: ca.crt
-              path: ca.crt
-            - key: namespace
-              path: namespace
-          {{- end }}
-      {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -29,6 +29,9 @@ spec:
       {{- range $key, $value := .Values.migrations.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+        kuma.io/service-account-token-volume: {{ template "kong.serviceAccountTokenName" . }}
+      {{- end }}
       {{- end }}
     spec:
       {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
@@ -85,5 +88,40 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
       {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+      - name: {{ template "kong.serviceAccountTokenName" . }}
+        {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
+        See the related documentation of semver module that Helm depends on for semverCompare:
+        https://github.com/Masterminds/semver#working-with-prerelease-versions
+        Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
+        {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+        {{- else }}
+        secret:
+          secretName: {{ template "kong.serviceAccountTokenName" . }}
+          items:
+          - key: token
+            path: token
+          - key: ca.crt
+            path: ca.crt
+          - key: namespace
+            path: namespace
+        {{- end }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -88,40 +88,5 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
       {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
-      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
-      - name: {{ template "kong.serviceAccountTokenName" . }}
-        {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
-        See the related documentation of semver module that Helm depends on for semverCompare:
-        https://github.com/Masterminds/semver#working-with-prerelease-versions
-        Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
-        {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
-        projected:
-          sources:
-          - serviceAccountToken:
-              expirationSeconds: 3607
-              path: token
-          - configMap:
-              items:
-              - key: ca.crt
-                path: ca.crt
-              name: kube-root-ca.crt
-          - downwardAPI:
-              items:
-              - fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-                path: namespace
-        {{- else }}
-        secret:
-          secretName: {{ template "kong.serviceAccountTokenName" . }}
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-        {{- end }}
-      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -90,40 +90,5 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
       {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
-      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
-      - name: {{ template "kong.serviceAccountTokenName" . }}
-        {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
-        See the related documentation of semver module that Helm depends on for semverCompare:
-        https://github.com/Masterminds/semver#working-with-prerelease-versions
-        Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
-        {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
-        projected:
-          sources:
-          - serviceAccountToken:
-              expirationSeconds: 3607
-              path: token
-          - configMap:
-              items:
-              - key: ca.crt
-                path: ca.crt
-              name: kube-root-ca.crt
-          - downwardAPI:
-              items:
-              - fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-                path: namespace
-        {{- else }}
-        secret:
-          secretName: {{ template "kong.serviceAccountTokenName" . }}
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-        {{- end }}
-      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -31,6 +31,9 @@ spec:
       {{- range $key, $value := .Values.migrations.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+        kuma.io/service-account-token-volume: {{ template "kong.serviceAccountTokenName" . }}
+      {{- end }}
       {{- end }}
     spec:
       {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
@@ -87,5 +90,40 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
       {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+      - name: {{ template "kong.serviceAccountTokenName" . }}
+        {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
+        See the related documentation of semver module that Helm depends on for semverCompare:
+        https://github.com/Masterminds/semver#working-with-prerelease-versions
+        Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
+        {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+        {{- else }}
+        secret:
+          secretName: {{ template "kong.serviceAccountTokenName" . }}
+          items:
+          - key: token
+            path: token
+          - key: ca.crt
+            path: ca.crt
+          - key: namespace
+            path: namespace
+        {{- end }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -98,41 +98,6 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
       {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
-      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
-      - name: {{ template "kong.serviceAccountTokenName" . }}
-        {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
-        See the related documentation of semver module that Helm depends on for semverCompare:
-        https://github.com/Masterminds/semver#working-with-prerelease-versions
-        Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
-        {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
-        projected:
-          sources:
-          - serviceAccountToken:
-              expirationSeconds: 3607
-              path: token
-          - configMap:
-              items:
-              - key: ca.crt
-                path: ca.crt
-              name: kube-root-ca.crt
-          - downwardAPI:
-              items:
-              - fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-                path: namespace
-        {{- else }}
-        secret:
-          secretName: {{ template "kong.serviceAccountTokenName" . }}
-          items:
-          - key: token
-            path: token
-          - key: ca.crt
-            path: ca.crt
-          - key: namespace
-            path: namespace
-        {{- end }}
-      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -39,6 +39,9 @@ spec:
       {{- range $key, $value := .Values.migrations.annotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
+      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+        kuma.io/service-account-token-volume: {{ template "kong.serviceAccountTokenName" . }}
+      {{- end }}
       {{- end }}
     spec:
       {{- if or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name }}
@@ -95,6 +98,41 @@ spec:
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
       {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- if (and (not .Values.deployment.serviceAccount.automountServiceAccountToken) (or .Values.deployment.serviceAccount.create .Values.deployment.serviceAccount.name)) }}
+      - name: {{ template "kong.serviceAccountTokenName" . }}
+        {{- /* Due to GKE versions (e.g. v1.23.15-gke.1900) we need to handle pre-release part of the version as well.
+        See the related documentation of semver module that Helm depends on for semverCompare:
+        https://github.com/Masterminds/semver#working-with-prerelease-versions
+        Related Helm issue: https://github.com/helm/helm/issues/3810 */}}
+        {{- if semverCompare ">=1.20.0-0" .Capabilities.KubeVersion.Version }}
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+        {{- else }}
+        secret:
+          secretName: {{ template "kong.serviceAccountTokenName" . }}
+          items:
+          - key: token
+            path: token
+          - key: ca.crt
+            path: ca.crt
+          - key: namespace
+            path: namespace
+        {{- end }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add SAT volume and volume hint to migrations Pod templates.

#### Special notes for your reviewer:

Awaiting confirmation from reporter, but this fixes issues with running PG instances with Kuma in a testing environment.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
