### PR TITLE
chore: remove redundant $ in docs and `engine` field in Chart.yaml

### DIFF
--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v2
 description: Deploy Kong Ingress Controller and Kong Gateway
-engine: gotpl
 home: https://konghq.com/
 icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
 maintainers:

--- a/charts/ingress/README.md
+++ b/charts/ingress/README.md
@@ -10,10 +10,10 @@ Kong Gateway using [Helm](https://helm.sh) package manager.
 ## Usage
 
 ```bash
-$ helm repo add kong https://charts.konghq.com
-$ helm repo update
+helm repo add kong https://charts.konghq.com
+helm repo update
 
-$ helm install kong kong/ingress -n kong
+helm install kong kong/ingress -n kong
 ```
 
 If you need more control over what is deployed, see the [kong/kong chart](https://github.com/Kong/charts/blob/main/charts/kong/README.md). Any `values.yaml` setting can be specified in the `controller` or `gateway` section of your `values.yaml` using this chart.

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -1,20 +1,19 @@
 apiVersion: v2
 description: The Cloud-Native Ingress and API-management
-engine: gotpl
 home: https://konghq.com/
 icon: https://s3.amazonaws.com/downloads.kong/universe/assets/icon-kong-inc-large.png
 maintainers:
-- name: hbagdi
-  email: harry@konghq.com
-- name: rainest
-  email: traines@konghq.com
+  - name: hbagdi
+    email: harry@konghq.com
+  - name: rainest
+    email: traines@konghq.com
 name: kong
 sources:
-- https://github.com/Kong/charts/tree/main/charts/kong
+  - https://github.com/Kong/charts/tree/main/charts/kong
 version: 2.29.0
 appVersion: "3.4"
 dependencies:
-- name: postgresql
-  version: 11.9.13
-  repository: https://charts.bitnami.com/bitnami
-  condition: postgresql.enabled
+  - name: postgresql
+    version: 11.9.13
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -11,10 +11,10 @@ This chart bootstraps all the components needed to run Kong on a
 ## TL;DR;
 
 ```bash
-$ helm repo add kong https://charts.konghq.com
-$ helm repo update
+helm repo add kong https://charts.konghq.com
+helm repo update
 
-$ helm install kong/kong --generate-name
+helm install kong/kong --generate-name
 ```
 
 ## Table of contents
@@ -91,10 +91,10 @@ $ helm install kong/kong --generate-name
 To install Kong:
 
 ```bash
-$ helm repo add kong https://charts.konghq.com
-$ helm repo update
+helm repo add kong https://charts.konghq.com
+helm repo update
 
-$ helm install kong/kong --generate-name
+helm install kong/kong --generate-name
 ```
 
 ## Uninstall
@@ -102,7 +102,7 @@ $ helm install kong/kong --generate-name
 To uninstall/delete a Helm release `my-release`:
 
 ```bash
-$ helm delete my-release
+helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the
@@ -1013,7 +1013,7 @@ If you have paid for a license, but you do not have a copy of yours, please
 contact Kong Support. Once you have it, you will need to store it in a Secret:
 
 ```bash
-$ kubectl create secret generic kong-enterprise-license --from-file=license=./license.json
+kubectl create secret generic kong-enterprise-license --from-file=license=./license.json
 ```
 
 Set the secret name in `values.yaml`, in the `.enterprise.license_secret` key.
@@ -1031,7 +1031,7 @@ from \<your username\> \> Edit Profile \> API Key. Use this to create registry
 secrets:
 
 ```bash
-$ kubectl create secret docker-registry kong-enterprise-edition-docker \
+kubectl create secret docker-registry kong-enterprise-edition-docker \
     --docker-server=hub.docker.io \
     --docker-username=<username-provided-to-you> \
     --docker-password=<password-provided-to-you>
@@ -1107,14 +1107,30 @@ whereas this is optional for the Developer Portal on versions 0.36+. Providing
 Portal session configuration in values.yaml provides the default session
 configuration, which can be overridden on a per-workspace basis.
 
+```bash
+cat admin_gui_session_conf
 ```
-$ cat admin_gui_session_conf
+
+```json
 {"cookie_name":"admin_session","cookie_samesite":"off","secret":"admin-secret-CHANGEME","cookie_secure":true,"storage":"kong"}
-$ cat portal_session_conf
+```
+
+```bash
+cat portal_session_conf
+```
+
+```json
 {"cookie_name":"portal_session","cookie_samesite":"off","secret":"portal-secret-CHANGEME","cookie_secure":true,"storage":"kong"}
-$ kubectl create secret generic kong-session-config --from-file=admin_gui_session_conf --from-file=portal_session_conf
+```
+
+```bash
+kubectl create secret generic kong-session-config --from-file=admin_gui_session_conf --from-file=portal_session_conf
+```
+
+```bash
 secret/kong-session-config created
 ```
+
 The exact plugin settings may vary in your environment. The `secret` should
 always be changed for both configurations.
 
@@ -1175,7 +1191,7 @@ between the initial install and upgrades. Both operations are a "sync" in Argo
 terms. This affects when migration Jobs execute in database-backed Kong
 installs.
 
-The chart sets the `Sync` and `BeforeHookCreation` deletion 
+The chart sets the `Sync` and `BeforeHookCreation` deletion
 [hook policies](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/)
 on the `init-migrations` and `pre-upgrade-migrations` Jobs.
 

--- a/charts/kong/UPGRADE.md
+++ b/charts/kong/UPGRADE.md
@@ -193,7 +193,7 @@ database](https://www.postgresql.org/docs/current/backup-dump.html) and
 creating a separate release if you wish to continue using 8.6.8:
 
 ```
-$ helm install my-release -f values.yaml --version 8.6.8 bitnami/postgresql
+helm install my-release -f values.yaml --version 8.6.8 bitnami/postgresql
 ```
 
 Afterwords, you will upgrade your Kong chart release with
@@ -233,26 +233,28 @@ upgrade in multiple steps:
 First, pin the controller version and upgrade to chart 2.4.0:
 
 ```console
-$ helm upgrade --wait \
+helm upgrade --wait \
   --set ingressController.image.tag=<CURRENT_CONTROLLER_VERSION> \
   --version 2.4.0 \
   --namespace <YOUR_RELEASE_NAMESPACE> \
   <YOUR_RELEASE_NAME> kong/kong
 ```
+
 Second, temporarily disable the ingress controller:
 
 ```console
-$ helm upgrade --wait \
+helm upgrade --wait \
   --set ingressController.enabled=false \
   --set deployment.serviceaccount.create=true \
   --version 2.4.0 \
   --namespace <YOUR_RELEASE_NAMESPACE> \
   <YOUR_RELEASE_NAME> kong/kong
 ```
+
 Finally, re-enable the ingress controller at the new version:
 
 ```console
-$ helm upgrade --wait \
+helm upgrade --wait \
   --set ingressController.enabled=true \
   --set ingressController.image.tag=<NEW_CONTROLLER_VERSION> \
   --version 2.4.0 \


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

- Field `engine: gotpl` is redundant in `Chart.yaml` files, it is optional and the default is `gotpl` - [see the docs](https://v2.helm.sh/docs/developing_charts/#the-chart-yaml-file).

- Remove redundant `$` from example commands to make them easily copyable.

