### PR TITLE
feat: version check for Kong Gateway with KIC >=3.0.0

### DIFF
--- a/charts/ingress/templates/validate-prerequisites.yaml
+++ b/charts/ingress/templates/validate-prerequisites.yaml
@@ -1,0 +1,11 @@
+{{- /*
+This file contains checks of prerequisites to render a fully correct chart that will install a fully functioning application.
+In case of failure, it will cause the whole chart to fail with a descriptive message.
+*/}}
+
+{{ $kicVersion := (include "kong.effectiveVersion" .Values.controller.ingressController.image) -}}
+{{ $kongGatewayVersion := (include "kong.effectiveVersion" .Values.gateway.image) -}}
+{{- if (and (semverCompare ">= 3.0.0" $kicVersion ) (semverCompare "< 3.4.1" $kongGatewayVersion )) -}}
+    {{- fail (printf "Kong Gateway in version: %s is not supported by Kong Kubernetes Ingress Controller in version: %s (>=3.0.0), the lowest supported version is 3.4.1"
+            $kongGatewayVersion $kicVersion) -}}
+{{- end -}}

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -16,6 +16,8 @@
   world-accessible and runtime-created files are created in temporary
   directories created for the run as user.
   [#911](https://github.com/Kong/charts/pull/911)
+* Check version of Kong Gateway to ensure compatible one when KIC is in version >= 3.0.0.
+  [#900](https://github.com/Kong/charts/pull/900)
 
 ## 2.29.0
 

--- a/charts/kong/templates/validate-prerequisites.yaml
+++ b/charts/kong/templates/validate-prerequisites.yaml
@@ -1,0 +1,11 @@
+{{- /*
+This file contains checks of prerequisites to render a fully correct chart that will install a fully functioning application.
+In case of failure, it will cause the whole chart to fail with a descriptive message.
+*/}}
+
+{{ $kicVersion := (include "kong.effectiveVersion" .Values.ingressController.image) -}}
+{{ $kongGatewayVersion := (include "kong.effectiveVersion" .Values.image) -}}
+{{- if (and (semverCompare ">= 3.0.0" $kicVersion ) (semverCompare "< 3.4.1" $kongGatewayVersion )) -}}
+    {{- fail (printf "Kong Gateway in version: %s is not supported by Kong Kubernetes Ingress Controller in version: %s (>=3.0.0), the lowest supported version is 3.4.1"
+            $kongGatewayVersion $kicVersion) -}}
+{{- end -}}

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -27,6 +27,9 @@ TEST_ENV_NAME="${TEST_ENV_NAME:-kong-charts-tests}"
 KUBECTL="kubectl --context kind-${TEST_ENV_NAME}"
 KUBERNETES_VERSION="$($KUBECTL version -o json | jq -r '.serverVersion.gitVersion')"
 
+# TODO: Remove this one when Kong Gateway will updated from 3.4.
+KONG_GATEWAY_EFFECTIVE_VERSION="3.4.1"
+
 CONTROLLER_PREFIX=""
 ADDITIONAL_FLAGS=()
 
@@ -51,6 +54,7 @@ set -x
 helm install --create-namespace --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
     --set ${CONTROLLER_PREFIX}ingressController.env.anonymous_reports="false" \
     --set deployment.test.enabled=true ${ADDITIONAL_FLAGS[*]} \
+    --set ${CONTROLLER_PREFIX}image.effectiveSemver="${KONG_GATEWAY_EFFECTIVE_VERSION}" \
     "charts/${CHART_NAME}"
 set +x
 # ------------------------------------------------------------------------------
@@ -72,6 +76,7 @@ helm upgrade --namespace "${RELEASE_NAMESPACE}" "${RELEASE_NAME}" \
     --set deployment.test.enabled=true ${ADDITIONAL_FLAGS[*]} \
     --set ${CONTROLLER_PREFIX}ingressController.env.anonymous_reports="false" \
     --set ${CONTROLLER_PREFIX}ingressController.image.effectiveSemver="${EFFECTIVE_TAG}" \
+    --set ${CONTROLLER_PREFIX}image.effectiveSemver="${KONG_GATEWAY_EFFECTIVE_VERSION}" \
     "charts/${CHART_NAME}"
 set +x
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Introduce the check that prevents running KIC 3.0.0 with too old Kong Gateway, chart rendering will fail.

#### Which issue this PR fixes

The last one closes https://github.com/Kong/kubernetes-ingress-controller/issues/4764

#### Special notes for your reviewer:

AFAIK there is no standard way of doing such validation. JSON schema for values is an option, but it doesn't have a mechanism for cross-field validation, so it won't help in a such case. So this PR proposes introducing a special file that only serves the purpose of doing such checks to keep it clean because it's not obvious in what other file it should be put. Check indeed works, [see](https://github.com/Kong/charts/actions/runs/6533165482/job/17737795195?pr=900#step:6:59), workaround with `KONG_GATEWAY_EFFECTIVE_VERSION` is needed for now.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] ~New or modified sections of values.yaml are documented in the README.md~
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
