### PR TITLE
feat(sec) add securitycontext restrictions

### DIFF
--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -878,7 +878,7 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | `""`                |
 | secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
 | securityContext                    | Set the securityContext for Kong Pods                                                 | `{}`                |
-| containerSecurityContext           | Set the securityContext for Containers                                                | `{"readOnlyRootFilesystem": true}`                |
+| containerSecurityContext           | Set the securityContext for Containers                                                | See values.yaml     |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | `false`             |
 | serviceMonitor.interval            | Scraping interval                                                                     | `30s`               |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -948,6 +948,14 @@ securityContext: {}
 # securityContext for containers.
 containerSecurityContext:
   readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsUser: 1000
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+    - ALL
 
 ## Optional DNS configuration for Kong pods
 # dnsPolicy: ClusterFirst


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the container security context defaults with various settings.

Didn't stick the whole thing in the readme since it'd look a bit silly.

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4102

#### Special notes for your reviewer:

These settings apply the [restricted pod security standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/). Namespaces with [restricted standards enforced](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces) will accept chart Pods with these settings in place.

The `containerSecurityContext` from values.yaml applies to all chart-managed containers equally. We do not support different security contexts for KIC and Kong containers.

The `runAsUser` setting is set to align with the current proxy image user ID, though I am [basing this off partial knowledge of the build process](https://github.com/Kong/kubernetes-ingress-controller/issues/4102#issuecomment-1756418527) and waiting on gateway team confirmation. The controller currently uses a different UID, but I intend to change that in https://github.com/Kong/kubernetes-ingress-controller/pull/4911.

Basic testing suggested a mismatch between the controller image and `runAsUser` ID doesn't actually matter, which makes sense--our executable is world-executable and doesn't need to do anything on the filesystem. The Kong image has many more relevant files, though anything it writes all goes in emptydirs.

AFAIK there is no reason we should need any of the restricted capabilities under normal circumstances. As the context settings are part of values.yaml, they can be adjusted if you need to.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
