### PR TITLE
Disable PodDisruptionBudget for replicaCount: 1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-* Prevent installing PodDisruptionBudget for `replicaCount: 1`.
+* Prevent installing PodDisruptionBudget for `replicaCount: 1` or `autoscaling.minReplicas: 1`.
 
 ## 2.29.0
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-Nothing yet.
+### Improvements
+
+* Prevent installing PodDisruptionBudget for `replicaCount: 1`.
 
 ## 2.29.0
 

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -45,9 +45,6 @@ proxy:
     parameters:
     - ssl
 
-# - PDB is enabled
-podDisruptionBudget:
-  enabled: true
 # update strategy
 updateStrategy:
   type: "RollingUpdate"

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -37,9 +37,6 @@ proxy:
     annotations: {}
     path: /
 
-# - PDB is enabled
-podDisruptionBudget:
-  enabled: true
 # update strategy
 updateStrategy:
   type: "RollingUpdate"

--- a/charts/kong/templates/pdb.yaml
+++ b/charts/kong/templates/pdb.yaml
@@ -1,4 +1,10 @@
-{{- if and .Values.podDisruptionBudget.enabled (gt (int (.Values.replicaCount)) 1) }}
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- if and (not .Values.autoscaling.enabled) (le (int .Values.replicaCount) 1) }}
+{{- fail "Enabling PodDisruptionBudget with replicaCount: 1 and no autoscaling prevents pod restarts during upgrades" }}
+{{- end }}
+{{- if and .Values.autoscaling.enabled (le (int .Values.autoscaling.minReplicas) 1) }}
+{{- fail "Enabling PodDisruptionBudget with autoscaling.minReplicas: 1 prevents pod restarts during upgrades" }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/kong/templates/pdb.yaml
+++ b/charts/kong/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget.enabled }}
+{{- if and .Values.podDisruptionBudget.enabled (gt (int (.Values.replicaCount)) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Check if replicaCount is above 1 before including the PodDisruptionBudget when enabled.

Installations leaving `replicaCount: 1` as default and specifying `podDisruptionBudget.enabled: true` will prevent kong Deployments from progressing during upgrades.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
