### PR TITLE
chore: trigger admission on secrets creation for KIC >= 2.12.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -5,11 +5,15 @@
 ### Improvements
 
 * Prevent installing PodDisruptionBudget for `replicaCount: 1` or `autoscaling.minReplicas: 1`.
+  [#896](https://github.com/Kong/charts/pull/896)
+* The admission webhook now will be triggered on Secrets creation for KIC 2.12.1+.
+  [#907](https://github.com/Kong/charts/pull/907)
 
 ## 2.29.0
 
 ### Improvements
 * Make it possible to set the admission webhook's `timeoutSeconds`.
+  [#894](https://github.com/Kong/charts/pull/894)
 
 ## 2.28.1
 
@@ -18,6 +22,7 @@
 * The admission webhook now includes Gateway API resources and Ingress
   resources for controller versions 2.12+. This version introduces new
   validations for Kong's regex path implementation.
+  [#892](https://github.com/Kong/charts/pull/892)
 
 ## 2.28.0
 

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -80,6 +80,9 @@ webhooks:
     apiVersions:
     - 'v1'
     operations:
+{{- if (semverCompare ">= 2.12.1" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+    - CREATE
+{{- end }}
     - UPDATE
     resources:
     - secrets


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `CREATE` trigger for `secrets` resource in admission webhook config when KIC version is >= 2.12.1. 

It's required for https://github.com/Kong/kubernetes-ingress-controller/pull/4887 to work.

#### Which issue this PR fixes

https://github.com/Kong/kubernetes-ingress-controller/issues/4885

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
