### PR TITLE
chore: use ingressClass field instead of annotation

### DIFF
--- a/charts/ingress/templates/tests/test-resources.yaml
+++ b/charts/ingress/templates/tests/test-resources.yaml
@@ -32,9 +32,9 @@ metadata:
   name: "{{ .Release.Name }}-httpbin"
   annotations:
     httpbin.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: "kong"
     konghq.com/strip-path: "true"
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:

--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -9,7 +9,6 @@ admin:
       konghq.com/https-redirect-status-code: "301"
       konghq.com/protocols: https
       konghq.com/strip-path: "true"
-      kubernetes.io/ingress.class: default
       nginx.ingress.kubernetes.io/app-root: /
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
       nginx.ingress.kubernetes.io/permanent-redirect-code: "301"
@@ -176,8 +175,8 @@ manager:
   ingress:
     annotations:
       konghq.com/https-redirect-status-code: "301"
-      kubernetes.io/ingress.class: default
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    ingressClassName: kong
     enabled: true
     hostname: kong.127-0-0-1.nip.io
     path: /
@@ -209,7 +208,7 @@ portal:
       konghq.com/https-redirect-status-code: "301"
       konghq.com/protocols: https
       konghq.com/strip-path: "false"
-      kubernetes.io/ingress.class: default
+    ingressClassName: kong
     enabled: true
     hostname: developer.127-0-0-1.nip.io
     path: /
@@ -232,8 +231,8 @@ portalapi:
       konghq.com/https-redirect-status-code: "301"
       konghq.com/protocols: https
       konghq.com/strip-path: "true"
-      kubernetes.io/ingress.class: default
       nginx.ingress.kubernetes.io/app-root: /
+    ingressClassName: kong
     enabled: true
     hostname: developer.127-0-0-1.nip.io
     path: /api

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -40,8 +40,7 @@ admin:
     enabled: true
     tls: CHANGEME-admin-tls-secret
     hostname: admin.kong.CHANGEME.example
-    annotations:
-      kubernetes.io/ingress.class: "kong"
+    ingressClassName: kong
     path: /
 
 proxy:
@@ -148,8 +147,7 @@ portal:
     enabled: true
     tls: CHANGEME-portal-tls-secret
     hostname: portal.kong.CHANGEME.example
-    annotations:
-      kubernetes.io/ingress.class: "kong"
+    ingressClassName: kong
     path: /
 
   externalIPs: []
@@ -177,8 +175,7 @@ portalapi:
     enabled: true
     tls: CHANGEME-portalapi-tls-secret
     hostname: portalapi.kong.CHANGEME.example
-    annotations:
-      kubernetes.io/ingress.class: "kong"
+    ingressClassName: kong
     path: /
 
   externalIPs: []

--- a/charts/kong/templates/tests/test-resources.yaml
+++ b/charts/kong/templates/tests/test-resources.yaml
@@ -32,9 +32,9 @@ metadata:
   name: "{{ .Release.Name }}-httpbin"
   annotations:
     httpbin.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.class: "kong"
     konghq.com/strip-path: "true"
 spec:
+  ingressClassName: kong
   rules:
   - http:
       paths:


### PR DESCRIPTION
#### What this PR does / why we need it:

Stop using deprecated ingress class annotation and use `ingressClass` field instead.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
