### PR TITLE
kong: add RBACs for KongLicense

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## Unreleased
+## 2.36.0
 
-Nothing yet.
+### Fixed
+
+* Add `KongLicense` RBAC rules.
+  [#1006](https://github.com/Kong/charts/pull/1006)
 
 ## 2.35.1
 
@@ -13,7 +16,7 @@ Nothing yet.
 
 ## 2.35.0
 
-### Added 
+### Added
 
 * Added controller's RBAC rules for `KongVault` CRD (installed only when KIC
   version >= 3.1.0).

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.35.1
+version: 2.36.0
 appVersion: "3.5"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -275,7 +275,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -287,7 +287,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-admin
         namespace: default
     spec:
@@ -310,7 +310,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -338,7 +338,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -365,7 +365,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -411,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -659,7 +659,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -678,7 +678,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -742,7 +742,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -765,7 +765,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -781,7 +781,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -794,7 +794,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -822,7 +822,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -849,7 +849,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -864,7 +864,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -874,7 +874,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -431,7 +431,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -679,7 +679,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -698,7 +698,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -762,7 +762,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -785,7 +785,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -801,7 +801,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -823,7 +823,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -851,7 +851,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -878,7 +878,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -893,7 +893,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -903,7 +903,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -433,7 +433,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -681,7 +681,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -700,7 +700,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -764,7 +764,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -787,7 +787,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -803,7 +803,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -825,7 +825,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -853,7 +853,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -880,7 +880,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -895,7 +895,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -905,7 +905,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -429,7 +429,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -677,7 +677,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -696,7 +696,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -760,7 +760,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -783,7 +783,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -799,7 +799,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -812,7 +812,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -840,7 +840,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -867,7 +867,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -882,7 +882,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -892,7 +892,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -464,7 +464,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -712,7 +712,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -731,7 +731,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -795,7 +795,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -818,7 +818,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -834,7 +834,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -865,7 +865,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -893,7 +893,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -920,7 +920,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -935,7 +935,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -945,7 +945,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -1,11 +1,10 @@
-[custom-labels-values]
+['kong-ingress-5-3.1-rbac-values']
 SnapShot = """
 - object:
     apiVersion: admissionregistration.k8s.io/v1
     kind: ValidatingWebhookConfiguration
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -79,7 +78,6 @@ SnapShot = """
     kind: Deployment
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/component: app
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
@@ -102,7 +100,6 @@ SnapShot = """
                     kuma.io/service-account-token-volume: chartsnap-kong-token
                     traffic.sidecar.istio.io/includeInboundPorts: \"\"
                 labels:
-                    acme.com/some-key: some-value
                     app: chartsnap-kong
                     app.kubernetes.io/component: app
                     app.kubernetes.io/instance: chartsnap
@@ -128,6 +125,8 @@ SnapShot = """
                                 fieldPath: metadata.namespace
                         - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
                           value: 0.0.0.0:8080
+                        - name: CONTROLLER_ANONYMOUS_REPORTS
+                          value: \"false\"
                         - name: CONTROLLER_ELECTION_ID
                           value: kong-ingress-controller-leader-kong
                         - name: CONTROLLER_INGRESS_CLASS
@@ -138,7 +137,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1.0
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -200,6 +199,8 @@ SnapShot = """
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
                           value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+                        - name: KONG_ANONYMOUS_REPORTS
+                          value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -312,6 +313,8 @@ SnapShot = """
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
                           value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+                        - name: KONG_ANONYMOUS_REPORTS
+                          value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -404,7 +407,6 @@ SnapShot = """
     kind: ClusterRole
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -620,6 +622,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -653,7 +687,6 @@ SnapShot = """
     kind: ClusterRoleBinding
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -673,7 +706,6 @@ SnapShot = """
     kind: Role
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -738,7 +770,6 @@ SnapShot = """
     kind: RoleBinding
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -762,7 +793,6 @@ SnapShot = """
     kind: Secret
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -779,7 +809,6 @@ SnapShot = """
     kind: Secret
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -793,7 +822,6 @@ SnapShot = """
     kind: Service
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -821,7 +849,6 @@ SnapShot = """
     kind: Service
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -850,7 +877,6 @@ SnapShot = """
     kind: Service
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
@@ -865,7 +891,6 @@ SnapShot = """
               protocol: TCP
               targetPort: webhook
         selector:
