### PR TITLE
feat(kong): allow using templates when specifying `controller.proxy.nameOverride`

### DIFF
--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -4,7 +4,7 @@ deployment:
 
 controller:
   proxy:
-    nameOverride: kong-gateway-proxy
+    nameOverride: "{{ .Release.Name }}-gateway-proxy"
 
   enabled: true
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.30.0
 
 ### Improvements
 
@@ -16,6 +16,8 @@
   world-accessible and runtime-created files are created in temporary
   directories created for the run as user.
   [#911](https://github.com/Kong/charts/pull/911)
+* Allow using templates (via `tpl`) when specifying `controller.proxy.nameOverride`.
+  [#914](https://github.com/Kong/charts/pull/914)
 
 ## 2.29.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.29.0
+version: 2.30.0
 appVersion: "3.4"
 dependencies:
   - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -447,14 +447,28 @@ The name of the service used for the ingress controller's validation webhook
 {{ include "kong.fullname" . }}-validation-webhook
 {{- end -}}
 
+
+{{/*
+The name of the Service which will be used by the controller to update the Ingress status field.
+*/}}
+
+{{- define "kong.controller-publish-service" -}}
+{{- $proxyOverride := "" -}}
+  {{- if .Values.proxy.nameOverride -}}
+    {{- $proxyOverride = ( tpl .Values.proxy.nameOverride . ) -}}
+  {{- end -}}
+{{- (printf "%s/%s" ( include "kong.namespace" . ) ( default ( printf "%s-proxy" (include "kong.fullname" . )) $proxyOverride )) -}}
+{{- end -}}
+
 {{- define "kong.ingressController.env" -}}
 {{/*
     ====== AUTO-GENERATED ENVIRONMENT VARIABLES ======
 */}}
 
+
 {{- $autoEnv := dict -}}
   {{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" true -}}
-  {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" (printf "%s/%s" ( include "kong.namespace" . ) ( .Values.proxy.nameOverride | default ( printf "%s-proxy" (include "kong.fullname" . )))) -}}
+  {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" ( include "kong.controller-publish-service" . ) -}}
   {{- $_ := set $autoEnv "CONTROLLER_INGRESS_CLASS" .Values.ingressController.ingressClass -}}
   {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

When using the [`ingress` chart 
](https://github.com/Kong/charts/tree/main/charts/ingress) we have to specify the proxy name override 

https://github.com/Kong/charts/blob/824d02276e92d4fea084f603b6833fbd0a38ee92/charts/ingress/values.yaml#L7

in order to get controller's `CONTROLLER_PUBLISH_SERVICE` set properly.

Currently the override is set to `kong-gateway-proxy` which works only when the release name (set by the user) is `kong`. When a different release name is chosen users have to know what to change and how to change it, e.g. when using a release name `kong123` `controller.proxy.nameOverride` has to be set to `kong123-gateway-proxy`.

Without this change installing the `ingress` chart using `kong123` release name yields the following controller env variables:

```
- name: CONTROLLER_KONG_ADMIN_SVC
  value: kong/kong123-gateway-admin
- name: CONTROLLER_PUBLISH_SERVICE
  value: kong/kong-gateway-proxy
```

With this change:

```
- name: CONTROLLER_KONG_ADMIN_SVC
  value: kong/kong123-gateway-admin
- name: CONTROLLER_PUBLISH_SERVICE
  value: kong/kong123-gateway-proxy
```

without the user specifying the override themselves.

Release `kong/kong` chart 2.30.0.
