### PR TITLE
chore(ingress): bump kong subchart dependency

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.9.0
+
+### Improvements
+
+- Bumped dependencies on `kong/kong` chart to `>=2.31.0`.
+  This most notably brings a default version of KIC to [v3.0][kic_3_0].
+  [#930](https://github.com/Kong/charts/pull/930)
+
+[kic_3_0]: https://github.com/Kong/kubernetes-ingress-controller/releases/tag/v3.0.0
+
 ## 0.8.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.30.0
+  version: 2.31.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.30.0
-digest: sha256:afe37b17e6c10c8c21fc2b63609fc73c8eb5cf2c5b8f567178c054758f54cc4b
-generated: "2023-10-26T20:06:09.51917+02:00"
+  version: 2.31.0
+digest: sha256:2897c91fb6e37c04f99a413dac85f991fed223591b8de327a04795e27b90a617
+generated: "2023-11-06T14:36:11.845865+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.8.0
+version: 0.9.0
 appVersion: "3.4"
 dependencies:
   - name: kong
-    version: ">=2.30.0"
+    version: ">=2.31.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.30.0"
+    version: ">=2.31.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Bring in changes from https://github.com/Kong/charts/releases/tag/kong-2.31.0 to `ingress` chart.

Release `ingress` 0.9.0.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
