### PR TITLE
fix(serviceMonitor) fix target port for cmetrics

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -9,6 +9,11 @@
 * Added services resource to admission webhook config for KIC >= 3.0.0.
   [#919](https://github.com/Kong/charts/pull/919)
 
+### Fixed
+
+* The target port for cmetrics should only be applied if the ingress controller is enabled.
+  [#926](https://github.com/Kong/charts/pull/926)
+
 ## 2.30.0
 
 ### Improvements

--- a/charts/kong/templates/servicemonitor.yaml
+++ b/charts/kong/templates/servicemonitor.yaml
@@ -24,7 +24,7 @@ spec:
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
     {{- end }}
-  {{ if (semverCompare ">= 2.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) -}}
+  {{- if and .Values.ingressController.enabled (semverCompare ">= 2.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
   - targetPort: cmetrics
     scheme: http
     {{- if .Values.serviceMonitor.interval }}


### PR DESCRIPTION
The target port for cmetrics should only be applied if the ingress controller is enabled.

#### What this PR does / why we need it:

#### Which issue this PR fixes
No issue created.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `main` branch.
- [X] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [X] New or modified sections of values.yaml are documented in the README.md
- [X] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
