### PR TITLE
feat: change default suggestion for scrape interval to 30s

### DIFF
--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -964,7 +964,7 @@ serviceMonitor:
   # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:
   # https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
   enabled: false
-  # interval: 10s
+  # interval: 30s
   # Specifies namespace, where ServiceMonitor should be installed
   # namespace: monitoring
   # labels:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Changes the suggestion for scrape interval from 10s to 30s. 30s is good enough for most use-cases, a higher rate causes Kong to perform worse.

#### Which issue this PR fixes

None

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md - didn't do, is this changelog worthy?
- [x] New or modified sections of values.yaml are documented in the README.md - N/A
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
