### PR TITLE
chore(kong) bump proxy image version

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Improvements
 
+* Bumped Kong version to 3.5.
+  [#957](https://github.com/Kong/charts/pull/957)
 * Support for `affinity` configuration has been added to migration job templates.
 * Display a warning message when Kong Manager is enabled and the Admin API is disabled.
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -9,7 +9,7 @@ name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
 version: 2.32.0
-appVersion: "3.4"
+appVersion: "3.5"
 dependencies:
   - name: postgresql
     version: 11.9.13

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -609,7 +609,7 @@ directory.
 | Parameter                          | Description                                                                           | Default             |
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | image.repository                   | Kong image                                                                            | `kong`              |
-| image.tag                          | Kong image version                                                                    | `3.4`               |
+| image.tag                          | Kong image version                                                                    | `3.5`               |
 | image.effectiveSemver              | Semantic version to use for version-dependent features (if `tag` is not a semver)     |                     |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |

--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -145,7 +145,7 @@ extraLabels:
   konghq.com/component: quickstart
 image:
   repository: kong/kong-gateway
-  tag: "3.4"
+  tag: "3.5"
 ingressController:
   enabled: true
   env:

--- a/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/full-k4k8s-with-kong-enterprise.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.4"
+  tag: "3.5"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
+++ b/charts/kong/example-values/minimal-k4k8s-with-kong-enterprise.yaml
@@ -9,7 +9,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.4"
+  tag: "3.5"
 
 admin:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-controller.yaml
+++ b/charts/kong/example-values/minimal-kong-controller.yaml
@@ -2,7 +2,7 @@
 
 image:
   repository: kong
-  tag: "3.4"
+  tag: "3.5"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-dbless.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.4"
+  tag: "3.5"
 
 enterprise:
   enabled: true

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-control.yaml
@@ -14,7 +14,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.4"
+  tag: "3.5"
 
 env:
   database: postgres

--- a/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-enterprise-hybrid-data.yaml
@@ -12,7 +12,7 @@
 
 image:
   repository: kong/kong-gateway
-  tag: "3.4"
+  tag: "3.5"
 
 env:
   role: data_plane

--- a/charts/kong/example-values/minimal-kong-hybrid-control.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-control.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "3.4"
+  tag: "3.5"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-hybrid-data.yaml
+++ b/charts/kong/example-values/minimal-kong-hybrid-data.yaml
@@ -11,7 +11,7 @@
 
 image:
   repository: kong
-  tag: "3.4"
+  tag: "3.5"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/example-values/minimal-kong-standalone.yaml
+++ b/charts/kong/example-values/minimal-kong-standalone.yaml
@@ -6,7 +6,7 @@
 
 image:
   repository: kong
-  tag: "3.4"
+  tag: "3.5"
 
 env:
   prefix: /kong_prefix/

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -126,10 +126,10 @@ extraLabels: {}
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "3.4"
+  tag: "3.5"
   # Kong Enterprise
   # repository: kong/kong-gateway
-  # tag: "3.4"
+  # tag: "3.5"
 
   # Specify a semver version if your image tag is not one (e.g. "nightly")
   effectiveSemver:


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps the Kong version to 3.5.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
