### PR TITLE
chore: use env var CONTROLLER_INGRESS_SERVICE for KIC >= 3.0.0

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -454,7 +454,10 @@ The name of the service used for the ingress controller's validation webhook
 
 {{- $autoEnv := dict -}}
   {{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" true -}}
-  {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" (printf "%s/%s" ( include "kong.namespace" . ) ( .Values.proxy.nameOverride | default ( printf "%s-proxy" (include "kong.fullname" . )))) -}}
+
+  {{ $controllerServiceEnvVarName := ternary "CONTROLLER_PUBLISH_SERVICE" "CONTROLLER_INGRESS_SERVICE" (semverCompare "< 3.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) -}}
+  {{- $_ := set $autoEnv $controllerServiceEnvVarName (printf "%s/%s" ( include "kong.namespace" . ) ( .Values.proxy.nameOverride | default ( printf "%s-proxy" (include "kong.fullname" . )))) -}}
+
   {{- $_ := set $autoEnv "CONTROLLER_INGRESS_CLASS" .Values.ingressController.ingressClass -}}
   {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

For KIC 3.0.0 some flags (and env vars) become deprecated, hence chart should you new one when KIC >=3.0.0 is used. See KIC PRs https://github.com/Kong/kubernetes-ingress-controller/pull/4765 and https://github.com/Kong/kubernetes-ingress-controller/pull/4820.

#### Which issue this PR fixes

The last one closes https://github.com/Kong/kubernetes-ingress-controller/issues/4518

