### PR TITLE
ingress: enforce expressions router flavor when using KIC v3.0+

### DIFF
--- a/charts/ingress/templates/_helpers.tpl
+++ b/charts/ingress/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{- define "ingressController.enforceGatewayRouterFlavorFor3_0AndUp" -}}
+{{ $gatewayValues := .Subcharts.gateway.Values }}
+{{ $controllerValues := .Subcharts.controller.Values }}
+{{- if semverCompare ">=3.0.0" (include "kong.effectiveVersion" $controllerValues.ingressController.image ) -}}
+  {{- if (not (eq $gatewayValues.env.router_flavor "expressions")) -}}
+    {{- fail (printf "Can't use KIC v3.0+ with Gateway router flavor different than expressions (currently used: %s)" $gatewayValues.env.router_flavor) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/ingress/templates/ingress_controller.yaml
+++ b/charts/ingress/templates/ingress_controller.yaml
@@ -1,0 +1,1 @@
+{{- include "ingressController.enforceGatewayRouterFlavorFor3_0AndUp" . -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Use an obscure `.Subcharts` variable to get subcharts values and based on that enforce the `expressions` router flavor in Kong Gateway when KIC v3.0+ is used
