### PR TITLE
fix: explicitly define status port in controller container

### DIFF
--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -158,6 +158,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -157,6 +157,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -155,6 +155,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -155,6 +155,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -155,6 +155,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -155,6 +155,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -155,6 +155,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -157,6 +157,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -159,6 +159,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -170,6 +170,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -162,6 +162,9 @@ SnapShot = """
                         - containerPort: 10255
                           name: cmetrics
                           protocol: TCP
+                        - containerPort: 10254
+                          name: status
+                          protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
                         httpGet:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -890,6 +890,9 @@ The name of the Service which will be used by the controller to update the Ingre
     containerPort: 10255
     protocol: TCP
   {{- end }}
+  - name: status
+    containerPort: 10254
+    protocol: TCP
   env:
   - name: POD_NAME
     valueFrom:


### PR DESCRIPTION
#### What this PR does / why we need it:

Port used for liveness and readiness probes was not explicitly defined in the controller's container.

#### Which issue this PR fixes
Issue found by kube-lint in https://github.com/Kong/charts/pull/988.


#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
