### PR TITLE
ingress: allow templating `controller.proxy.nameOverride`

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.0
 
 ### Improvements
 
@@ -8,6 +8,10 @@
   from Kuma and Istio mesh interception. Controller to admin API configuration
   uses its own mTLS configuration, which is not compatible with mesh mTLS.
   [#913](https://github.com/Kong/charts/pull/913)
+- Allow using templates (via `tpl`) when specifying `controller.proxy.nameOverride`.
+  [#915](https://github.com/Kong/charts/pull/915)
+- Bumped dependency `kong/kong` to `2.30.0`.
+  [#915](https://github.com/Kong/charts/pull/915)
 
 ## 0.7.0
 

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.28.1
+  version: 2.30.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.28.1
-digest: sha256:ff4cd98c838fb0abcefb22d503c78f793c885ac97ba44b2022072e473a26c22a
-generated: "2023-10-04T12:22:07.714539+02:00"
+  version: 2.30.0
+digest: sha256:afe37b17e6c10c8c21fc2b63609fc73c8eb5cf2c5b8f567178c054758f54cc4b
+generated: "2023-10-26T20:06:09.51917+02:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.7.0
-appVersion: "3.3"
+version: 0.8.0
+appVersion: "3.4"
 dependencies:
   - name: kong
-    version: ">=2.26.0"
+    version: ">=2.30.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.26.0"
+    version: ">=2.30.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled

--- a/charts/ingress/ci/gateway-discovery-values.yaml
+++ b/charts/ingress/ci/gateway-discovery-values.yaml
@@ -16,4 +16,3 @@ controller:
 gateway:
   env:
     anonymous_reports: "off"
-  nameOverride: gateway

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -16,7 +16,7 @@
   world-accessible and runtime-created files are created in temporary
   directories created for the run as user.
   [#911](https://github.com/Kong/charts/pull/911)
-* Allow using templates (via `tpl`) when specifying `controller.proxy.nameOverride`.
+* Allow using templates (via `tpl`) when specifying `proxy.nameOverride`.
   [#914](https://github.com/Kong/charts/pull/914)
 
 ## 2.29.0


### PR DESCRIPTION
#### What this PR does / why we need it:

`ingress` change which incorporates #914.

Release `ingress` 0.8.0.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the ~"Unreleased"~ 0.8.0 header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
