### PR TITLE
feat: add RBAC rules for KongVault

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-Nothing yet.
+### Added 
+
+* Added controller's RBAC rules for `KongVault` CRD (installed only when KIC
+  version >= 3.1.0).
+  [#992](https://github.com/Kong/charts/pull/992)
 
 ## 2.34.0
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1647,6 +1647,16 @@ of a Role or ClusterRole) that provide the ingress controller access to the
 Kubernetes Cluster-scoped resources it uses to build Kong configuration.
 */}}
 {{- define "kong.kubernetesRBACClusterRules" -}}
+{{- if (semverCompare ">= 3.1.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongvaults
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
 - apiGroups:
   - configuration.konghq.com
   resources:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1656,6 +1656,14 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   - get
   - list
   - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongvaults/status
+  verbs:
+  - get
+  - patch
+  - update
 {{- end }}
 - apiGroups:
   - configuration.konghq.com


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a cluster RBAC rule for KongVault to be installed when KIC version >= 3.1.0. 

#### Which issue this PR fixes

Fixes https://github.com/Kong/kubernetes-ingress-controller/issues/5471.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
