### PR TITLE
fix: use GW API v1 in webhook config only when KIC >= 3.0.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * Support for `affinity` configuration has been added to migration job templates.
 * Display a warning message when Kong Manager is enabled and the Admin API is disabled.
+* Validate Gateway API's `Gateway` and `HTTPRoute` resources in the controller's
+  admission webhook only when KIC version is 3.0 or higher.
+  [#954](https://github.com/Kong/charts/pull/954)
 
 ## 2.32.0
 

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -104,7 +104,9 @@ webhooks:
     apiVersions:
     - 'v1alpha2'
     - 'v1beta1'
+{{- if (semverCompare ">= 3.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
     - 'v1'
+{{- end }}
     operations:
     - CREATE
     - UPDATE


### PR DESCRIPTION
#### What this PR does / why we need it:

Because of this configuration, KIC 2.12's admission webhook receives requests to validate v1 resources which it doesn't know about: 
```
msg="failed to run validation" error="unknown resource type to validate: gateway.networking.k8s.io/v1 gateways"
msg="failed to run validation" error="unknown resource type to validate: gateway.networking.k8s.io/v1 httproutes
``` 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
