### PR TITLE
chore(tests): bump gateway-api to v0.8.1, move to variable, stop testing with old K8s

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -77,11 +77,10 @@ jobs:
     env:
       # Specify this here because these tests rely on ktf to run kind for cluster creation.
       KIND_VERSION: v0.20.0
+      GATEWAY_API_VERSION: v0.8.1
     strategy:
       matrix:
         kubernetes-version:
-        - "1.21.14"
-        - "1.22.15"
         - "1.23.13"
         - "1.24.7"
         - "1.25.9"
@@ -123,6 +122,7 @@ jobs:
     env:
       # Specify this here because these tests rely on ktf to run kind for cluster creation.
       KIND_VERSION: v0.20.0
+      GATEWAY_API_VERSION: v0.8.1
     strategy:
       matrix:
         kic-version:

--- a/charts/kong/templates/tests/test-resources.yaml
+++ b/charts/kong/templates/tests/test-resources.yaml
@@ -46,14 +46,14 @@ spec:
             port:
               number: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: GatewayClass
 metadata:
   name: "{{ .Release.Name }}-kong-test"
 spec:
   controllerName: konghq.com/kic-gateway-controller
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:
   name: "{{ .Release.Name }}-kong-test"
@@ -66,7 +66,7 @@ spec:
     protocol: HTTP
     port: 80
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: "{{ .Release.Name }}-httpbin"

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -32,6 +32,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}/.."
 KIND_VERSION="${KIND_VERSION:-v0.19.0}"
 KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.27.1}"
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v0.8.1}"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
 KTF_URL=https://github.com/Kong/kubernetes-testing-framework/releases/latest/download/ktf.${OS}.${ARCH}
@@ -87,7 +88,7 @@ ktf 1>/dev/null
 
 ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --addon kuma --kubernetes-version "${KUBERNETES_VERSION}"
 
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl apply -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${GATEWAY_API_VERSION}" | kubectl apply -f -
 
 echo "INFO: Updating helm dependencies"
 for i in charts/*; do


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

- Set the version of [`gateway-api`](https://github.com/kubernetes-sigs/gateway-api) explicitly to increase visibility in the CI pipeline and bump it to the newest `v0.8.1`.
- In `test-resources.yaml` bump API version from `v1alpha1` to `v1beta1`
- Stop testing with very old K8s versions
   - `1.22` end of active support `28 Aug 2022`, end of maintenance `28 Oct 2022`, [see the problem](https://github.com/Kong/charts/actions/runs/6535008939/job/17744956716?pr=901)
   - `1.21` end of active support `28 Aug 2022`, end of maintenance `28 Jun 2022`, [see the problem](https://github.com/Kong/charts/actions/runs/6535008939/job/17744958122?pr=901)


#### Special notes for your reviewer:

It's not an ideal solution, ultimately use the same approach as KIC with renovate for updating dependencies. But still it's better with this fix than without it. 
