### PR TITLE
fix(env) add missing envFrom render and release 2.35

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 ## Unreleased
 
+Nothing yet.
+
+## 2.35.0
+
 ### Added 
 
 * Added controller's RBAC rules for `KongVault` CRD (installed only when KIC
   version >= 3.1.0).
   [#992](https://github.com/Kong/charts/pull/992)
+
+### Fixed
+
+* Added a missing `envFrom` render in the main Kong proxy container.
+  [#994](https://github.com/Kong/charts/pull/994)
 
 ## 2.34.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.34.0
+version: 2.34.1
 appVersion: "3.5"
 dependencies:
   - name: postgresql

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.34.1
+version: 2.35.0
 appVersion: "3.5"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -279,7 +279,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -291,7 +291,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-admin
         namespace: default
     spec:
@@ -314,7 +314,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -342,7 +342,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -369,7 +369,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -85,7 +85,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -109,7 +109,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -413,7 +413,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -662,7 +662,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -682,7 +682,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -747,7 +747,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -771,7 +771,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -788,7 +788,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -802,7 +802,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -831,7 +831,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -859,7 +859,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -875,7 +875,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -886,7 +886,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -415,7 +415,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -663,7 +663,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -682,7 +682,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -746,7 +746,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -769,7 +769,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -785,7 +785,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -798,7 +798,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -826,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -853,7 +853,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -868,7 +868,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -878,7 +878,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -409,7 +409,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -435,7 +435,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -683,7 +683,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -702,7 +702,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -766,7 +766,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -789,7 +789,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -805,7 +805,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -827,7 +827,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -855,7 +855,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -882,7 +882,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -897,7 +897,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -907,7 +907,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -409,7 +409,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -437,7 +437,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -685,7 +685,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -704,7 +704,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -768,7 +768,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -791,7 +791,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -807,7 +807,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -829,7 +829,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -857,7 +857,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -884,7 +884,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -899,7 +899,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -909,7 +909,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -409,7 +409,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -433,7 +433,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -681,7 +681,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -700,7 +700,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -764,7 +764,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -787,7 +787,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -803,7 +803,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -816,7 +816,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -844,7 +844,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -871,7 +871,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -886,7 +886,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -896,7 +896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -409,7 +409,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -468,7 +468,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -716,7 +716,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -735,7 +735,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -799,7 +799,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -822,7 +822,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -838,7 +838,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -869,7 +869,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -897,7 +897,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -924,7 +924,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -939,7 +939,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -949,7 +949,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -409,7 +409,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -657,7 +657,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -676,7 +676,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -740,7 +740,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -763,7 +763,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -779,7 +779,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -792,7 +792,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -820,7 +820,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -847,7 +847,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -862,7 +862,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -872,7 +872,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: my-kong-sa
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -415,7 +415,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -663,7 +663,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -682,7 +682,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -746,7 +746,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -769,7 +769,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -785,7 +785,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -798,7 +798,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -826,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -853,7 +853,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -868,7 +868,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -878,7 +878,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -33,7 +33,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -254,7 +254,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -282,7 +282,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -309,7 +309,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
                     environment: test
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -452,7 +452,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -478,7 +478,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -502,7 +502,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -750,7 +750,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -769,7 +769,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -833,7 +833,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -856,7 +856,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -872,7 +872,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -885,7 +885,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -913,7 +913,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -940,7 +940,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -955,7 +955,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -965,7 +965,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -84,7 +84,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -112,7 +112,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -269,6 +269,9 @@ SnapShot = """
                           value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
+                      envFrom:
+                        - configMapRef:
+                            name: env-config
                       image: kong:3.5
                       imagePullPolicy: IfNotPresent
                       lifecycle:
@@ -728,7 +731,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -744,7 +747,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -985,7 +988,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -1001,7 +1004,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1244,7 +1247,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1260,7 +1263,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1497,7 +1500,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1521,7 +1524,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1564,7 +1567,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1583,7 +1586,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1647,7 +1650,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-default
         namespace: default
     rules:
@@ -1865,7 +1868,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1885,7 +1888,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-default
         namespace: default
     roleRef:
@@ -1911,7 +1914,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1933,7 +1936,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1949,7 +1952,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1977,7 +1980,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -2005,7 +2008,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -2040,7 +2043,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -2055,7 +2058,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: Service
@@ -2115,7 +2118,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -300,7 +300,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -312,7 +312,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -340,7 +340,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -367,7 +367,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -276,7 +276,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -309,7 +309,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -321,7 +321,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -349,7 +349,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -384,7 +384,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -111,7 +111,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -701,7 +701,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -717,7 +717,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -943,7 +943,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -959,7 +959,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1187,7 +1187,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1203,7 +1203,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.34.0
+                    helm.sh/chart: kong-2.35.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1425,7 +1425,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1449,7 +1449,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1697,7 +1697,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1716,7 +1716,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1780,7 +1780,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1806,7 +1806,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1821,7 +1821,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1837,7 +1837,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1865,7 +1865,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -1893,7 +1893,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1920,7 +1920,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -1935,7 +1935,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
 - object:
     apiVersion: v1
     kind: Service
@@ -1995,7 +1995,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.34.0
+            helm.sh/chart: kong-2.35.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -137,6 +137,7 @@ spec:
         {{ toYaml .Values.containerSecurityContext | nindent 10 }}
         env:
         {{- include "kong.no_daemon_env" . | nindent 8 }}
+        {{- include "kong.envFrom" .Values.envFrom | nindent 8 }}
         lifecycle:
           {{- toYaml .Values.lifecycle | nindent 10 }}
         ports:


### PR DESCRIPTION
#### What this PR does / why we need it:

Earlier `envFrom` addition only got the init container of the main Deployment. This adds it to the regular proxy container.

Releases 2.35.

#### Which issue this PR fixes

Reported in chat.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
