### PR TITLE
chore(admission) remove GWAPI types from webhook

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,8 +4,16 @@
 
 ### Improvements
 
-* Support for `affinity` configuration has been added to migration job templates.
-* Display a warning message when Kong Manager is enabled and the Admin API is disabled.
+* Support for `affinity` configuration has been added to migration job
+  templates.
+  [#946](https://github.com/Kong/charts/pull/946)
+* Display a warning message when Kong Manager is enabled and the Admin API is
+  disabled.
+  [#951](https://github.com/Kong/charts/pull/951)
+* Removed GWAPI types from the admission webhook. These checks are not
+  necessary (they are either handled by resource-level validation or status
+  information) and are slated for removal in the controller.
+  [#956](https://github.com/Kong/charts/pull/956)
 
 ## 2.32.0
 

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -99,18 +99,6 @@ webhooks:
     - UPDATE
     resources:
     - ingresses
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - 'v1alpha2'
-    - 'v1beta1'
-    - 'v1'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
 {{- end }}
   clientConfig:
     {{- if not .Values.ingressController.admissionWebhook.certificate.provided }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove GWAPI types from the webhook. We plan to remove these in the controller (https://github.com/Kong/kubernetes-ingress-controller/issues/5197) and there's no clear need to continue using them. Since they currently cause a version compatibility issue (https://github.com/Kong/charts/pull/954) I'd like to just remove them preemptively. KIC hasn't changed yet, but those changes aren't a hard prereq to removing the webhook config.

Held pending confirmation that we don't need these.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
