### PR TITLE
fix(controller): use the renamed API group for incubator package

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.33.1
+
+### Fixed
+
+* Use changed `incubator.ingress-controller.konghq.com` API group name in `KongServiceFacade`
+  RBAC rules. Refer to [KIC#5302](https://github.com/Kong/kubernetes-ingress-controller/pull/5302)
+  for rename reasoning.
+  [#968](https://github.com/Kong/charts/pull/968)
+
 ## 2.33.0
 
 ### Improvements

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.33.0
+version: 2.33.1
 appVersion: "3.5"
 dependencies:
   - name: postgresql

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1266,7 +1266,7 @@ resource roles into their separate templates.
 {{- if and (semverCompare ">= 3.1.0" (include "kong.effectiveVersion" .Values.ingressController.image))
            (contains (print .Values.ingressController.env.feature_gates) "KongServiceFacade=true") }}
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades
   verbs:
@@ -1274,7 +1274,7 @@ resource roles into their separate templates.
   - list
   - watch
 - apiGroups:
-  - incubator.konghq.com
+  - incubator.ingress-controller.konghq.com
   resources:
   - kongservicefacades/status
   verbs:


### PR DESCRIPTION
#### What this PR does / why we need it:

Aligns the API group name for `KongServiceFacade` RBAC rules so it's matching after the rename https://github.com/Kong/kubernetes-ingress-controller/pull/5302. Releases a `kong/kong` 2.33.1 patch.

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5152.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
