### PR TITLE
feat: exclude controller to admin comms from mesh

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Controller Pods now include annotations to exempt the gateway admin API port
+  from Kuma and Istio mesh interception. Controller to admin API configuration
+  uses its own mTLS configuration, which is not compatible with mesh mTLS.
+  [#913](https://github.com/Kong/charts/pull/913)
+
 ## 0.7.0
 
 - Bumped dependency `kong/kong` minimum to `2.28.1`. Review the [kong chart

--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -19,6 +19,14 @@ controller:
       enabled: true
       generateAdminApiService: true
 
+  podAnnotations:
+    kuma.io/gateway: enabled
+    # This port must match your Kong admin API port. 8444 is the default.
+    # If you set gateway.admin.tls.containerPort, change these annotations
+    # to use that value.
+    traffic.kuma.io/exclude-outbound-ports: "8444"
+    traffic.sidecar.istio.io/excludeOutboundPorts: "8444"
+
 gateway:
   enabled: true
   deployment:


### PR DESCRIPTION
#### What this PR does / why we need it:

Set Kuma and Istio outbound traffic excludes 

#### Which issue this PR fixes
Part of https://github.com/Kong/kubernetes-ingress-controller/issues/4698

#### Special notes for your reviewer:

See https://github.com/Kong/kubernetes-ingress-controller/issues/4698#issuecomment-1775710675 re design. The ingress chart subchart usage prevents us from automating the annotation value cleanly. It's unlikely it would need to change (we do expose the admin port configuration, but I don't know a reason you'd ever change it), but setting it in ingress's values.yaml runs the risk of accidentally excluding new annotations added in the kong chart values.yaml.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] ~New or modified sections of values.yaml are documented in the README.md~ ingress doesn't really use it?
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
