### PR TITLE
:bug:  fix converting YAML to JSON  after the addition of affinity in migrations

### DIFF
--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -78,7 +78,7 @@ spec:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.affinity }}
       affinity:
-      {{- toYaml .Values.affinity | indent 8 }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -80,7 +80,7 @@ spec:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.affinity }}
       affinity:
-      {{- toYaml .Values.affinity | indent 8 }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -88,7 +88,7 @@ spec:
       {{- include "kong.podsecuritycontext" . | nindent 8 }}
       {{- if .Values.affinity }}
       affinity:
-      {{- toYaml .Values.affinity | indent 8 }}
+      {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes

fixes the error when correctly converting from YAML to JSON

Error: YAML parse error on kong/templates/migrations-post-upgrade.yaml: error converting YAML to JSON: yaml: line 226: mapping values are not allowed in this context
helm.go:84: [debug] error converting YAML to JSON: yaml: line 226: mapping values are not allowed in this context
YAML parse error on kong/templates/migrations-post-upgrade.yaml

  - fixes #967 

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ X] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ X] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
