### PR TITLE
chore(docs) add missing changelog entry

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,6 +8,14 @@
   [#896](https://github.com/Kong/charts/pull/896)
 * The admission webhook now will be triggered on Secrets creation for KIC 2.12.1+.
   [#907](https://github.com/Kong/charts/pull/907)
+* Container security context defaults now comply with the restricted pod
+  security standard. This includes an enforced run as user ID set to 1000. UID
+  1000 is used for official Kong images other than Alpine images (which use UID
+  100) and for KIC images 3.0.0+ (older images use UID 65532). Images that do
+  not use UID 1000 can still run with this user, as static image files are
+  world-accessible and runtime-created files are created in temporary
+  directories created for the run as user.
+  [#911](https://github.com/Kong/charts/pull/911)
 
 ## 2.29.0
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Forgot a changelog for another PR: https://github.com/Kong/charts/pull/909#issuecomment-1774734425

#### Special notes for your reviewer:

Gateway team has confirmed that most images use UID 1000. Alpine doesn't for whatever reason, but runs fine with UID 1000 when I test it. For a partial view of permissions in an Alpine container: 
[perms.txt](https://github.com/Kong/charts/files/13068718/perms.txt)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
