### PR TITLE
feat: set default router flavor to expressions if KIC >=3.0 and traditional_compatible otherwide

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,9 +8,11 @@
   [#917](https://github.com/Kong/charts/pull/917)
 * Added services resource to admission webhook config for KIC >= 3.0.0.
   [#919](https://github.com/Kong/charts/pull/919)
-* Update default ingress controller version to v3.0
+* Update default ingress controller version to v3.0.
   [#929](https://github.com/Kong/charts/pull/929)
   [#930](https://github.com/Kong/charts/pull/930)
+* Set default router flavor to `expressions` for KIC >= 3.0.0.
+  [#935](https://github.com/Kong/charts/pull/935)
 
 ### Fixed
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1144,6 +1144,7 @@ the template that it itself is using form the above sections.
 {{- end }}
 
 {{- $_ := set $autoEnv "KONG_PLUGINS" (include "kong.plugins" .) -}}
+{{- $_ := set $autoEnv "KONG_ROUTER_FLAVOR" (include "kong.router_flavor" .) -}}
 
 {{/*
     ====== USER-SET ENVIRONMENT VARIABLES ======
@@ -1709,4 +1710,16 @@ extensions/v1beta1
     {{- end -}}
 {{- end -}}
 {{- (toYaml $proxyReadiness) -}}
+{{- end -}}
+
+{{- define "kong.router_flavor" -}}
+{{- if .Values.env.router_flavor -}}
+.Values.env.router_flavor
+{{- else -}}
+    {{- if (and  .Values.ingressController.enabled  (semverCompare ">= 3.0.0" (include "kong.effectiveVersion" .Values.ingressController.image))) -}}
+        expressions
+    {{- else -}}
+        traditional_compatible
+    {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -84,11 +84,6 @@ deployment:
 # is set below. In general, you should not set values here if they are set elsewhere.
 env:
   database: "off"
-  # the chart uses the traditional router (for Kong 3.x+) because the ingress
-  # controller generates traditional routes. if you do not use the controller,
-  # you may set this to "traditional_compatible" or "expressions" to use the new
-  # DSL-based router
-  router_flavor: "traditional"
   nginx_worker_processes: "2"
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout


### PR DESCRIPTION

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Add `kong.router_flavor` to set router flavor to:
- `values.env.router_flavor` if specified
- `expressions` if KIC is enabled and image version >= 3.0.0
- `traditional_compatible` otherwise (REVIEW: is it better to leave it empty to let Kong gateway to use the default value)?

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes https://github.com/Kong/charts/issues/1188

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
