### PR TITLE
chore: display a warning message when Kong Manager is enabled but the Admin API is not enabled

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 * Support for `affinity` configuration has been added to migration job templates.
+* Display a warning message when Kong Manager is enabled and the Admin API is disabled.
 
 ## 2.32.0
 

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -12,9 +12,16 @@ Once installed, please follow along the getting started guide to start using
 Kong: https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/getting-started/
 
 {{ $warnings := list -}}
+
 {{- if (hasKey .Values.ingressController "serviceAccount") -}}
 {{- if (or (hasKey .Values.ingressController.serviceAccount "name") (hasKey .Values.ingressController.serviceAccount "annotations")) -}}
 {{- $warnings = append $warnings "you have set either .ingressController.serviceAccount.name or .ingressController.serviceAccount.annotations. These settings have moved to .deployment.serviceAccount.name and .deployment.serviceAccount.annotations. You must move your configuration to the new location in values.yaml" -}}
+{{- end -}}
+{{- end -}}
+
+{{- if and .Values.manager.enabled (or .Values.manager.http.enabled .Values.manager.tls.enabled) -}}
+{{- if not (and .Values.admin.enabled (or .Values.admin.http.enabled .Values.admin.tls.enabled)) -}}
+{{- $warnings = append $warnings "Kong Manager will not be functional because the Admin API is not enabled. Setting both .admin.enabled and .admin.http.enabled and/or .admin.tls.enabled to true to enable the Admin API over HTTP/TLS." -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Feedback from issue kong/kong#11995 highlighted potential user confusion due to the internal connection between Kong Manager and the Admin API.

To address this, a warning message will now be displayed to notify users that the current configuration combination will not function as expected.

#### Special notes for your reviewer:
None

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
