### PR TITLE
chore(docs) add effectiveSemver for Kong

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -601,6 +601,7 @@ directory.
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
 | image.tag                          | Kong image version                                                                    | `3.4`               |
+| image.effectiveSemver              | Semantic version to use for version-dependent features (if `tag` is not a semver)     |                     |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true         | `1`                 |

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -126,6 +126,8 @@ image:
   # repository: kong/kong-gateway
   # tag: "3.4"
 
+  # Specify a semver version if your image tag is not one (e.g. "nightly")
+  effectiveSemver:
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds effectiveSemver to Kong image section. We had added this to [part of the template](https://github.com/Kong/charts/blob/main/charts/kong/templates/_helpers.tpl#L1674), but not the documentation.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] ~Changes are documented under the "Unreleased" header in CHANGELOG.md~
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
