### PR TITLE
Update admission webhook config, remove Chart.lock, and release kong 2.29.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 charts/kong/charts
 charts/ingress/charts
+**/Chart.lock

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,18 +4,18 @@
 
 Nothing yet.
 
-## 2.29.0
-
-### Improvements
-* Make it possible to set the admission webhook's `timeoutSeconds`.
-
-## 2.28.1
+## 2.29.1
 
 ### Fixed
 
 * The admission webhook now includes Gateway API resources and Ingress
   resources for controller versions 2.12+. This version introduces new
   validations for Kong's regex path implementation.
+
+## 2.29.0
+
+### Improvements
+* Make it possible to set the admission webhook's `timeoutSeconds`.
 
 ## 2.28.0
 

--- a/charts/kong/Chart.lock
+++ b/charts/kong/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.9.13
-digest: sha256:051285066cef2799e39e2953c4abd405c36510a09e9e1bd1833a29224daffddb
-generated: "2022-12-19T11:56:46.951582785-08:00"

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: kong
 sources:
 - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.29.0
+version: 2.29.1
 appVersion: "3.4"
 dependencies:
 - name: postgresql


### PR DESCRIPTION
#### What this PR does / why we need it:

See https://github.com/Kong/kubernetes-ingress-controller/pull/4733. Adds that; releases 2.28.1.

Removes Chart.lock and adds it to gitignore.

#### Special notes for your reviewer:

Technically we had GWAPI checks available for earlier versions also, but they never made it into the chart webhook config. I'm gating them to 2.12+ because backporting the checks isn't that crucial.

I don't think we should be including Chart.lock in our distributed chart, though unfortunately docs are kinda vague about this. https://helm.sh/docs/helm/helm_dependency_update/ and https://helm.sh/docs/helm/helm_dependency_build/ suggest the intended use of this file is so that installs from a local copy of the chart repo can be restored to their original installed version in some sort of data loss scenario.

We did not include a Chart.lock until [2.8.1](https://github.com/Kong/charts/commit/2e89647d86ec7c8fa2a2a1697a325e6679b18d08) and had no issues. Chart.yaml includes its own version rules that look more appropriate for distribution (you can specify ranges rather than a pinned version+hash, though we don't actually use them for the Postgres dep).

AFAIK this got included because the `helm dependency` commands you use to get dependency updates always create it, and it's not obvious whether you should include it or not.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
