### PR TITLE
Drop empty plugin defaults and release 2.35.1

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 Nothing yet.
 
+## 2.35.1
+
+### Fixed
+
+* The plugin helper no longer sets the plugin list when not in use.
+  [#1002](https://github.com/Kong/charts/pull/1002)
+
 ## 2.35.0
 
 ### Added 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.35.0
+version: 2.35.1
 appVersion: "3.5"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -60,8 +60,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -179,8 +177,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -279,7 +275,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -291,7 +287,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-admin
         namespace: default
     spec:
@@ -314,7 +310,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -342,7 +338,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -369,7 +365,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -85,7 +85,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -109,7 +109,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -210,8 +210,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -324,8 +322,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -413,7 +409,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -662,7 +658,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -682,7 +678,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -747,7 +743,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -771,7 +767,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -788,7 +784,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -802,7 +798,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -831,7 +827,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -859,7 +855,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -875,7 +871,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -886,7 +882,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -211,8 +211,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -327,8 +325,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -415,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -663,7 +659,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -682,7 +678,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -746,7 +742,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -769,7 +765,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -785,7 +781,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -798,7 +794,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -826,7 +822,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -853,7 +849,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -868,7 +864,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -878,7 +874,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -207,8 +207,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -321,8 +319,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -409,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -435,7 +431,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -683,7 +679,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -702,7 +698,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -766,7 +762,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -789,7 +785,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -805,7 +801,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -827,7 +823,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -855,7 +851,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -882,7 +878,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -897,7 +893,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -907,7 +903,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -207,8 +207,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -321,8 +319,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -409,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -437,7 +433,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -685,7 +681,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -704,7 +700,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -768,7 +764,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -791,7 +787,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -807,7 +803,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -829,7 +825,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -857,7 +853,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -884,7 +880,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -899,7 +895,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -909,7 +905,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -207,8 +207,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -321,8 +319,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -409,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -433,7 +429,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -681,7 +677,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -700,7 +696,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -764,7 +760,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -787,7 +783,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -803,7 +799,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -816,7 +812,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -844,7 +840,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -871,7 +867,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -886,7 +882,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -896,7 +892,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -207,8 +207,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -321,8 +319,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -409,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -468,7 +464,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -716,7 +712,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -735,7 +731,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -799,7 +795,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -822,7 +818,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -838,7 +834,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -869,7 +865,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -897,7 +893,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -924,7 +920,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -939,7 +935,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -949,7 +945,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -207,8 +207,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -321,8 +319,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -409,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -657,7 +653,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -676,7 +672,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -740,7 +736,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -763,7 +759,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -779,7 +775,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -792,7 +788,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -820,7 +816,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -847,7 +843,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -862,7 +858,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -872,7 +868,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: my-kong-sa
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -211,8 +211,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -327,8 +325,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -415,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -663,7 +659,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -682,7 +678,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -746,7 +742,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -769,7 +765,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -785,7 +781,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -798,7 +794,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -826,7 +822,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -853,7 +849,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -868,7 +864,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -878,7 +874,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -33,7 +33,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -57,8 +57,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -169,8 +167,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -254,7 +250,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -282,7 +278,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -309,7 +305,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
                     environment: test
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -222,8 +222,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -344,8 +342,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -452,7 +448,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -478,7 +474,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -502,7 +498,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -750,7 +746,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -769,7 +765,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -833,7 +829,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -856,7 +852,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -872,7 +868,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -885,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -913,7 +909,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -940,7 +936,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -955,7 +951,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -965,7 +961,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -84,7 +84,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -112,7 +112,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -237,8 +237,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -375,8 +373,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -480,8 +476,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -731,7 +725,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -747,7 +741,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -792,8 +786,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -899,8 +891,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -988,7 +978,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -1004,7 +994,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1049,8 +1039,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -1156,8 +1144,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -1247,7 +1233,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1263,7 +1249,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1308,8 +1294,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -1415,8 +1399,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -1500,7 +1482,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1524,7 +1506,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1567,7 +1549,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1586,7 +1568,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1650,7 +1632,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-default
         namespace: default
     rules:
@@ -1868,7 +1850,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1888,7 +1870,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-default
         namespace: default
     roleRef:
@@ -1914,7 +1896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1936,7 +1918,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1952,7 +1934,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1980,7 +1962,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -2008,7 +1990,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -2043,7 +2025,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -2058,7 +2040,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: Service
@@ -2118,7 +2100,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -62,8 +62,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -182,8 +180,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -300,7 +296,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -312,7 +308,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -340,7 +336,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -367,7 +363,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -62,8 +62,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -186,8 +184,6 @@ SnapShot = """
                           value: /opt/?.lua;/opt/?/init.lua;;
                         - name: KONG_NGINX_WORKER_PROCESSES
                           value: \"2\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -276,7 +272,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -309,7 +305,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -321,7 +317,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -349,7 +345,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -384,7 +380,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     spec:
@@ -111,7 +111,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -231,8 +231,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -362,8 +360,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -453,8 +449,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -701,7 +695,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -717,7 +711,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -764,8 +758,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -857,8 +849,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -943,7 +933,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -959,7 +949,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1006,8 +996,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -1099,8 +1087,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -1187,7 +1173,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1203,7 +1189,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.0
+                    helm.sh/chart: kong-2.35.1
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1250,8 +1236,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -1343,8 +1327,6 @@ SnapShot = """
                                 name: chartsnap-postgresql
                         - name: KONG_PG_PORT
                           value: \"5432\"
-                        - name: KONG_PLUGINS
-                          value: bundled
                         - name: KONG_PORTAL_API_ACCESS_LOG
                           value: /dev/stdout
                         - name: KONG_PORTAL_API_ERROR_LOG
@@ -1425,7 +1407,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1449,7 +1431,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1697,7 +1679,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1716,7 +1698,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1780,7 +1762,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1806,7 +1788,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1821,7 +1803,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1837,7 +1819,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1865,7 +1847,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -1893,7 +1875,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1920,7 +1902,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -1935,7 +1917,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
 - object:
     apiVersion: v1
     kind: Service
@@ -1995,7 +1977,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.0
+            helm.sh/chart: kong-2.35.1
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1158,7 +1158,9 @@ the template that it itself is using form the above sections.
 {{- end }}
 {{- end }}
 
+{{- if (.Values.plugins) }}
 {{- $_ := set $autoEnv "KONG_PLUGINS" (include "kong.plugins" .) -}}
+{{- end }}
 
 {{/*
     ====== USER-SET ENVIRONMENT VARIABLES ======


### PR DESCRIPTION
#### What this PR does / why we need it:

Do not set KONG_PLUGINS if no plugins are configured.

Release 2.35.1.

#### Which issue this PR fixes

Cannot override KONG_PLUGINS with a reference under `env` or a value loaded from a ConfigMap in envFrom.

#### Special notes for your reviewer:

Previously, the plugins helper would set `KONG_PLUGINS` to its default value (`bundled`) if no plugins were configured. There's no need for this (it just mirrors the upstream kong.conf default), but the template (maybe) needed to return something to not send `KONG_PLUGINS=""` (dunno if this actually tells the plugins loader to load nothing or if it defaults to bundled anyway, but whatever).

This change conditions automatic population on the presence of anything under the `plugins` value: if there are no plugins, it sets nothing and the proxy uses its native defaults.

Helm (rather, Sprig) has a rather pernicious claim that the `mergeOverwrite` function uses its highest-precedence merge value, but this isn't actually true: it relies on mergo, which has a more [Go-like understanding of types](https://github.com/darccio/mergo/blob/cde9f0ea26cccb1168ee3900cf8ca457bb928c3c/merge.go#L392-L394) and doesn't allow you to override with non-like types. Sprig uses a ["oops, didn't actually merge? who cares! fail silently."](https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/dict.go#L109-L117) approach, so if the lower-priority input is a different type (`"bundled"` is a string, and a `valueFrom` is a `map[string]interface{}`), it actually gives up and uses the lower-priority value.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
