### PR TITLE
add `alignWithControllerVersion` to allow auto-adjustment of GW settings

### DIFF
--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
-  repository: https://charts.konghq.com
+  repository: file://../kong/
   version: 2.31.0
 - name: kong
-  repository: https://charts.konghq.com
+  repository: file://../kong/
   version: 2.31.0
-digest: sha256:2897c91fb6e37c04f99a413dac85f991fed223591b8de327a04795e27b90a617
-generated: "2023-11-06T14:36:11.845865+01:00"
+digest: sha256:43b29b6944b4f933dac8cea47c076a151e793df14464d52b4029c9d5689c5c6d
+generated: "2023-11-09T13:56:18.166194+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -13,11 +13,11 @@ appVersion: "3.4"
 dependencies:
   - name: kong
     version: ">=2.31.0"
-    repository: https://charts.konghq.com
+    repository: file://../kong/
     alias: controller
     condition: controller.enabled
   - name: kong
     version: ">=2.31.0"
-    repository: https://charts.konghq.com
+    repository: file://../kong/
     alias: gateway
     condition: gateway.enabled

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1714,12 +1714,17 @@ extensions/v1beta1
 
 {{- define "kong.router_flavor" -}}
 {{- if .Values.env.router_flavor -}}
+{{- /* If explicitly specified in envs, it always wins. */ -}}
 .Values.env.router_flavor
 {{- else -}}
-    {{- if (and  .Values.ingressController.enabled  (semverCompare ">= 3.0.0" (include "kong.effectiveVersion" .Values.ingressController.image))) -}}
+    {{- /* If not set explicitly in envs, try using the most modern router based on Ingress Controller version. */ -}}
+    {{- if or (and .Values.ingressController.enabled (semverCompare ">= 3.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)))
+              (and .Values.deployment.kong.alignWithControllerVersion (semverCompare ">= 3.0.0" .Values.deployment.kong.alignWithControllerVersion))
+    -}}
         expressions
+    {{- /* If no Ingress Controller version is set, use a default router flavor. */ -}}
     {{- else -}}
-        traditional_compatible
+        traditional
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -19,6 +19,12 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+
+    # Make Gateway deployment settings to be aligned with a given Ingress Controller version capabilities
+    # (e.g. use a most-modern router flavor supported by a given Ingress Controller version).
+    # If left empty, safe defaults will be used (if not specified explicitly in this chart).
+    alignWithControllerVersion: ""
+
   ## Minimum number of seconds for which a newly created pod should be ready without any of its container crashing,
   ## for it to be considered available.
   # minReadySeconds: 60


### PR DESCRIPTION
#### What this PR does / why we need it:

It's an attempt to provide a workaround for the inability to propagate values between two subcharts (`gateway` and `controller`) in `kong/ingress` chart. 

Branches off https://github.com/Kong/charts/pull/935. 

This is a bit explicit way, but I couldn't come up with anything else that could allow us to pick a `controller.ingressController.image` value and somehow inject it into the other subchart.

Example `values.yaml` that demonstrates how this could be used in Konnect installation instructions:

```yaml
controller:
  ingressController:
    image:
      tag: &ingressControllerVersion "2.11"
    env:
      feature_gates: "FillIDs=true"
    konnect:
      license:
        enabled: true
      enabled: true
      runtimeGroupID: "adea34c5-90c6-4e23-bc93-3c2df8554f72"
      tlsClientSecretName: konnect-client-tls
      apiHostname: "us.kic.api.konghq.tech"

gateway:
  deployment:
    kong:
      # Align Gateway's settings with the controller version capabilities (e.g. router flavor).
      alignWithControllerVersion: *ingressControllerVersion
  image:
    repository: kong/kong-gateway
    tag: "3.3"
  env:
    konnect_mode: "on"
    vitals: "off"
    cluster_mtls: pki
    cluster_telemetry_endpoint: "3e07ee37d9.tp0.konghq.tech:443"
    cluster_telemetry_server_name: "3e07ee37d9.tp0.konghq.tech"
    cluster_cert: /etc/secrets/konnect-client-tls/tls.crt
    cluster_cert_key: /etc/secrets/konnect-client-tls/tls.key
    lua_ssl_trusted_certificate: system

  secretVolumes:
    - konnect-client-tls
```

This should be safe, as when `gateway.deployment.kong.alignWithControllerVersion` will be left empty, the old default will be used, so we're not breaking anything. It would be opt-in and instructions would have to be updated to use that.

An obvious drawback is that it won't work with just `helm install kong kong/ingress`. Installation command would have to be more complex, i.e.: 
```bash
helm install kong kong/ingress --set gateway.deployment.kong.alignWithControllerVersion=3.0 --set controller.ingressController.image.tag=3.0
```

So it's on a similar level of user-friendliness as just telling the user to set the router flavor explicitly if they're using KIC >= 3.0:
```bash
helm install kong kong/ingress --set gateway.env.router_flavor=expressions
```
