### PR TITLE
Use mTLS by default for 3.x

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches:
       - main
-      - release/kong-2.x
+      - release/*
 
 jobs:
   lint:

--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - release/kong-2.x
+      - release/*
 
 jobs:
   lint-test:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -183,7 +183,7 @@ admin:
     # - caBundle (PEM-encoded certificate string).
     # If both are set, caBundle takes precedence.
     # If neither are set, and the controller uses generated client certificates
-    # ($.Values.ingressController.adminApi.tls.client.enabled=true and $.Values.ingressController.adminApi.tls.client.certProvided=false),
+    # (ingressController.adminApi.tls.client.enabled=true and ingressController.adminApi.tls.client.certProvided=false),
     # the chart will use the generated certificate's CA for the Kong admin API
     client:
       caBundle: ""

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -182,6 +182,9 @@ admin:
     # - secretName - the secret must contain a key named "tls.crt" with the PEM-encoded certificate.
     # - caBundle (PEM-encoded certificate string).
     # If both are set, caBundle takes precedence.
+    # If neither are set, and the controller uses generated client certificates
+    # ($.Values.ingressController.adminApi.tls.client.enabled=true and $.Values.ingressController.adminApi.tls.client.certProvided=false),
+    # the chart will use the generated certificate's CA for the Kong admin API
     client:
       caBundle: ""
       secretName: ""
@@ -718,7 +721,7 @@ ingressController:
     tls:
       client:
         # Enable TLS client authentication for the Admin API.
-        enabled: false
+        enabled: true
 
         # If set to false, Helm will generate certificates for you.
         # If set to true, you are expected to provide your own secret (see secretName, caSecretName).


### PR DESCRIPTION
#### What this PR does / why we need it:

Enables mTLS on the controller and admin API by default.

Changes the default gateway discovery strategy to `pod` for compatibility with generated certificates. This soft breaks compatibility with controllers older than 3.0 (you can disable mTLS but need to come up with your own approach to admin API security).

Uses the CA generated for the controller client certificate by default if no other CA is configured for the admin API.

#### Which issue this PR fixes

Part of the split chart work. Since we need to expose the admin API outside the Pod network, we need to protect it, and mTLS is a readily and universally available option for this.

I don't know of a great way to 

#### Special notes for your reviewer:

Going to 3.x for staging instead of main.

The original implementation and UX [has some issues](https://github.com/Kong/charts/issues/921#issuecomment-1830952573) that make this change a bit kludgy, but I'm on the fence about completely refactoring it and breaking existing config.

mTLS does have a one significant drawback: client certificates are generally annoying for human-use clients, and using them complicates using Manager and performing diagnostic admin API requests with curl. The generated certificate is particularly bad for this, since there's no mechanism to issue and distribute multiple certificates for the controller and other clients. You'd likely want to operate your own CA if you use Manager or the admin API regularly. I have not tested to see if mTLS introduces additional complications in Manager (beyond browser client certificates being generally annoying).

I don't have any great alternatives here. RBAC is a viable alternative that is simpler to use for non-controller requests, but is not universally available. An additional localhost-only HTTP listen would work for direct admin API requests with a port-forward, but would be a poor option for Manager use.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
