### PR TITLE
fix(serviceMonitor) set 30s as default interval

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* The default interval should be 30s to support the rate of 1m of the official [Kong Grafana dashboard](https://grafana.com/grafana/dashboards/7424-kong-official/).
+  [#941](https://github.com/Kong/charts/pull/941)
+
 ## 2.31.0
 
 ### Improvements

--- a/charts/kong/templates/servicemonitor.yaml
+++ b/charts/kong/templates/servicemonitor.yaml
@@ -17,6 +17,8 @@ spec:
     scheme: http
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
+    {{- else }}
+    interval: 30s
     {{- end }}
     {{- if .Values.serviceMonitor.honorLabels }}
     honorLabels: true
@@ -29,6 +31,8 @@ spec:
     scheme: http
     {{- if .Values.serviceMonitor.interval }}
     interval: {{ .Values.serviceMonitor.interval }}
+    {{- else }}
+    interval: 30s
     {{- end }}
     {{- if .Values.serviceMonitor.honorLabels }}
     honorLabels: true


### PR DESCRIPTION
#### What this PR does / why we need it:
The default interval should be 30s to support the rate of 1m of the official Kong Grafana dashboard.
Dashboard https://grafana.com/grafana/dashboards/7424-kong-official/


#### Which issue this PR fixes
N/A

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
