### PR TITLE
feat(env) add support for envFrom

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+* The `envFrom` and `ingressController.envFrom` values.yaml keys now populate
+  the container field of the same name. This loads environment variables from
+  ConfigMap or Secret resource keys in bulk:
+  https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  [#987](https://github.com/Kong/charts/pull/987)
+
 ## 2.33.3
 
 ### Fixed

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -613,10 +613,11 @@ directory.
 | image.effectiveSemver              | Semantic version to use for version-dependent features (if `tag` is not a semver)     |                     |
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
-| replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true         | `1`                 |
+| replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true       | `1`                 |
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
-| customEnv                          | Custom Environment variables without `KONG_` prefix      |                                |
+| customEnv                          | Custom Environment variables without `KONG_` prefix                                   |                     |
+| envFrom                            | Populate environment variables from ConfigMap or Secret keys                          |                     |
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
 | migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false" |
@@ -741,6 +742,7 @@ section of `values.yaml` file:
 | installCRDs                                | Legacy toggle for Helm 2-style CRD management. Should not be set [unless necessary due to cluster permissions](#removing-cluster-scoped-permissions).    | false                              |
 | env                                        | Specify Kong Ingress Controller configuration via environment variables                                                                                  |                                    |
 | customEnv                                  | Specify custom environment variables (without the CONTROLLER_ prefix)                                                                                    |                                    |
+| envFrom                                    | Populate environment variables from ConfigMap or Secret keys                                                                                             |                                    |
 | ingressClass                               | The name of this controller's ingressClass                                                                                                               | kong                               |
 | ingressClassAnnotations                    | The ingress-class value for controller                                                                                                                   | kong                               |
 | args                                       | List of ingress-controller cli arguments                                                                                                                 | []                                 |

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -147,6 +147,9 @@ SnapShot = """
                           value: default
                         - name: TZ
                           value: Europe/Berlin
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong/kubernetes-ingress-controller:3.0
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
@@ -396,6 +399,9 @@ SnapShot = """
                           value: 0.0.0.0:8100
                         - name: KONG_STREAM_LISTEN
                           value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
@@ -498,6 +504,9 @@ SnapShot = """
                           value: 0.0.0.0:8100
                         - name: KONG_STREAM_LISTEN
                           value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: wait-for-db
@@ -809,6 +818,9 @@ SnapShot = """
                           value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: kong-migrations
@@ -913,6 +925,9 @@ SnapShot = """
                           value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
@@ -1060,6 +1075,9 @@ SnapShot = """
                           value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: kong-post-upgrade-migrations
@@ -1164,6 +1182,9 @@ SnapShot = """
                           value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
@@ -1313,6 +1334,9 @@ SnapShot = """
                           value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: kong-upgrade-migrations
@@ -1417,6 +1441,9 @@ SnapShot = """
                           value: 0.0.0.0:9000, 0.0.0.0:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
@@ -1884,6 +1911,13 @@ SnapShot = """
             helm.sh/chart: kong-2.33.3
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
+- object:
+    apiVersion: v1
+    data:
+        test-env: test
+    kind: ConfigMap
+    metadata:
+        name: env-config
 - object:
     apiVersion: v1
     data:

--- a/charts/kong/ci/test2-values.yaml
+++ b/charts/kong/ci/test2-values.yaml
@@ -11,6 +11,9 @@ ingressController:
     timeoutSeconds: 5
   env:
     anonymous_reports: "false"
+  envFrom:
+  - configMapRef:
+      name: env-config
   customEnv:
     TZ: "Europe/Berlin"
   watchNamespaces:
@@ -23,6 +26,9 @@ postgresql:
 env:
   anonymous_reports: "off"
   database: "postgres"
+envFrom:
+- configMapRef:
+    name: env-config
 # - ingress resources are created without hosts
 admin:
   ingress:
@@ -63,3 +69,11 @@ deployment:
         requests:
           cpu: "100m"
           memory: "64Mi"
+
+extraObjects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: env-config
+  data:
+    test-env: test

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -827,6 +827,7 @@ The name of the Service which will be used by the controller to update the Ingre
   {{ toYaml .Values.containerSecurityContext | nindent 4 }}
   env:
   {{- include "kong.env" . | nindent 2 }}
+  {{- include "kong.envFrom" .Values.envFrom | nindent 2 }}
 {{/* TODO the prefix override is to work around https://github.com/Kong/charts/issues/295
      Note that we use args instead of command here to /not/ override the standard image entrypoint. */}}
   args: [ "/bin/bash", "-c", "export KONG_NGINX_DAEMON=on KONG_PREFIX=`mktemp -d` KONG_KEYRING_ENABLED=off; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop"]
@@ -891,6 +892,7 @@ The name of the Service which will be used by the controller to update the Ingre
         apiVersion: v1
         fieldPath: metadata.namespace
 {{- include "kong.ingressController.env" .  | indent 2 }}
+{{ include "kong.envFrom" .Values.ingressController.envFrom | indent 2 }}
   image: {{ include "kong.getRepoTag" .Values.ingressController.image }}
   imagePullPolicy: {{ .Values.image.pullPolicy }}
 {{/* disableReadiness is a hidden setting to drop this block entirely for use with a debugger
@@ -1222,6 +1224,7 @@ Environment variables are sorted alphabetically
   imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
   env:
   {{- include "kong.no_daemon_env" . | nindent 2 }}
+  {{- include "kong.envFrom" .Values.envFrom | nindent 2 }}
   command: [ "bash", "/wait_postgres/wait.sh" ]
   volumeMounts:
   - name: {{ template "kong.fullname" . }}-bash-wait-for-postgres
@@ -1737,4 +1740,12 @@ extensions/v1beta1
     {{- end -}}
 {{- end -}}
 {{- (toYaml $proxyReadiness) -}}
+{{- end -}}
+
+{{- define "kong.envFrom" -}}
+  {{- if (gt (len .) 0) -}}
+envFrom:
+{{- toYaml . | nindent 2 -}}
+  {{- else -}}
+  {{- end -}}
 {{- end -}}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -101,6 +101,7 @@ spec:
         - "$KONG_PREFIX/pids"
         env:
         {{- include "kong.env" . | nindent 8 }}
+        {{- include "kong.envFrom" .Values.envFrom | nindent 8 }}
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
         {{- if .Values.deployment.initContainers }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -68,6 +68,7 @@ spec:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }} 
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
+        {{- include "kong.envFrom" .Values.envFrom | nindent 8 }}
         args: [ "kong", "migrations", "finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -70,6 +70,7 @@ spec:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
+        {{- include "kong.envFrom" .Values.envFrom | nindent 8 }}
         args: [ "kong", "migrations", "up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -78,6 +78,7 @@ spec:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }} 
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
+        {{- include "kong.envFrom" .Values.envFrom | nindent 8 }}
         args: [ "kong", "migrations", "bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -120,6 +120,10 @@ env:
 #         name: api_key
 #   client_name: testClient
 
+# Load all ConfigMap or Secret keys as environment variables:
+# https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+envFrom: []
+
 # This section can be used to configure some extra labels that will be added to each Kubernetes object generated.
 extraLabels: {}
 
@@ -564,6 +568,10 @@ ingressController:
   # Example as below, uncomment if required and add additional attributes as required.
   # customEnv:
   #   TZ: "Europe/Berlin"
+
+  # Load all ConfigMap or Secret keys as environment variables:
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  envFrom: []
 
   admissionWebhook:
     enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:
Add envFrom and ingressController.envFrom values. These populate the standard container envFrom field, which contains a list of ConfigMap or Secret refs. Keys and values from the referenced resources are set as environment variables in the containers.

#### Which issue this PR fixes

Aha idea KIC-I-52 from @felderi 

#### Special notes for your reviewer:

The root-level `envFrom` violates the modern rule about placing config for the Deployment under the `deployment` key. I put it there for consistency with the existing `env` and `customEnv` values.

This uses the `envFrom` key to populate `envFrom` in the Deployment Kong container as well as the init containers and migrations containers. Several of these only appear in DB mode. test2-values uses Postgres and the the controller, so it hits every use of this value in templates.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
