### PR TITLE
fix(services) support non-None ClusterIP always

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Improvements
 
-* Only set `Service` `clusterIP` when `type` is `ClusterIP`
+* Only allow `None` ClusterIPs on ClusterIP-type Services.
+  [#961](https://github.com/Kong/charts/pull/961)
+  [#962](https://github.com/Kong/charts/pull/962)
 * Bumped Kong version to 3.5.
   [#957](https://github.com/Kong/charts/pull/957)
 * Support for `affinity` configuration has been added to migration job templates.

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -251,8 +251,10 @@ spec:
   {{- if .externalTrafficPolicy }}
   externalTrafficPolicy: {{ .externalTrafficPolicy }}
   {{- end }}
-  {{- if (and (eq .type "ClusterIP") .clusterIP )}}
+  {{- if .clusterIP }}
+  {{- if (or (not (eq .clusterIP "None")) (and (eq .type "ClusterIP") (eq .clusterIP "None"))) }}
   clusterIP: {{ .clusterIP }}
+  {{- end }}
   {{- end }}
   selector:
     {{- .selectorLabels | nindent 4 }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Support user-chosen ClusterIP values for all Service types so long as the ClusterIP value is not the special "None" value.

Support the "None" value when the Service type is ClusterIP.

#### Which issue this PR fixes

https://github.com/Kong/charts/pull/961#pullrequestreview-1765916969

#### Special notes for your reviewer:

Examples:

```
$ helm template ana /tmp/symkong --set admin.enabled=true --set admin.clusterIP=None --set admin.type=NodePort 2>/dev/null | grep -i clusterIP:
$ helm template ana /tmp/symkong --set admin.enabled=true --set admin.clusterIP=None --set admin.type=ClusterIP 2>/dev/null | grep -i clusterIP:
  clusterIP: None
$ helm template ana /tmp/symkong --set admin.enabled=true --set admin.clusterIP=10.0.0.1 --set admin.type=ClusterIP 2>/dev/null | grep -i clusterIP: 
  clusterIP: 10.0.0.1
$ helm template ana /tmp/symkong --set admin.enabled=true --set admin.clusterIP=10.0.0.1 --set admin.type=NodePort 2>/dev/null | grep -i clusterIP: 
  clusterIP: 10.0.0.1
$ helm template ana /tmp/symkong --set admin.enabled=true --set admin.type=NodePort 2>/dev/null | grep -i clusterIP: 
$ helm template ana /tmp/symkong --set admin.enabled=true --set admin.type=ClusterIP 2>/dev/null | grep -i clusterIP: 

```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
