### PR TITLE
ingress: add gateway-discovery example and CI values

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -41,6 +41,11 @@ jobs:
     env:
       # Specify this here because these tests rely on ktf to run kind for cluster creation.
       KIND_VERSION: v0.20.0
+    strategy:
+      matrix:
+        chart-name:
+          - kong
+          - ingress
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -73,7 +78,7 @@ jobs:
         run: ./scripts/test-env.sh
 
       - name: Run chart-testing (install)
-        run: ct install --charts charts/kong
+        run: ct install --charts charts/${{ matrix.chart-name}}
 
   integration-test:
     runs-on: ubuntu-latest

--- a/charts/ingress/ci/gateway-discovery-values.yaml
+++ b/charts/ingress/ci/gateway-discovery-values.yaml
@@ -1,0 +1,19 @@
+controller:
+  ingressController:
+    env:
+      anonymous_reports: "false"
+    enabled: true
+    image:
+      repository: kong/kubernetes-ingress-controller
+
+    gatewayDiscovery:
+      enabled: true
+    adminApi:
+      tls:
+        client:
+          enabled: true
+
+gateway:
+  env:
+    anonymous_reports: "off"
+  nameOverride: gateway

--- a/charts/ingress/example-values/kic-gateway-discovery.yaml
+++ b/charts/ingress/example-values/kic-gateway-discovery.yaml
@@ -1,0 +1,15 @@
+controller:
+  ingressController:
+    enabled: true
+    image:
+      repository: kong/kubernetes-ingress-controller
+
+    gatewayDiscovery:
+      enabled: true
+    adminApi:
+      tls:
+        client:
+          enabled: true
+
+gateway:
+  nameOverride: gateway


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR adds gateway-discovery values.yaml file to exemplar values in `ingress` chart and also adds a similar (with disabled anonymous reporting) one to `ci/` directory and enables `ct install` testing for `ingress` chart.



#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
