### PR TITLE
Add post-install warning to docs AIO values.yaml file

### DIFF
--- a/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
+++ b/charts/kong/example-values/doc-examples/quickstart-enterprise-licensed-aio.yaml
@@ -1,3 +1,4 @@
+demo: true
 admin:
   annotations:
     konghq.com/protocol: https

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -27,7 +27,7 @@ Kong: https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/gettin
 
 {{- include "kong.deprecation-warnings" $warnings -}}
 
-{{- if contains "LoadBalancer" .Values.proxy.type -}}
+{{- if .Values.demo -}}
 
 #############################################################################################
 ##### WARNING: DEMO VALUES USED

--- a/charts/kong/templates/NOTES.txt
+++ b/charts/kong/templates/NOTES.txt
@@ -26,3 +26,17 @@ Kong: https://docs.konghq.com/kubernetes-ingress-controller/latest/guides/gettin
 {{- end -}}
 
 {{- include "kong.deprecation-warnings" $warnings -}}
+
+{{- if contains "LoadBalancer" .Values.proxy.type -}}
+
+#############################################################################################
+##### WARNING: DEMO VALUES USED
+#############################################################################################
+
+The values file used has been marked as a demo configuration.
+It should NOT be used in production without comprehensive review of all settings provided.
+
+#############################################################################################
+##### WARNING: DEMO VALUES USED
+#############################################################################################
+{{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a post-install warning if `demo: true` is set in `values.yaml`.

We've had several reports of the docs all-in-one Helm quickstart is misleading customers. This PR clearly marks it as "demo only"

Output:

![CleanShot 2024-01-09 at 13 08 53](https://github.com/Kong/charts/assets/59130/abce7c7f-6326-4f0d-9471-4339115731cc)


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md - N/A
- [ ] New or modified sections of values.yaml are documented in the README.md - N/A
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
