### PR TITLE
chore(ingress) release 0.7.0

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.0
+
+- Bumped dependency `kong/kong` minimum to 2.29. Review the [kong chart
+  changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#2290)
+  for details.
+
 ## 0.6.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: kong
-  repository: https://charts.konghq.com
-  version: 2.26.2
-- name: kong
-  repository: https://charts.konghq.com
-  version: 2.26.2
-digest: sha256:1f2ab6c8758b1575ede9814fbc634eddac43b9a831fe506c758f2532d4c20cce
-generated: "2023-08-15T19:03:24.569526+02:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -9,16 +9,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 0.6.0
-appVersion: "3.3"
+version: 0.7.0
+appVersion: "3.4"
 dependencies:
   - name: kong
-    version: ">=2.26.0"
+    version: "~2.29"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.26.0"
+    version: "~2.29"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Releases the ingress 0.7 release, which bumps the kong dependency version to 2.28.

Removes the Chart.lock.

#### Special notes for your reviewer:

tl;dr do not merge this until after https://github.com/Kong/charts/pull/886 merges and releases.

See https://github.com/Kong/charts/pull/886 re Chart.lock stuff. We don't have a clear version management policy re `kong` versions used by `ingress`, but it seems like we can express anything we need via Chart.yaml ranges.

Helm dependency handling for umbrella charts is... not what I expected. Code safari is needed to confirm, but black box testing on a fork suggests that:

- Minimum-only ranges with patch values like `>= 1.2.0` will use that exact patch version regardless of what's available past it. New minor or patch versions aren't used automatically for upgrades or new installs after a `helm repo update` that makes the new dependency available.
- Relative ranges like `~2.3` (which should be [shorthand](https://helm.sh/docs/chart_best_practices/dependencies/) for a combination minimum and upper bound) will use patch versions beyond `.0`, but...
- Dependency versions are apparently pinned in the _upstream_ repo at release time. If you set `0.4.0` to require (dependency) `~2.3` and `2.3.1` is available when `0.4.0` releases, installs will use `2.3.1`. However, if you release `2.3.2` of a dependency after, installs/upgrades to `0.4.0` will still use `2.3.1`.
- A subsequent `0.4.1` (that doesn't actually change anything other than the umbrella chart version) after `2.3.2` becomes available _will_ use `2.3.2`.

The [index updates](https://github.com/rainest/charts-citest/commit/0ecff07f524b013838f90af0d0df585190219d2f) only use the Chart.yaml version ranges, but the [release artifacts](https://github.com/rainest/charts-citest/releases/tag/ingress-0.9.0) include a Chart.lock and a complete copy of the dependency chart, which will presumably pin it one way or the other. This is rather inconvenient.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
