### PR TITLE
feat: make expressions router default

### DIFF
--- a/.github/workflows/main-pr.yaml
+++ b/.github/workflows/main-pr.yaml
@@ -126,8 +126,8 @@ jobs:
     strategy:
       matrix:
         kic-version:
-        - "2.10"
         - "2.11"
+        - "2.12"
         kong-version:
         - "3.3"
         - "3.2"

--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.10.0
+
+### Improvements
+
+- Changed the default Gateway's router flavor (`gateway.env.router_flavor` value) to performance-boosting `expressions`.
+  It can make `helm install` fail if you're using this chart with Kong Ingress Controller pinned to a version
+  older than `3.0.0`.
+  To fix it, you have the following options for given controller versions:
+  - < `2.10.0`:
+    1. Bump the controller version to >= `3.0.0`.
+    1. Set `gateway.env.router_flavor` to `traditional` to keep using the old router flavor.
+  - \>= `2.10.0` and < `3.0.0`:
+    1. Bump the controller version to >= `3.0.0`.
+    1. Set `gateway.env.router_flavor` to `traditional` to keep using the old router flavor.
+    1. Set `controller.env.feature_gates=ExpressionRoutes=true` to use the new router flavor.
+  [#939](https://github.com/Kong/charts/pull/939)
+
 ## 0.9.0
 
 ### Improvements

--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -11,10 +11,10 @@
   - < `2.10.0`:
     1. Bump the controller version to >= `3.0.0`.
     1. Set `gateway.env.router_flavor` to `traditional` to keep using the old router flavor.
-  - \>= `2.10.0` and < `3.0.0`:
+  - < `3.0.0`:
     1. Bump the controller version to >= `3.0.0`.
     1. Set `gateway.env.router_flavor` to `traditional` to keep using the old router flavor.
-    1. Set `controller.env.feature_gates=ExpressionRoutes=true` to use the new router flavor.
+    1. Set `controller.ingressController.env.feature_gates=ExpressionRoutes=true` to use the new router flavor.
   [#939](https://github.com/Kong/charts/pull/939)
 
 ## 0.9.0

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
-  repository: https://charts.konghq.com
-  version: 2.31.0
+  repository: file://../kong/
+  version: 2.32.0
 - name: kong
-  repository: https://charts.konghq.com
-  version: 2.31.0
-digest: sha256:2897c91fb6e37c04f99a413dac85f991fed223591b8de327a04795e27b90a617
-generated: "2023-11-06T14:36:11.845865+01:00"
+  repository: file://../kong/
+  version: 2.32.0
+digest: sha256:237d8d361b79638a5e0730a476383ff38e0dc0e89d8bf16a68d4ae59b7066464
+generated: "2023-11-13T10:56:42.680929+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.9.0
+version: 0.10.0
 appVersion: "3.4"
 dependencies:
   - name: kong

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -12,12 +12,12 @@ version: 0.10.0
 appVersion: "3.4"
 dependencies:
   - name: kong
-    version: ">=2.31.0"
-    repository: https://charts.konghq.com
+    version: ">=2.32.0"
+    repository: file://../kong/
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.31.0"
-    repository: https://charts.konghq.com
+    version: ">=2.32.0"
+    repository: file://../kong/
     alias: gateway
     condition: gateway.enabled

--- a/charts/ingress/templates/validation.tpl
+++ b/charts/ingress/templates/validation.tpl
@@ -1,0 +1,7 @@
+{{- /* Validate 'expressions' router flavor is not used with KIC < 3.0 */}}
+{{- if and .Values.controller.ingressController.enabled
+           (eq .Values.gateway.env.router_flavor "expressions")
+           (semverCompare "< 3.0" (include "kong.effectiveVersion" .Values.controller.ingressController.image))
+-}}
+    {{- fail (printf "expressions router flavor is not supported with ingress controller %s" .Values.controller.ingressController.image.tag ) -}}
+{{- end -}}

--- a/charts/ingress/templates/validation.tpl
+++ b/charts/ingress/templates/validation.tpl
@@ -1,7 +1,51 @@
-{{- /* Validate 'expressions' router flavor is not used with KIC < 3.0 */}}
+{{- /* Validate 'expressions' router flavor is not used with KIC < 2.10 as it's not supported */}}
 {{- if and .Values.controller.ingressController.enabled
            (eq .Values.gateway.env.router_flavor "expressions")
-           (semverCompare "< 3.0" (include "kong.effectiveVersion" .Values.controller.ingressController.image))
+           (semverCompare "< 2.10" (include "kong.effectiveVersion" .Values.controller.ingressController.image))
 -}}
-    {{- fail (printf "expressions router flavor is not supported with ingress controller %s" .Values.controller.ingressController.image.tag ) -}}
+    {{- fail (printf `
+⚠️ Warning!
+
+"kong/ingress" chart in version 0.10.0 has introduced "gateway.env.router_flavor" value defaulting to "expressions".
+"expressions" router flavor is not supported with Kong Ingress Controller %q that you're using.
+
+✅ How to fix it (alternatives)
+
+1. Upgrade to Kong Ingress Controller 3.0 to use this feature.
+
+2. If you want to keep using your Kong Ingress Controller version, set "gateway.env.router_flavor" to "traditional" to
+backoff to the previous router flavor in your values.yaml:
+
+gateway:
+  env:
+    router_flavor: "traditional"` .Values.controller.ingressController.image.tag  ) -}}
+{{- end -}}
+
+{{- /* Validate that when 'expressions' router flavor is used with KIC < 3.0, feature flag must be set. */ -}}
+{{- if and (.Values.controller.ingressController.enabled)
+           (eq .Values.gateway.env.router_flavor "expressions")
+           (not (contains "ExpressionRoutes=true" (default "" .Values.controller.ingressController.env.feature_gates)))
+           (semverCompare "< 3.0" (include "kong.effectiveVersion" .Values.controller.ingressController.image)) -}}
+    {{- fail (printf `
+⚠️ Warning!
+
+"kong/ingress" chart in version 0.10.0 has introduced "gateway.env.router_flavor" value defaulting to "expressions".
+You're using Kong Ingress Controller version %q which supports this feature only when feature flag "ExpressionRoutes=true" is set.
+
+✅ How to fix it (alternatives)
+
+1. Upgrade to Kong Ingress Controller 3.0 to use this feature.
+
+2. Set "controller.ingressController.env.feature_gates" to "ExpressionRoutes=true" to enable this feature in your values.yaml:
+
+controller:
+  ingressController:
+    env:
+      feature_gates: "ExpressionRoutes=true"
+
+3. Set "gateway.env.router_flavor" to "traditional" to use the previous router flavor in your values.yaml:
+
+gateway:
+  env:
+    router_flavor: "traditional"` .Values.controller.ingressController.image.tag) -}}
 {{- end -}}

--- a/charts/ingress/templates/validation.tpl
+++ b/charts/ingress/templates/validation.tpl
@@ -4,7 +4,7 @@
            (semverCompare "< 2.10" (include "kong.effectiveVersion" .Values.controller.ingressController.image))
 -}}
     {{- fail (printf `
-⚠️ Warning!
+❌ Error!
 
 "kong/ingress" chart in version 0.10.0 has introduced "gateway.env.router_flavor" value defaulting to "expressions".
 "expressions" router flavor is not supported with Kong Ingress Controller %q that you're using.
@@ -27,7 +27,7 @@ gateway:
            (not (contains "ExpressionRoutes=true" (default "" .Values.controller.ingressController.env.feature_gates)))
            (semverCompare "< 3.0" (include "kong.effectiveVersion" .Values.controller.ingressController.image)) -}}
     {{- fail (printf `
-⚠️ Warning!
+❌ Error!
 
 "kong/ingress" chart in version 0.10.0 has introduced "gateway.env.router_flavor" value defaulting to "expressions".
 You're using Kong Ingress Controller version %q which supports this feature only when feature flag "ExpressionRoutes=true" is set.

--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -44,3 +44,4 @@ gateway:
   env:
     role: traditional
     database: "off"
+    router_flavor: "expressions"

--- a/charts/ingress/values.yaml
+++ b/charts/ingress/values.yaml
@@ -44,4 +44,3 @@ gateway:
   env:
     role: traditional
     database: "off"
-    router_flavor: "expressions"

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2.32.0
+
+### Improvements
+
+- Changed the default router flavor (`env.router_flavor` value) to performance-boosting `expressions`.
+  It can make `helm install` fail if you're using this chart with Kong Ingress Controller pinned to a version
+  older than `3.0.0`.
+  To fix it, you have the following options for given controller versions:
+  - < `2.10.0`:
+    1. Bump the controller version to >= `3.0.0`.
+    1. Set `env.router_flavor` to `traditional` to keep using the old router flavor.
+  - < `3.0.0`:
+    1. Bump the controller version to >= `3.0.0`.
+    1. Set `env.router_flavor` to `traditional` to keep using the old router flavor.
+    1. Set `ingressController.env.feature_gates=ExpressionRoutes=true` to use the new router flavor.
+  [#939](https://github.com/Kong/charts/pull/939)
+
 ## 2.31.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.31.0
+version: 2.32.0
 appVersion: "3.4"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/admin-api-service-clusterip-values.yaml
+++ b/charts/kong/ci/admin-api-service-clusterip-values.yaml
@@ -11,8 +11,7 @@ dblessConfig:
       url: http://example.com
       routes:
       - name: example
-        paths:
-        - "/example"
+        expression: http.path ^= "/example"
 
 ingressController:
   enabled: false

--- a/charts/kong/ci/test3-values.yaml
+++ b/charts/kong/ci/test3-values.yaml
@@ -37,5 +37,4 @@ dblessConfig:
         url: http://example.com
         routes:
         - name: example
-          paths:
-          - "/example"
+          expression: http.path ^= "/example"

--- a/charts/kong/ci/test4-values.yaml
+++ b/charts/kong/ci/test4-values.yaml
@@ -31,5 +31,4 @@ dblessConfig:
         url: http://example.com
         routes:
         - name: example
-          paths:
-          - "/example"
+          expression: http.path ^= "/example"

--- a/charts/kong/templates/validation.tpl
+++ b/charts/kong/templates/validation.tpl
@@ -1,0 +1,48 @@
+{{- /* Validate 'expressions' router flavor is not used with KIC < 2.10 as it's not supported */}}
+{{- if and .Values.ingressController.enabled
+           (eq .Values.env.router_flavor "expressions")
+           (semverCompare "< 2.10" (include "kong.effectiveVersion" .Values.ingressController.image))
+-}}
+    {{- fail (printf `
+❌ Error!
+
+"kong/kong" chart in version 2.32.0 has introduced "env.router_flavor" value defaulting to "expressions".
+"expressions" router flavor is not supported with Kong Ingress Controller %q that you're using.
+
+✅ How to fix it (alternatives)
+
+1. Upgrade to Kong Ingress Controller 3.0 to use this feature.
+
+2. If you want to keep using your Kong Ingress Controller version, set "env.router_flavor" to "traditional" to
+backoff to the previous router flavor in your values.yaml:
+
+env:
+  router_flavor: "traditional"` .Values.ingressController.image.tag  ) -}}
+{{- end -}}
+
+{{- /* Validate that when 'expressions' router flavor is used with KIC < 3.0, feature flag must be set. */ -}}
+{{- if and (.Values.ingressController.enabled)
+           (eq .Values.env.router_flavor "expressions")
+           (not (contains "ExpressionRoutes=true" (default "" .Values.ingressController.env.feature_gates)))
+           (semverCompare "< 3.0" (include "kong.effectiveVersion" .Values.ingressController.image)) -}}
+    {{- fail (printf `
+❌ Error!
+
+"kong/kong" chart in version 2.32.0 has introduced "env.router_flavor" value defaulting to "expressions".
+"expressions" router flavor is not supported with Kong Ingress Controller %q that you're using.
+
+✅ How to fix it (alternatives)
+
+1. Upgrade to Kong Ingress Controller 3.0 to use this feature.
+
+2. Set "ingressController.env.feature_gates" to "ExpressionRoutes=true" to enable this feature in your values.yaml:
+
+ingressController:
+  env:
+    feature_gates: "ExpressionRoutes=true"
+
+3. Set "env.router_flavor" to "traditional" to use the previous router flavor in your values.yaml:
+
+env:
+  router_flavor: "traditional"` .Values.ingressController.image.tag) -}}
+{{- end -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -84,11 +84,7 @@ deployment:
 # is set below. In general, you should not set values here if they are set elsewhere.
 env:
   database: "off"
-  # the chart uses the traditional router (for Kong 3.x+) because the ingress
-  # controller generates traditional routes. if you do not use the controller,
-  # you may set this to "traditional_compatible" or "expressions" to use the new
-  # DSL-based router
-  router_flavor: "traditional"
+  router_flavor: "expressions"
   nginx_worker_processes: "2"
   proxy_access_log: /dev/stdout
   admin_access_log: /dev/stdout

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -86,18 +86,18 @@ then
 fi
 
 # Configure values for all tests
-# Enable Gateway API
 
-# Enable ExpressionRoutes when testing old KIC versions.
+# Enable feature gates.
 if [[ -n "${KIC_VERSION-}" ]]; then
-ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.feature_gates=GatewayAlpha=true,ExpressionRoutes=true")
+# If testing old version, set ExpressionRoutes.
+ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.feature_gates=ExpressionRoutes=true,GatewayAlpha=true")
 else
+# Otherwise, just GatewayAlpha.
 ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.feature_gates=GatewayAlpha=true")
 fi
 
 # Tests should not show up in reporting
 ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.anonymous_reports=false")
-
 
 if [[ -n "${KONG_VERSION-}" ]]
 then

--- a/scripts/test-run.sh
+++ b/scripts/test-run.sh
@@ -87,9 +87,17 @@ fi
 
 # Configure values for all tests
 # Enable Gateway API
+
+# Enable ExpressionRoutes when testing old KIC versions.
+if [[ -n "${KIC_VERSION-}" ]]; then
+ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.feature_gates=GatewayAlpha=true,ExpressionRoutes=true")
+else
 ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.feature_gates=GatewayAlpha=true")
+fi
+
 # Tests should not show up in reporting
 ADDITIONAL_FLAGS+=("--set ${CONTROLLER_PREFIX}ingressController.env.anonymous_reports=false")
+
 
 if [[ -n "${KONG_VERSION-}" ]]
 then


### PR DESCRIPTION
#### What this PR does / why we need it:

Sets the expression router as default in `kong/kong`. Adds validations that ensure that:
- `expressions` router flavor is not used with KIC < 2.10 as it's not supported
- when `expressions` router flavor is used with KIC < 3.0, the feature gate must be set.

to both `kong/kong` and `kong/ingress` charts.

Validations will output instructions on how to fix the issue if it is encountered.

It also changes the way we refer to `kong/kong` in `kong/ingress`'s `Chart.yaml`: instead of using the repository URL that forces us to bump charts in two steps, use `file://` to make it possible in one step.

#### Which issue this PR fixes

Should solve https://github.com/Kong/charts/issues/1188.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
