### PR TITLE
chore: fix charts meta and owners

### DIFF
--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
     email: michael.heap@konghq.com
 name: ingress
 sources:
-  - https://github.com/Kong/charts/tree/main/charts/kong
+  - https://github.com/Kong/charts/tree/main/charts/ingress
 version: 0.7.0
 appVersion: "3.3"
 dependencies:

--- a/charts/kong/OWNERS
+++ b/charts/kong/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-- hbagdi
-- shashiranjan84
-- rainest
-reviewers:
-- hbagdi
-- shashiranjan84
-- rainest


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix `ingress` chart source URL and remove `charts/kong/OWNERS` since it's out-dated and the same information (up to date) is in https://github.com/Kong/charts/blob/main/CODEOWNERS