-            acme.com/some-key: some-value
             app.kubernetes.io/component: app
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
@@ -877,7 +902,6 @@ SnapShot = """
     kind: ServiceAccount
     metadata:
         labels:
-            acme.com/some-key: some-value
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -653,7 +653,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -672,7 +672,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -736,7 +736,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -759,7 +759,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -775,7 +775,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -788,7 +788,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -816,7 +816,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -843,7 +843,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -858,7 +858,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -868,7 +868,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: my-kong-sa
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -411,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -659,7 +659,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -678,7 +678,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -742,7 +742,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -765,7 +765,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -781,7 +781,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -794,7 +794,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -822,7 +822,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -849,7 +849,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -864,7 +864,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -874,7 +874,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -33,7 +33,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -250,7 +250,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -278,7 +278,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -305,7 +305,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
                     environment: test
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -448,7 +448,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -474,7 +474,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -498,7 +498,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -746,7 +746,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -765,7 +765,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -829,7 +829,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -852,7 +852,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -868,7 +868,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -881,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -909,7 +909,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -936,7 +936,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -951,7 +951,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -961,7 +961,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -84,7 +84,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -112,7 +112,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -725,7 +725,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -741,7 +741,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -978,7 +978,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -994,7 +994,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1233,7 +1233,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1249,7 +1249,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1482,7 +1482,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1506,7 +1506,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1549,7 +1549,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1568,7 +1568,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1632,7 +1632,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-default
         namespace: default
     rules:
@@ -1850,7 +1850,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1870,7 +1870,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-default
         namespace: default
     roleRef:
@@ -1896,7 +1896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1918,7 +1918,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1934,7 +1934,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1962,7 +1962,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -1990,7 +1990,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -2025,7 +2025,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -2040,7 +2040,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: Service
@@ -2100,7 +2100,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -296,7 +296,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -308,7 +308,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -336,7 +336,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -363,7 +363,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -272,7 +272,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -305,7 +305,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -317,7 +317,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -345,7 +345,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -380,7 +380,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -111,7 +111,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -695,7 +695,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -711,7 +711,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -933,7 +933,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -949,7 +949,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1173,7 +1173,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1189,7 +1189,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.35.1
+                    helm.sh/chart: kong-2.36.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1407,7 +1407,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1431,7 +1431,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1679,7 +1679,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1698,7 +1698,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1762,7 +1762,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1788,7 +1788,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1803,7 +1803,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1819,7 +1819,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1847,7 +1847,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -1875,7 +1875,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1902,7 +1902,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -1917,7 +1917,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
 - object:
     apiVersion: v1
     kind: Service
@@ -1977,7 +1977,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.35.1
+            helm.sh/chart: kong-2.36.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/kong-ingress-5-3.1-rbac-values.yaml
+++ b/charts/kong/ci/kong-ingress-5-3.1-rbac-values.yaml
@@ -1,0 +1,7 @@
+env:
+  anonymous_reports: "off"
+ingressController:
+  env:
+    anonymous_reports: "false"
+  image:
+    tag: "3.1.0"

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1641,6 +1641,24 @@ resource roles into their separate templates.
   - get
   - list
   - watch
+{{- if (semverCompare ">= 3.1.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
#### What this PR does / why we need it:

Add [`KongLicense`](https://docs.konghq.com/kubernetes-ingress-controller/latest/reference/custom-resources/#konglicense) RBAC rules from https://github.com/Kong/kubernetes-ingress-controller/blob/cf9900489e89eb8c8dc4c7c93aeb240698891cc3/config/rbac/role.yaml#L124-L139

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
