### PR TITLE
fix(ingress): bump kong/kong dependencies to fix incubator API group

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.10.1
+
+### Fixed
+
+- Bumped dependencies on `kong/kong` chart to `>=2.33.1`. This fixes an API group
+  name of `KongServiceFacade` in the controller RBAC rules after a rename.
+  [#969](https://github.com/Kong/charts/pull/969)
+
 ## 0.10.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.33.0
+  version: 2.33.1
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.33.0
-digest: sha256:b43f09a826e481bc227e39cc5a3f0da56f26e1444371d8bb96d94082ee35e2c2
-generated: "2023-12-06T14:55:20.682668+01:00"
+  version: 2.33.1
+digest: sha256:6160eb2f7d11ae111187e0c8ad261eda5583ded7447ce641604dba9949fe8f2b
+generated: "2023-12-08T09:44:54.868948+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.10.0
+version: 0.10.1
 appVersion: "3.4"
 dependencies:
   - name: kong
-    version: ">=2.33.0"
+    version: ">=2.33.1"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.33.0"
+    version: ">=2.33.1"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps `kong/ingress` dependencies on `kong/kong` to >= `2.33.1` which introduced a fix for `KongServiceFacade` API group name that was changed before KIC 3.1 actual release.

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5152.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
