### PR TITLE
feat: add KongServiceFacade RBACs, release kong/kong 2.33.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.33.0
 
 ### Improvements
 
@@ -11,6 +11,9 @@
 * Validate Gateway API's `Gateway` and `HTTPRoute` resources in the controller's
   admission webhook only when KIC version is 3.0 or higher.
   [#954](https://github.com/Kong/charts/pull/954)
+* Added controller's RBAC rules for `KongServiceFacade` CRD (installed only when
+  KongServiceFacade feature gate turned on and KIC version >= 3.1.0).
+  [#963](https://github.com/Kong/charts/pull/963)
 
 ## 2.32.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.32.0
+version: 2.33.0
 appVersion: "3.5"
 dependencies:
   - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1261,6 +1261,25 @@ role sets used in the charts. Updating these requires separating out cluster
 resource roles into their separate templates.
 */}}
 {{- define "kong.kubernetesRBACRules" -}}
+{{- if and (semverCompare ">= 3.1.0" (include "kong.effectiveVersion" .Values.ingressController.image))
+           (contains (print .Values.ingressController.env.feature_gates) "KongServiceFacade=true") }}
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}
 {{- if (semverCompare ">= 3.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
 - apiGroups:
   - configuration.konghq.com


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds `KongServiceFacade` RBAC rules and releases `kong/kong` 2.33.0. ~both charts (changed the `ingress`'s `Chart.yaml` to refer to `kong` by `file://` instead of `https://` which allows bumping both charts in a single commit).~

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5152.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
