### PR TITLE
feat(listens) support multiple addresses and IPv6

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.34.0
+
 ### Added
 
 * The `envFrom` and `ingressController.envFrom` values.yaml keys now populate

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -9,6 +9,8 @@
   ConfigMap or Secret resource keys in bulk:
   https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
   [#987](https://github.com/Kong/charts/pull/987)
+* Kong listens now use both IPv4 and IPv6 addresses.
+  [#986](https://github.com/Kong/charts/pull/986)
 
 ## 2.33.3
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.33.3
+version: 2.34.0
 appVersion: "3.5"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -279,7 +279,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -291,7 +291,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-admin
         namespace: default
     spec:
@@ -314,7 +314,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -342,7 +342,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -369,7 +369,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -49,7 +49,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 0.0.0.0:8444 http2 ssl
+                          value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -75,7 +75,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -87,7 +87,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -168,7 +168,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 0.0.0.0:8444 http2 ssl
+                          value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -194,7 +194,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -206,7 +206,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -196,7 +196,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -222,7 +222,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -234,7 +234,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -310,7 +310,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -336,7 +336,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -348,7 +348,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -85,7 +85,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -109,7 +109,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -410,7 +410,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -659,7 +659,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -679,7 +679,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -744,7 +744,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -768,7 +768,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -785,7 +785,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -799,7 +799,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -828,7 +828,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -856,7 +856,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -872,7 +872,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -883,7 +883,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -412,7 +412,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -660,7 +660,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -679,7 +679,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -743,7 +743,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -766,7 +766,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -782,7 +782,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -795,7 +795,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -823,7 +823,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -850,7 +850,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -865,7 +865,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -875,7 +875,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -195,7 +195,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -223,7 +223,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -235,7 +235,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -311,7 +311,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -339,7 +339,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -351,7 +351,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -406,7 +406,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -432,7 +432,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -680,7 +680,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -699,7 +699,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -763,7 +763,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -786,7 +786,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -802,7 +802,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -824,7 +824,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -852,7 +852,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -879,7 +879,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -894,7 +894,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -904,7 +904,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -193,7 +193,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -219,7 +219,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -231,7 +231,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -307,7 +307,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -333,7 +333,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -345,7 +345,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -406,7 +406,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -434,7 +434,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -682,7 +682,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -701,7 +701,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -765,7 +765,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -788,7 +788,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -804,7 +804,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -826,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -854,7 +854,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -881,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -896,7 +896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -906,7 +906,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -193,7 +193,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -219,7 +219,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -231,7 +231,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -307,7 +307,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -333,7 +333,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -345,7 +345,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -406,7 +406,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -430,7 +430,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -678,7 +678,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -697,7 +697,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -761,7 +761,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -784,7 +784,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -800,7 +800,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -813,7 +813,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -841,7 +841,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -868,7 +868,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -883,7 +883,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -893,7 +893,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -193,7 +193,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -219,7 +219,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -231,7 +231,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -307,7 +307,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -333,7 +333,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -345,7 +345,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -406,7 +406,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -465,7 +465,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -713,7 +713,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -732,7 +732,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -796,7 +796,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -819,7 +819,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -835,7 +835,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -866,7 +866,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -894,7 +894,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -921,7 +921,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -936,7 +936,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -946,7 +946,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -193,7 +193,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -219,7 +219,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -231,7 +231,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -307,7 +307,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -333,7 +333,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -345,7 +345,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -406,7 +406,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -654,7 +654,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -673,7 +673,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -737,7 +737,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -760,7 +760,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -776,7 +776,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -789,7 +789,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -817,7 +817,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -844,7 +844,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -859,7 +859,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -869,7 +869,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: my-kong-sa
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -193,7 +193,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -219,7 +219,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -231,7 +231,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -307,7 +307,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -333,7 +333,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -345,7 +345,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -195,7 +195,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -223,7 +223,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -235,7 +235,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -311,7 +311,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -339,7 +339,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -351,7 +351,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.4.1

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -412,7 +412,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -660,7 +660,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -679,7 +679,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -743,7 +743,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -766,7 +766,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -782,7 +782,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -795,7 +795,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -823,7 +823,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -850,7 +850,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -865,7 +865,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -875,7 +875,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -33,7 +33,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -254,7 +254,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -282,7 +282,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -309,7 +309,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -48,7 +48,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -72,7 +72,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -84,7 +84,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -160,7 +160,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -184,7 +184,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -196,7 +196,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong/kong-gateway:3.4.0.0

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
                     environment: test
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -449,7 +449,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -475,7 +475,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -499,7 +499,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -747,7 +747,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -766,7 +766,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -830,7 +830,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -853,7 +853,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -869,7 +869,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -882,7 +882,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -910,7 +910,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -937,7 +937,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -952,7 +952,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -962,7 +962,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -206,7 +206,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -234,7 +234,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -246,7 +246,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -328,7 +328,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -356,7 +356,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -368,7 +368,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -84,7 +84,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -112,7 +112,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -725,7 +725,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -741,7 +741,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -982,7 +982,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -998,7 +998,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1241,7 +1241,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1257,7 +1257,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1494,7 +1494,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1518,7 +1518,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1561,7 +1561,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1580,7 +1580,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1644,7 +1644,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-default
         namespace: default
     rules:
@@ -1862,7 +1862,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1882,7 +1882,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-default
         namespace: default
     roleRef:
@@ -1908,7 +1908,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1930,7 +1930,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1946,7 +1946,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1974,7 +1974,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -2002,7 +2002,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -2037,7 +2037,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -2052,7 +2052,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: Service
@@ -2112,7 +2112,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -212,7 +212,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -249,7 +249,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -261,9 +261,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
                       image: kong:3.5
@@ -347,7 +347,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -384,7 +384,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -396,9 +396,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                       envFrom:
                         - configMapRef:
                             name: env-config
@@ -452,7 +452,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -489,7 +489,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -501,9 +501,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                       envFrom:
                         - configMapRef:
                             name: env-config
@@ -764,7 +764,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -801,7 +801,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -813,9 +813,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
                       envFrom:
@@ -871,7 +871,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -908,7 +908,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -920,9 +920,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
                       envFrom:
@@ -1021,7 +1021,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -1058,7 +1058,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -1070,9 +1070,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
                       envFrom:
@@ -1128,7 +1128,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -1165,7 +1165,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -1177,9 +1177,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
                       envFrom:
@@ -1280,7 +1280,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -1317,7 +1317,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -1329,9 +1329,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
                       envFrom:
@@ -1387,7 +1387,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -1424,7 +1424,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -1436,9 +1436,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
                       envFrom:

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -49,7 +49,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -77,7 +77,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -89,7 +89,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -169,7 +169,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -197,7 +197,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -209,7 +209,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -300,7 +300,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -312,7 +312,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -340,7 +340,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -367,7 +367,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -276,7 +276,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -309,7 +309,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -321,7 +321,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -349,7 +349,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -384,7 +384,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -49,7 +49,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -77,7 +77,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -89,9 +89,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
                       image: kong:3.5
@@ -173,7 +173,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -201,7 +201,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -213,9 +213,9 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -206,7 +206,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -243,7 +243,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -255,7 +255,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -337,7 +337,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -374,7 +374,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -386,7 +386,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5
@@ -428,7 +428,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -465,7 +465,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -477,7 +477,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                       image: kong:3.5
@@ -739,7 +739,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -776,7 +776,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -788,7 +788,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -832,7 +832,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -869,7 +869,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -881,7 +881,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -981,7 +981,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -1018,7 +1018,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -1030,7 +1030,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -1074,7 +1074,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -1111,7 +1111,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -1123,7 +1123,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -1225,7 +1225,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -1262,7 +1262,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -1274,7 +1274,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
@@ -1318,7 +1318,7 @@ SnapShot = """
                         - name: KONG_ADMIN_GUI_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl
+                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
                         - name: KONG_ANONYMOUS_REPORTS
                           value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
@@ -1355,7 +1355,7 @@ SnapShot = """
                         - name: KONG_PROXY_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, 0.0.0.0:8443 http2 ssl
+                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
                         - name: KONG_PROXY_STREAM_ACCESS_LOG
                           value: /dev/stdout basic
                         - name: KONG_PROXY_STREAM_ERROR_LOG
@@ -1367,7 +1367,7 @@ SnapShot = """
                         - name: KONG_STATUS_ERROR_LOG
                           value: /dev/stderr
                         - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100
+                          value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -111,7 +111,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -698,7 +698,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -714,7 +714,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -940,7 +940,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -956,7 +956,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1184,7 +1184,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1200,7 +1200,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.33.3
+                    helm.sh/chart: kong-2.34.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1422,7 +1422,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1446,7 +1446,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1694,7 +1694,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1713,7 +1713,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1777,7 +1777,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1803,7 +1803,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1818,7 +1818,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1834,7 +1834,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1862,7 +1862,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -1890,7 +1890,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1917,7 +1917,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -1932,7 +1932,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
 - object:
     apiVersion: v1
     kind: Service
@@ -1992,7 +1992,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.33.3
+            helm.sh/chart: kong-2.34.0
         name: chartsnap-kong
         namespace: default
 """


### PR DESCRIPTION
#### What this PR does / why we need it:
Configure default IPv6 listens for Kong listeners by default. The controller defaults are unchanged as the controller settings do not support multiple listen addresses. Note that this [diverges from upstream](https://github.com/Kong/kong/blob/a0710952e02a3f5dcd8a9892dce0437127fa47d3/kong.conf.default#L488): kong.conf.default _does not_ bind to IPv6.

Replace the hidden .address service setting with a new hidden .addresses setting. The new setting is a list whereas the old setting was a single string.

Honor address overrides for the admin listen. It previously forced you to the default 0.0.0.0 address or 127.0.0.1 when disabled.

#### Which issue this PR fixes

Fix #847.

Relevant to https://github.com/Kong/kubernetes-ingress-controller/issues/5138.

#### Special notes for your reviewer:

See [listen_tests.txt](https://github.com/Kong/charts/files/13970976/listen_tests.txt) for example settings using 
[values.yaml.txt](https://github.com/Kong/charts/files/13971043/values.yaml.txt)

Umbrella chart shenanigans mean we can't really check this in `ingress` easily. I stuffed the modified `kong` chart into 
[ingress.tar.gz](https://github.com/Kong/charts/files/13970989/ingress.tar.gz). It requires a nightly to actually work because of kic#5138:

```
helm install ana /tmp/symingress --set controller.ingressController.image.repository="kong/nightly-ingress-controller" --set controller.ingressController.image.tag="nightly" --set controller.ingressController.image.effectiveSemver=3.1.0
```

The old `address` field was never documented and AFAIK there shouldn't be much reason to use it (containers in Kubernetes shouldn't have reason to listen on anything other than all addresses or localhost only). The change to `addresses` is technically breaking but I'm considering it not so because it was effectively a developer-only setting.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
