### PR TITLE
feat: add services to admission webhook config for KIC >= 3.0.0

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -59,7 +59,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Run chart-testing (lint)
         run: ct lint --check-version-increment=false

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Added controller's RBAC rules for `KongUpstreamPolicy` CRD.
   [#917](https://github.com/Kong/charts/pull/917)
+* Added services resource to admission webhook config for KIC >= 3.0.0.
+  [#919](https://github.com/Kong/charts/pull/919)
 
 ## 2.30.0
 

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -86,6 +86,9 @@ webhooks:
     - UPDATE
     resources:
     - secrets
+{{- if (semverCompare ">= 3.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+    - services
+{{- end }}
 {{- if (semverCompare ">= 2.12.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
   - apiGroups:
     - networking.k8s.io


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `services` to admission webhook settings for https://github.com/Kong/kubernetes-ingress-controller/pull/5022 to function correctly.

#### Which issue this PR fixes

Follow up of https://github.com/Kong/kubernetes-ingress-controller/pull/5022.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
