### PR TITLE
chore(env) update router default

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+* The `env.router_flavor` default is now `expressions`. This requires Kong
+  3.4.1 or higher and controller 3.0.0 or higher. Releases using older image
+  versions should change this value to `traditional`
+  [#911](https://github.com/Kong/charts/pull/911)
+
 ## 0.7.0
 
 - Bumped dependency `kong/kong` minimum to `2.28.1`. Review the [kong chart

--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -14,6 +14,10 @@ controller:
 
   ingressController:
     enabled: true
+    image:
+      repository: kong/nightly-ingress-controller
+      tag: "nightly"
+      effectiveSemver: "3.0.0"
 
     gatewayDiscovery:
       enabled: true

--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -36,3 +36,4 @@ gateway:
   env:
     role: traditional
     database: "off"
+    router_flavor: "expressions"

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-## Unreleased
-
 ### Improvements
 
 * Prevent installing PodDisruptionBudget for `replicaCount: 1` or `autoscaling.minReplicas: 1`.

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -84,11 +84,7 @@ deployment:
 # is set below. In general, you should not set values here if they are set elsewhere.
 env:
   database: "off"
-  # the chart uses the traditional router (for Kong 3.x+) because the ingress
-  # controller generates traditional routes. if you do not use the controller,
-  # you may set this to "traditional_compatible" or "expressions" to use the new
-  # DSL-based router
-  router_flavor: "traditional"
+  router_flavor: "traditional_compatible"
   nginx_worker_processes: "2"
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout


### PR DESCRIPTION
#### What this PR does / why we need it:
Changes the router default to `expressions`.

Notes this as a breaking change in unreleased release notes.

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4719

#### Special notes for your reviewer:

Ditto open questions in https://github.com/Kong/kubernetes-ingress-controller/pull/4934

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
