### PR TITLE
kong: only set `clusterIP` when `type` is `ClusterIP`

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+* Only set `Service` `clusterIP` when `type` is `ClusterIP`
 * Bumped Kong version to 3.5.
   [#957](https://github.com/Kong/charts/pull/957)
 * Support for `affinity` configuration has been added to migration job templates.

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -251,7 +251,7 @@ spec:
   {{- if .externalTrafficPolicy }}
   externalTrafficPolicy: {{ .externalTrafficPolicy }}
   {{- end }}
-  {{- if .clusterIP }}
+  {{- if (and (eq .type "ClusterIP") .clusterIP )}}
   clusterIP: {{ .clusterIP }}
   {{- end }}
   selector:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Only set `clusterIP` when `type` is `ClusterIP`. This will allow using e.g. `NodePort` in `ingress` chart.

#### Which issue this PR fixes
  - fixes #960

#### Special notes for your reviewer:

After this gets merged we can add a test case to `ingress` chart like so:

```yaml
controller:
  ingressController:
    env:
      anonymous_reports: "false"
    enabled: true
    image:
      repository: kong/kubernetes-ingress-controller

    gatewayDiscovery:
      enabled: true
    adminApi:
      tls:
        client:
          enabled: true

gateway:
  env:
    anonymous_reports: "off"
  admin:
    type: NodePort
  readinessProbe:
    initialDelaySeconds: 1
    timeoutSeconds: 1
    periodSeconds: 1
```

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
