### PR TITLE
ci: bump helm setup action

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -46,9 +46,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.0
+        uses: azure/setup-helm@v4.0.0
 
       - name: Add Helm repos
         run: |
@@ -97,9 +95,7 @@ jobs:
           fetch-depth: 0
 
       - name: setup helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.0
+        uses: azure/setup-helm@v4.0.0
 
       - name: setup testing environment (kind-cluster)
         env:
@@ -142,9 +138,7 @@ jobs:
           fetch-depth: 0
 
       - name: setup helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.0
+        uses: azure/setup-helm@v4.0.0
 
       - name: setup testing environment (kind-cluster)
         run: ./scripts/test-env.sh
@@ -167,9 +161,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.0
+        uses: azure/setup-helm@v4.0.0
 
       - name: build helm chart dependency
         run: |

--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -21,9 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.0
+        uses: azure/setup-helm@v4.0.0
 
       - uses: actions/setup-python@v5
         with:
@@ -73,9 +71,7 @@ jobs:
 
       # See https://github.com/helm/chart-releaser-action/issues/6
       - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.0
+        uses: azure/setup-helm@v4.0.0
 
       - name: Add dependency chart repos
         run: |


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump helm setup action to prevent the following warnings on CI

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: azure/setup-helm@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
