### PR TITLE
fix(kong): add RBAC rules for listing namespaces when gateway API is detected

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+* Add RBAC rules for get and list operations on namespaces so that Gateway API
+  controllers in KIC can access using a cached controller-runtime client.
+  [#974](https://github.com/Kong/charts/pull/974)
+
 ## 2.33.2
 
 * Fix a template bug related to the `affinity` field for migrations Pods.

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-* Add RBAC rules for get and list operations on namespaces so that Gateway API
+* Add RBAC rules for get, list and watch operations on namespaces so that Gateway API
   controllers in KIC can access using a cached controller-runtime client.
   [#974](https://github.com/Kong/charts/pull/974)
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1255,7 +1255,6 @@ Kubernetes namespace-scoped resources it uses to build Kong configuration.
 
 Collectively, these are built from:
 kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/rbac?ref=main
-kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/rbac/knative?ref=main
 kubectl kustomize github.com/kong/kubernetes-ingress-controller/config/rbac/gateway?ref=main
 
 However, there is no way to generate the split between cluster and namespaced
@@ -1675,6 +1674,13 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   verbs:
   - get
   - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
 {{- end }}
 - apiGroups:
   - networking.k8s.io

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1681,6 +1681,7 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   verbs:
   - get
   - list
+  - watch
 {{- end }}
 - apiGroups:
   - networking.k8s.io


### PR DESCRIPTION
#### What this PR does / why we need it:

This adds RBAC rules for listing namespaces. There's not way to detect if user has objects from particular API group present in the cluster so this can only be conditional on the presence of Gateway API CRDs in the cluster.

This could potentially be added (by refactoring) to https://github.com/Kong/charts/blob/72650f5768dde1867812fab42e863de7db60f80f/charts/kong/templates/controller-rbac-resources.yaml#L10-L18 but KIC doesn't need to list namespaces when users do not use Gateway API (and specifically namespace selectors).

Related controller-runtime issue describing why we need those permissions: https://github.com/kubernetes-sigs/controller-runtime/issues/1156

#### Which issue this PR fixes

Fixes #790

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
