### PR TITLE
chore(ingress): bump kong/kong dependency and release 0.10.0

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.10.0
+
+### Improvements
+
+- Bumped dependencies on `kong/kong` chart to `>=2.33.0`.
+  [#964](https://github.com/Kong/charts/pull/964)
+
 ## 0.9.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.31.0
+  version: 2.33.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.31.0
-digest: sha256:2897c91fb6e37c04f99a413dac85f991fed223591b8de327a04795e27b90a617
-generated: "2023-11-06T14:36:11.845865+01:00"
+  version: 2.33.0
+digest: sha256:b43f09a826e481bc227e39cc5a3f0da56f26e1444371d8bb96d94082ee35e2c2
+generated: "2023-12-06T14:55:20.682668+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.9.0
+version: 0.10.0
 appVersion: "3.4"
 dependencies:
   - name: kong
-    version: ">=2.31.0"
+    version: ">=2.33.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.31.0"
+    version: ">=2.33.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps `kong/kong` dependency in `kong/ingress` chart and releases 0.10.0.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
