### PR TITLE
feat: bump KIC to 3.1, update CRDs and bump Kong to 3.6

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.37.0
+
+### Changes
+
+* Bumped default `kong/kubernetes-ingress-controller` image tag and updated CRDs to 3.1.
+  [#1011](https://github.com/Kong/charts/pull/1011)
+* Bumped default `kong` image tag to 3.6.
+  [#1011](https://github.com/Kong/charts/pull/1011)
+
 ## 2.36.0
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -9,7 +9,7 @@ name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
 version: 2.37.0
-appVersion: "3.5"
+appVersion: "3.6"
 dependencies:
   - name: postgresql
     version: 11.9.13

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.36.0
+version: 2.37.0
 appVersion: "3.5"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -33,9 +33,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -274,7 +274,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
@@ -286,7 +286,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-admin
         namespace: default
@@ -309,7 +309,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -336,7 +336,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -364,7 +364,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -90,7 +90,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -205,7 +205,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -275,7 +275,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -287,7 +287,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-admin
         namespace: default
     spec:
@@ -310,7 +310,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -338,7 +338,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -365,7 +365,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -84,7 +84,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -108,9 +108,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -408,7 +408,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -689,7 +689,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -709,7 +709,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -774,7 +774,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -798,7 +798,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -815,7 +815,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -829,7 +829,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -857,7 +857,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -886,7 +886,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -902,7 +902,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -913,7 +913,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -85,7 +85,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -109,7 +109,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -138,7 +138,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -240,7 +240,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -350,7 +350,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -409,7 +409,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -620,6 +620,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -658,7 +690,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -678,7 +710,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -743,7 +775,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -767,7 +799,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -784,7 +816,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -798,7 +830,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -827,7 +859,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -855,7 +887,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -871,7 +903,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -882,7 +914,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -137,7 +137,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -241,7 +241,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -353,7 +353,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -411,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -622,6 +622,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -659,7 +691,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -678,7 +710,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -742,7 +774,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -765,7 +797,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -781,7 +813,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -794,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -822,7 +854,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -849,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -864,7 +896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -874,7 +906,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -105,9 +105,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -410,7 +410,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -690,7 +690,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -709,7 +709,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -773,7 +773,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -796,7 +796,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -812,7 +812,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -825,7 +825,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -852,7 +852,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -880,7 +880,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -895,7 +895,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -905,7 +905,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -105,9 +105,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -404,7 +404,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
@@ -430,7 +430,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -710,7 +710,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -729,7 +729,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -793,7 +793,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -816,7 +816,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -832,7 +832,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -854,7 +854,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -881,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -909,7 +909,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -924,7 +924,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -934,7 +934,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -135,7 +135,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -237,7 +237,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -347,7 +347,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -431,7 +431,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -642,6 +642,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -679,7 +711,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -698,7 +730,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -762,7 +794,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -785,7 +817,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -801,7 +833,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -823,7 +855,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -851,7 +883,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -878,7 +910,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -893,7 +925,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -903,7 +935,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -135,7 +135,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -237,7 +237,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -347,7 +347,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -433,7 +433,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -644,6 +644,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -681,7 +713,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -700,7 +732,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -764,7 +796,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -787,7 +819,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -803,7 +835,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -825,7 +857,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -853,7 +885,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -880,7 +912,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -895,7 +927,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -905,7 +937,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -105,9 +105,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -404,7 +404,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
@@ -432,7 +432,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -712,7 +712,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -731,7 +731,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -795,7 +795,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -818,7 +818,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -834,7 +834,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -856,7 +856,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -883,7 +883,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -911,7 +911,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -926,7 +926,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -936,7 +936,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -135,7 +135,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -237,7 +237,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -347,7 +347,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -429,7 +429,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -640,6 +640,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -677,7 +709,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -696,7 +728,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -760,7 +792,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -783,7 +815,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -799,7 +831,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -812,7 +844,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -840,7 +872,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -867,7 +899,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -882,7 +914,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -892,7 +924,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -105,9 +105,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -404,7 +404,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
@@ -428,7 +428,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -708,7 +708,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -727,7 +727,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -791,7 +791,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -814,7 +814,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -830,7 +830,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -843,7 +843,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -870,7 +870,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -898,7 +898,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -913,7 +913,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -923,7 +923,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -105,9 +105,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -404,7 +404,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
@@ -463,7 +463,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -743,7 +743,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -762,7 +762,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -826,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -849,7 +849,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -865,7 +865,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -896,7 +896,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -923,7 +923,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -951,7 +951,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -966,7 +966,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -976,7 +976,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -135,7 +135,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -237,7 +237,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -347,7 +347,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -464,7 +464,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -675,6 +675,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -712,7 +744,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -731,7 +763,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -795,7 +827,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -818,7 +850,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -834,7 +866,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -865,7 +897,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -893,7 +925,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -920,7 +952,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -935,7 +967,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -945,7 +977,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -241,7 +241,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -353,7 +353,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -411,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -691,7 +691,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -710,7 +710,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -774,7 +774,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -797,7 +797,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -813,7 +813,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -826,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -854,7 +854,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -881,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -896,7 +896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -906,7 +906,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -105,9 +105,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -410,7 +410,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -690,7 +690,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -709,7 +709,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -773,7 +773,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -796,7 +796,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -812,7 +812,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -825,7 +825,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -852,7 +852,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -880,7 +880,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -895,7 +895,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -905,7 +905,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -135,7 +135,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -237,7 +237,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -347,7 +347,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -616,6 +616,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -653,7 +685,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -672,7 +704,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -736,7 +768,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -759,7 +791,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -775,7 +807,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -788,7 +820,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -816,7 +848,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -843,7 +875,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -858,7 +890,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -868,7 +900,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: my-kong-sa
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -105,9 +105,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -404,7 +404,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -684,7 +684,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -703,7 +703,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -767,7 +767,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -790,7 +790,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -806,7 +806,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -819,7 +819,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -846,7 +846,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -874,7 +874,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -889,7 +889,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -899,7 +899,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: my-kong-sa
         namespace: default

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -411,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -622,6 +622,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -659,7 +691,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -678,7 +710,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -742,7 +774,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -765,7 +797,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -781,7 +813,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -794,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -822,7 +854,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -849,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -864,7 +896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -874,7 +906,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -105,9 +105,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -410,7 +410,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -690,7 +690,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -709,7 +709,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -773,7 +773,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -796,7 +796,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -812,7 +812,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -825,7 +825,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -852,7 +852,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -880,7 +880,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -895,7 +895,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -905,7 +905,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -33,7 +33,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -250,7 +250,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -278,7 +278,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -305,7 +305,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -32,9 +32,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -249,7 +249,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -276,7 +276,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -304,7 +304,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
                     environment: test
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -139,7 +139,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -252,7 +252,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -370,7 +370,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -448,7 +448,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -474,7 +474,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -498,7 +498,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -709,6 +709,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -746,7 +778,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -765,7 +797,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -829,7 +861,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -852,7 +884,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -868,7 +900,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -881,7 +913,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -909,7 +941,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -936,7 +968,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -951,7 +983,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -961,7 +993,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -104,10 +104,10 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     environment: test
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -447,7 +447,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -473,7 +473,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
@@ -497,7 +497,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -777,7 +777,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -796,7 +796,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -860,7 +860,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -883,7 +883,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -899,7 +899,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -912,7 +912,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -939,7 +939,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -967,7 +967,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -982,7 +982,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -992,7 +992,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -84,7 +84,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -112,7 +112,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -150,7 +150,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -270,7 +270,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -404,7 +404,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -507,7 +507,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: wait-for-db
                       resources: {}
@@ -725,7 +725,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -741,7 +741,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -819,7 +819,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: kong-migrations
                       resources: {}
@@ -924,7 +924,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
                       resources: {}
@@ -978,7 +978,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -994,7 +994,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1072,7 +1072,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: kong-post-upgrade-migrations
                       resources: {}
@@ -1177,7 +1177,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
                       resources: {}
@@ -1233,7 +1233,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1249,7 +1249,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1327,7 +1327,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: kong-upgrade-migrations
                       resources: {}
@@ -1432,7 +1432,7 @@ SnapShot = """
                       envFrom:
                         - configMapRef:
                             name: env-config
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
                       resources: {}
@@ -1482,7 +1482,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1506,9 +1506,25 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
         - apiGroups:
             - configuration.konghq.com
           resources:
@@ -1549,7 +1565,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1568,7 +1584,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1632,7 +1648,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-default
         namespace: default
     rules:
@@ -1841,6 +1857,22 @@ SnapShot = """
             - get
             - list
             - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
 - object:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
@@ -1850,7 +1882,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1870,7 +1902,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-default
         namespace: default
     roleRef:
@@ -1896,7 +1928,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1918,7 +1950,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1934,7 +1966,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1962,7 +1994,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -1990,7 +2022,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -2025,7 +2057,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -2040,7 +2072,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: Service
@@ -2100,7 +2132,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -111,9 +111,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -724,7 +724,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-init-migrations
         namespace: default
@@ -740,7 +740,7 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
                 name: kong-init-migrations
             spec:
@@ -977,7 +977,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
@@ -993,7 +993,7 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
                 name: kong-post-upgrade-migrations
             spec:
@@ -1232,7 +1232,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
@@ -1248,7 +1248,7 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
                 name: kong-pre-upgrade-migrations
             spec:
@@ -1481,7 +1481,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
@@ -1505,7 +1505,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -1564,7 +1564,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -1583,7 +1583,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -1647,7 +1647,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-default
         namespace: default
@@ -1881,7 +1881,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -1901,7 +1901,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-default
         namespace: default
@@ -1927,7 +1927,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
@@ -1949,7 +1949,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -1965,7 +1965,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -1993,7 +1993,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -2020,7 +2020,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -2056,7 +2056,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -2071,7 +2071,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -2131,7 +2131,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -33,9 +33,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -295,7 +295,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
@@ -307,7 +307,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -334,7 +334,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -362,7 +362,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -92,7 +92,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -208,7 +208,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -296,7 +296,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -308,7 +308,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -336,7 +336,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -363,7 +363,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -33,9 +33,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -271,7 +271,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
@@ -304,7 +304,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
@@ -316,7 +316,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -343,7 +343,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -379,7 +379,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -92,7 +92,7 @@ SnapShot = """
                           value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -212,7 +212,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -272,7 +272,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -305,7 +305,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -317,7 +317,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -345,7 +345,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -380,7 +380,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -111,7 +111,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                     version: \"3.5\"
             spec:
                 automountServiceAccountToken: false
@@ -142,7 +142,7 @@ SnapShot = """
                           value: https://localhost:8444
                         - name: CONTROLLER_PUBLISH_SERVICE
                           value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
+                      image: kong/kubernetes-ingress-controller:3.1
                       imagePullPolicy: IfNotPresent
                       livenessProbe:
                         failureThreshold: 3
@@ -261,7 +261,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       lifecycle:
                         preStop:
@@ -388,7 +388,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: clear-stale-pid
                       resources: {}
@@ -477,7 +477,7 @@ SnapShot = """
                           value: 0.0.0.0:8100, [::]:8100
                         - name: KONG_STREAM_LISTEN
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: wait-for-db
                       resources: {}
@@ -695,7 +695,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -711,7 +711,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -788,7 +788,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: kong-migrations
                       resources: {}
@@ -879,7 +879,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
                       resources: {}
@@ -933,7 +933,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -949,7 +949,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1026,7 +1026,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: kong-post-upgrade-migrations
                       resources: {}
@@ -1117,7 +1117,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
                       resources: {}
@@ -1173,7 +1173,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1189,7 +1189,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.5\"
-                    helm.sh/chart: kong-2.36.0
+                    helm.sh/chart: kong-2.37.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1266,7 +1266,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: kong-upgrade-migrations
                       resources: {}
@@ -1357,7 +1357,7 @@ SnapShot = """
                           value: \"off\"
                         - name: KONG_NGINX_DAEMON
                           value: \"off\"
-                      image: kong:3.5
+                      image: kong:3.6
                       imagePullPolicy: IfNotPresent
                       name: wait-for-postgres
                       resources: {}
@@ -1407,7 +1407,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1431,7 +1431,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1642,6 +1642,38 @@ SnapShot = """
         - apiGroups:
             - configuration.konghq.com
           resources:
+            - konglicenses
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - konglicenses/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults
+          verbs:
+            - get
+            - list
+            - watch
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
+            - kongvaults/status
+          verbs:
+            - get
+            - patch
+            - update
+        - apiGroups:
+            - configuration.konghq.com
+          resources:
             - kongclusterplugins
           verbs:
             - get
@@ -1679,7 +1711,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1698,7 +1730,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1762,7 +1794,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1788,7 +1820,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1803,7 +1835,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1819,7 +1851,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1847,7 +1879,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -1875,7 +1907,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1902,7 +1934,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -1917,7 +1949,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
     kind: Service
@@ -1977,7 +2009,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.5\"
-            helm.sh/chart: kong-2.36.0
+            helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -8,7 +8,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validations
         namespace: default
@@ -82,7 +82,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -110,9 +110,9 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
-                    version: \"3.5\"
+                    version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
                 containers:
@@ -694,7 +694,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-init-migrations
         namespace: default
@@ -710,7 +710,7 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
                 name: kong-init-migrations
             spec:
@@ -932,7 +932,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
@@ -948,7 +948,7 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
                 name: kong-post-upgrade-migrations
             spec:
@@ -1172,7 +1172,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
@@ -1188,7 +1188,7 @@ SnapShot = """
                     app.kubernetes.io/instance: chartsnap
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.5\"
+                    app.kubernetes.io/version: \"3.6\"
                     helm.sh/chart: kong-2.37.0
                 name: kong-pre-upgrade-migrations
             spec:
@@ -1406,7 +1406,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
         namespace: default
@@ -1430,7 +1430,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     rules:
@@ -1710,7 +1710,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
     roleRef:
@@ -1729,7 +1729,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -1793,7 +1793,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default
@@ -1819,7 +1819,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
@@ -1834,7 +1834,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
@@ -1850,7 +1850,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
@@ -1878,7 +1878,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-manager
         namespace: default
@@ -1905,7 +1905,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-proxy
@@ -1933,7 +1933,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong-validation-webhook
         namespace: default
@@ -1948,7 +1948,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
 - object:
     apiVersion: v1
@@ -2008,7 +2008,7 @@ SnapShot = """
             app.kubernetes.io/instance: chartsnap
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.5\"
+            app.kubernetes.io/version: \"3.6\"
             helm.sh/chart: kong-2.37.0
         name: chartsnap-kong
         namespace: default

--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -1,9 +1,9 @@
-# generated using: kubectl kustomize 'github.com/kong/kubernetes-ingress-controller/config/crd?ref=v3.0.0'
+# generated using: kubectl kustomize 'github.com/kong/kubernetes-ingress-controller/config/crd?ref=v3.1.0'
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: ingressclassparameterses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -21,14 +21,19 @@ spec:
           API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -37,10 +42,10 @@ spec:
             properties:
               enableLegacyRegexDetection:
                 default: false
-                description: EnableLegacyRegexDetection automatically detects if ImplementationSpecific
-                  Ingress paths are regular expression paths using the legacy 2.x
-                  heuristic. The controller adds the "~" prefix to those paths if
-                  the Kong version is 3.0 or higher.
+                description: |-
+                  EnableLegacyRegexDetection automatically detects if ImplementationSpecific Ingress paths are regular expression
+                  paths using the legacy 2.x heuristic. The controller adds the "~" prefix to those paths if the Kong version is
+                  3.0 or higher.
                 type: boolean
               serviceUpstream:
                 default: false
@@ -55,7 +60,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -98,25 +103,28 @@ spec:
         description: KongClusterPlugin is the Schema for the kongclusterplugins API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           config:
-            description: Config contains the plugin configuration. It's a list of
-              keys and values required to configure the plugin. Please read the documentation
-              of the plugin being configured to set values in here. For any plugin
-              in Kong, anything that goes in the `config` JSON key in the Admin API
-              request, goes into this property. Only one of `config` or `configFrom`
-              may be used in a KongClusterPlugin, not both at once.
+            description: |-
+              Config contains the plugin configuration. It's a list of keys and values
+              required to configure the plugin.
+              Please read the documentation of the plugin being configured to set values
+              in here. For any plugin in Kong, anything that goes in the `config` JSON
+              key in the Admin API request, goes into this property.
+              Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once.
             type: object
             x-kubernetes-preserve-unknown-fields: true
           configFrom:
-            description: ConfigFrom references a secret containing the plugin configuration.
-              This should be used when the plugin configuration contains sensitive
-              information, such as AWS credentials in the Lambda plugin or the client
-              secret in the OIDC plugin. Only one of `config` or `configFrom` may
-              be used in a KongClusterPlugin, not both at once.
+            description: |-
+              ConfigFrom references a secret containing the plugin configuration.
+              This should be used when the plugin configuration contains sensitive information,
+              such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin.
+              Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once.
             properties:
               secretKeyRef:
                 description: Specifies a name, a namespace, and a key of a secret
@@ -136,7 +144,55 @@ spec:
                 - name
                 - namespace
                 type: object
+            required:
+            - secretKeyRef
             type: object
+          configPatches:
+            description: |-
+              ConfigPatches represents JSON patches to the configuration of the plugin.
+              Each item means a JSON patch to add something in the configuration,
+              where path is specified in `path` and value is in `valueFrom` referencing
+              a key in a secret.
+              When Config is specified, patches will be applied to the configuration in Config.
+              Otherwise, patches will be applied to an empty object.
+            items:
+              description: |-
+                NamespacedConfigPatch is a JSON patch to add values from secrets to KongClusterPlugin
+                to the generated configuration of plugin in Kong.
+              properties:
+                path:
+                  description: Path is the JSON path to add the patch.
+                  type: string
+                valueFrom:
+                  description: ValueFrom is the reference to a key of a secret where
+                    the patched value comes from.
+                  properties:
+                    secretKeyRef:
+                      description: Specifies a name, a namespace, and a key of a secret
+                        to refer to.
+                      properties:
+                        key:
+                          description: The key containing the value.
+                          type: string
+                        name:
+                          description: The secret containing the key.
+                          type: string
+                        namespace:
+                          description: The namespace containing the secret.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      - namespace
+                      type: object
+                  required:
+                  - secretKeyRef
+                  type: object
+              required:
+              - path
+              - valueFrom
+              type: object
+            type: array
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
             type: string
@@ -144,25 +200,27 @@ spec:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
           instance_name:
-            description: InstanceName is an optional custom name to identify an instance
-              of the plugin. This is useful when running the same plugin in multiple
-              contexts, for example, on multiple services.
+            description: |-
+              InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the
+              same plugin in multiple contexts, for example, on multiple services.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           ordering:
-            description: 'Ordering overrides the normal plugin execution order. It''s
-              only available on Kong Enterprise. `<phase>` is a request processing
-              phase (for example, `access` or `body_filter`) and `<plugin>` is the
-              name of the plugin that will run before or after the KongPlugin. For
-              example, a KongPlugin with `plugin: rate-limiting` and `before.access:
-              ["key-auth"]` will create a rate limiting plugin that limits requests
-              _before_ they are authenticated.'
+            description: |-
+              Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise.
+              `<phase>` is a request processing phase (for example, `access` or `body_filter`) and
+              `<plugin>` is the name of the plugin that will run before or after the KongPlugin.
+              For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]`
+              will create a rate limiting plugin that limits requests _before_ they are authenticated.
             properties:
               after:
                 additionalProperties:
@@ -186,11 +244,13 @@ spec:
               config.
             type: string
           protocols:
-            description: Protocols configures plugin to run on requests received on
-              specific protocols.
+            description: |-
+              Protocols configures plugin to run on requests received on specific
+              protocols.
             items:
-              description: KongProtocol is a valid Kong protocol. This alias is necessary
-                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+              description: |-
+                KongProtocol is a valid Kong protocol.
+                This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https
@@ -202,8 +262,9 @@ spec:
               type: string
             type: array
           run_on:
-            description: RunOn configures the plugin to run on the first or the second
-              or both nodes in case of a service mesh deployment.
+            description: |-
+              RunOn configures the plugin to run on the first or the second or both
+              nodes in case of a service mesh deployment.
             enum:
             - first
             - second
@@ -220,46 +281,52 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Programmed
-                description: "Conditions describe the current conditions of the KongClusterPluginStatus.
-                  \n Known condition types are: \n * \"Programmed\""
+                description: |-
+                  Conditions describe the current conditions of the KongClusterPluginStatus.
+
+
+                  Known condition types are:
+
+
+                  * "Programmed"
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -273,11 +340,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -297,6 +365,13 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: Using both config and configFrom fields is not allowed.
+          rule: '!(has(self.config) && has(self.configFrom))'
+        - message: Using both configFrom and configPatches fields is not allowed.
+          rule: '!(has(self.configFrom) && has(self.configPatches))'
+        - message: The plugin field is immutable
+          rule: self.plugin == oldSelf.plugin
     served: true
     storage: true
     subresources:
@@ -306,7 +381,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -335,19 +410,24 @@ spec:
         description: KongConsumerGroup is the Schema for the kongconsumergroups API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           status:
-            description: Status represents the current status of the KongConsumer
+            description: Status represents the current status of the KongConsumerGroup
               resource.
             properties:
               conditions:
@@ -357,46 +437,52 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Programmed
-                description: "Conditions describe the current conditions of the KongConsumerGroup.
-                  \n Known condition types are: \n * \"Programmed\""
+                description: |-
+                  Conditions describe the current conditions of the KongConsumerGroup.
+
+
+                  Known condition types are:
+
+
+                  * "Programmed"
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -410,11 +496,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -441,7 +528,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -474,30 +561,38 @@ spec:
         description: KongConsumer is the Schema for the kongconsumers API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           consumerGroups:
-            description: ConsumerGroups are references to consumer groups (that consumer
-              wants to be part of) provisioned in Kong.
+            description: |-
+              ConsumerGroups are references to consumer groups (that consumer wants to be part of)
+              provisioned in Kong.
             items:
               type: string
             type: array
           credentials:
-            description: Credentials are references to secrets containing a credential
-              to be provisioned in Kong.
+            description: |-
+              Credentials are references to secrets containing a credential to be
+              provisioned in Kong.
             items:
               type: string
             type: array
           custom_id:
-            description: CustomID is a Kong cluster-unique existing ID for the consumer
-              - useful for mapping Kong with users in your existing database.
+            description: |-
+              CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping
+              Kong with users in your existing database.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -512,46 +607,52 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Programmed
-                description: "Conditions describe the current conditions of the KongConsumer.
-                  \n Known condition types are: \n * \"Programmed\""
+                description: |-
+                  Conditions describe the current conditions of the KongConsumer.
+
+
+                  Known condition types are:
+
+
+                  * "Programmed"
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -565,11 +666,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -590,6 +692,9 @@ spec:
             description: Username is a Kong cluster-unique username of the consumer.
             type: string
         type: object
+        x-kubernetes-validations:
+        - message: Need to provide either username or custom_id
+          rule: has(self.username) || has(self.custom_id)
     served: true
     storage: true
     subresources:
@@ -599,7 +704,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -620,37 +725,43 @@ spec:
         description: KongIngress is the Schema for the kongingresses API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           proxy:
-            description: Proxy defines additional connection options for the routes
-              to be configured in the Kong Gateway, e.g. `connection_timeout`, `retries`,
-              etc.
+            description: |-
+              Proxy defines additional connection options for the routes to be configured in the
+              Kong Gateway, e.g. `connection_timeout`, `retries`, etc.
             properties:
               connect_timeout:
                 description: "The timeout in milliseconds for\testablishing a connection
-                  to the upstream server. Deprecated: use Service's \"konghq.com/connect-timeout\"
+                  to the upstream server.\nDeprecated: use Service's \"konghq.com/connect-timeout\"
                   annotation instead."
                 minimum: 0
                 type: integer
               path:
-                description: '(optional) The path to be used in requests to the upstream
-                  server. Deprecated: use Service''s "konghq.com/path" annotation
-                  instead.'
+                description: |-
+                  (optional) The path to be used in requests to the upstream server.
+                  Deprecated: use Service's "konghq.com/path" annotation instead.
                 pattern: ^/.*$
                 type: string
               protocol:
-                description: 'The protocol used to communicate with the upstream.
-                  Deprecated: use Service''s "konghq.com/protocol" annotation instead.'
+                description: |-
+                  The protocol used to communicate with the upstream.
+                  Deprecated: use Service's "konghq.com/protocol" annotation instead.
                 enum:
                 - http
                 - https
@@ -661,73 +772,81 @@ spec:
                 - udp
                 type: string
               read_timeout:
-                description: 'The timeout in milliseconds between two successive read
-                  operations for transmitting a request to the upstream server. Deprecated:
-                  use Service''s "konghq.com/read-timeout" annotation instead.'
+                description: |-
+                  The timeout in milliseconds between two successive read operations
+                  for transmitting a request to the upstream server.
+                  Deprecated: use Service's "konghq.com/read-timeout" annotation instead.
                 minimum: 0
                 type: integer
               retries:
-                description: 'The number of retries to execute upon failure to proxy.
-                  Deprecated: use Service''s "konghq.com/retries" annotation instead.'
+                description: |-
+                  The number of retries to execute upon failure to proxy.
+                  Deprecated: use Service's "konghq.com/retries" annotation instead.
                 minimum: 0
                 type: integer
               write_timeout:
-                description: 'The timeout in milliseconds between two successive write
-                  operations for transmitting a request to the upstream server. Deprecated:
-                  use Service''s "konghq.com/write-timeout" annotation instead.'
+                description: |-
+                  The timeout in milliseconds between two successive write operations
+                  for transmitting a request to the upstream server.
+                  Deprecated: use Service's "konghq.com/write-timeout" annotation instead.
                 minimum: 0
                 type: integer
             type: object
           route:
-            description: Route define rules to match client requests. Each Route is
-              associated with a Service, and a Service may have multiple Routes associated
-              to it.
+            description: |-
+              Route define rules to match client requests.
+              Each Route is associated with a Service,
+              and a Service may have multiple Routes associated to it.
             properties:
               headers:
                 additionalProperties:
                   items:
                     type: string
                   type: array
-                description: 'Headers contains one or more lists of values indexed
-                  by header name that will cause this Route to match if present in
-                  the request. The Host header cannot be used with this attribute.
-                  Deprecated: use Ingress'' "konghq.com/headers" annotation instead.'
+                description: |-
+                  Headers contains one or more lists of values indexed by header name
+                  that will cause this Route to match if present in the request.
+                  The Host header cannot be used with this attribute.
+                  Deprecated: use Ingress' "konghq.com/headers" annotation instead.
                 type: object
               https_redirect_status_code:
-                description: 'HTTPSRedirectStatusCode is the status code Kong responds
-                  with when all properties of a Route match except the protocol. Deprecated:
-                  use Ingress'' "ingress.kubernetes.io/force-ssl-redirect" or "konghq.com/https-redirect-status-code"
-                  annotations instead.'
+                description: |-
+                  HTTPSRedirectStatusCode is the status code Kong responds with
+                  when all properties of a Route match except the protocol.
+                  Deprecated: use Ingress' "ingress.kubernetes.io/force-ssl-redirect" or
+                  "konghq.com/https-redirect-status-code" annotations instead.
                 type: integer
               methods:
-                description: 'Methods is a list of HTTP methods that match this Route.
-                  Deprecated: use Ingress'' "konghq.com/methods" annotation instead.'
+                description: |-
+                  Methods is a list of HTTP methods that match this Route.
+                  Deprecated: use Ingress' "konghq.com/methods" annotation instead.
                 items:
                   type: string
                 type: array
               path_handling:
-                description: 'PathHandling controls how the Service path, Route path
-                  and requested path are combined when sending a request to the upstream.
-                  Deprecated: use Ingress'' "konghq.com/path-handling" annotation
-                  instead.'
+                description: |-
+                  PathHandling controls how the Service path, Route path and requested path
+                  are combined when sending a request to the upstream.
+                  Deprecated: use Ingress' "konghq.com/path-handling" annotation instead.
                 enum:
                 - v0
                 - v1
                 type: string
               preserve_host:
-                description: 'PreserveHost sets When matching a Route via one of the
-                  hosts domain names, use the request Host header in the upstream
-                  request headers. If set to false, the upstream Host header will
-                  be that of the Service’s host. Deprecated: use Ingress'' "konghq.com/preserve-host"
-                  annotation instead.'
+                description: |-
+                  PreserveHost sets When matching a Route via one of the hosts domain names,
+                  use the request Host header in the upstream request headers.
+                  If set to false, the upstream Host header will be that of the Service’s host.
+                  Deprecated: use Ingress' "konghq.com/preserve-host" annotation instead.
                 type: boolean
               protocols:
-                description: 'Protocols is an array of the protocols this Route should
-                  allow. Deprecated: use Ingress'' "konghq.com/protocols" annotation
-                  instead.'
+                description: |-
+                  Protocols is an array of the protocols this Route should allow.
+                  Deprecated: use Ingress' "konghq.com/protocols" annotation instead.
                 items:
-                  description: KongProtocol is a valid Kong protocol. This alias is
-                    necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+                  description: |-
+                    KongProtocol is a valid Kong protocol.
+                    This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
                   enum:
                   - http
                   - https
@@ -739,43 +858,45 @@ spec:
                   type: string
                 type: array
               regex_priority:
-                description: 'RegexPriority is a number used to choose which route
-                  resolves a given request when several routes match it using regexes
-                  simultaneously. Deprecated: use Ingress'' "konghq.com/regex-priority"
-                  annotation instead.'
+                description: |-
+                  RegexPriority is a number used to choose which route resolves a given request
+                  when several routes match it using regexes simultaneously.
+                  Deprecated: use Ingress' "konghq.com/regex-priority" annotation instead.
                 type: integer
               request_buffering:
-                description: 'RequestBuffering sets whether to enable request body
-                  buffering or not. Deprecated: use Ingress'' "konghq.com/request-buffering"
-                  annotation instead.'
+                description: |-
+                  RequestBuffering sets whether to enable request body buffering or not.
+                  Deprecated: use Ingress' "konghq.com/request-buffering" annotation instead.
                 type: boolean
               response_buffering:
-                description: 'ResponseBuffering sets whether to enable response body
-                  buffering or not. Deprecated: use Ingress'' "konghq.com/response-buffering"
-                  annotation instead.'
+                description: |-
+                  ResponseBuffering sets whether to enable response body buffering or not.
+                  Deprecated: use Ingress' "konghq.com/response-buffering" annotation instead.
                 type: boolean
               snis:
-                description: 'SNIs is a list of SNIs that match this Route when using
-                  stream routing. Deprecated: use Ingress'' "konghq.com/snis" annotation
-                  instead.'
+                description: |-
+                  SNIs is a list of SNIs that match this Route when using stream routing.
+                  Deprecated: use Ingress' "konghq.com/snis" annotation instead.
                 items:
                   type: string
                 type: array
               strip_path:
-                description: 'StripPath sets When matching a Route via one of the
-                  paths strip the matching prefix from the upstream request URL. Deprecated:
-                  use Ingress'' "konghq.com/strip-path" annotation instead.'
+                description: |-
+                  StripPath sets When matching a Route via one of the paths
+                  strip the matching prefix from the upstream request URL.
+                  Deprecated: use Ingress' "konghq.com/strip-path" annotation instead.
                 type: boolean
             type: object
           upstream:
-            description: Upstream represents a virtual hostname and can be used to
-              loadbalance incoming requests over multiple targets (e.g. Kubernetes
-              `Services` can be a target, OR `Endpoints` can be targets).
+            description: |-
+              Upstream represents a virtual hostname and can be used to loadbalance
+              incoming requests over multiple targets (e.g. Kubernetes `Services` can
+              be a target, OR `Endpoints` can be targets).
             properties:
               algorithm:
-                description: 'Algorithm is the load balancing algorithm to use. Accepted
-                  values are: "round-robin", "consistent-hashing", "least-connections",
-                  "latency".'
+                description: |-
+                  Algorithm is the load balancing algorithm to use.
+                  Accepted values are: "round-robin", "consistent-hashing", "least-connections", "latency".
                 enum:
                 - round-robin
                 - consistent-hashing
@@ -783,14 +904,15 @@ spec:
                 - latency
                 type: string
               hash_fallback:
-                description: 'HashFallback defines What to use as hashing input if
-                  the primary hash_on does not return a hash. Accepted values are:
-                  "none", "consumer", "ip", "header", "cookie".'
+                description: |-
+                  HashFallback defines What to use as hashing input
+                  if the primary hash_on does not return a hash.
+                  Accepted values are: "none", "consumer", "ip", "header", "cookie".
                 type: string
               hash_fallback_header:
-                description: HashFallbackHeader is the header name to take the value
-                  from as hash input. Only required when "hash_fallback" is set to
-                  "header".
+                description: |-
+                  HashFallbackHeader is the header name to take the value from as hash input.
+                  Only required when "hash_fallback" is set to "header".
                 type: string
               hash_fallback_query_arg:
                 description: HashFallbackQueryArg is the "hash_fallback" version of
@@ -801,29 +923,33 @@ spec:
                   of HashOnURICapture.
                 type: string
               hash_on:
-                description: 'HashOn defines what to use as hashing input. Accepted
-                  values are: "none", "consumer", "ip", "header", "cookie", "path",
-                  "query_arg", "uri_capture".'
+                description: |-
+                  HashOn defines what to use as hashing input.
+                  Accepted values are: "none", "consumer", "ip", "header", "cookie", "path", "query_arg", "uri_capture".
                 type: string
               hash_on_cookie:
-                description: The cookie name to take the value from as hash input.
+                description: |-
+                  The cookie name to take the value from as hash input.
                   Only required when "hash_on" or "hash_fallback" is set to "cookie".
                 type: string
               hash_on_cookie_path:
-                description: The cookie path to set in the response headers. Only
-                  required when "hash_on" or "hash_fallback" is set to "cookie".
+                description: |-
+                  The cookie path to set in the response headers.
+                  Only required when "hash_on" or "hash_fallback" is set to "cookie".
                 type: string
               hash_on_header:
-                description: HashOnHeader defines the header name to take the value
-                  from as hash input. Only required when "hash_on" is set to "header".
+                description: |-
+                  HashOnHeader defines the header name to take the value from as hash input.
+                  Only required when "hash_on" is set to "header".
                 type: string
               hash_on_query_arg:
                 description: HashOnQueryArg is the query string parameter whose value
                   is the hash input when "hash_on" is set to "query_arg".
                 type: string
               hash_on_uri_capture:
-                description: HashOnURICapture is the name of the capture group whose
-                  value is the hash input when "hash_on" is set to "uri_capture".
+                description: |-
+                  HashOnURICapture is the name of the capture group whose value is the hash input when "hash_on" is set to
+                  "uri_capture".
                 type: string
               healthchecks:
                 description: Healthchecks defines the health check configurations
@@ -843,8 +969,9 @@ spec:
                           type: array
                         type: object
                       healthy:
-                        description: Healthy configures thresholds and HTTP status
-                          codes to mark targets healthy for an upstream.
+                        description: |-
+                          Healthy configures thresholds and HTTP status codes
+                          to mark targets healthy for an upstream.
                         properties:
                           http_statuses:
                             items:
@@ -870,8 +997,9 @@ spec:
                       type:
                         type: string
                       unhealthy:
-                        description: Unhealthy configures thresholds and HTTP status
-                          codes to mark targets unhealthy.
+                        description: |-
+                          Unhealthy configures thresholds and HTTP status codes
+                          to mark targets unhealthy.
                         properties:
                           http_failures:
                             minimum: 0
@@ -892,12 +1020,14 @@ spec:
                         type: object
                     type: object
                   passive:
-                    description: PassiveHealthcheck configures passive checks around
+                    description: |-
+                      PassiveHealthcheck configures passive checks around
                       passive health checks.
                     properties:
                       healthy:
-                        description: Healthy configures thresholds and HTTP status
-                          codes to mark targets healthy for an upstream.
+                        description: |-
+                          Healthy configures thresholds and HTTP status codes
+                          to mark targets healthy for an upstream.
                         properties:
                           http_statuses:
                             items:
@@ -913,8 +1043,9 @@ spec:
                       type:
                         type: string
                       unhealthy:
-                        description: Unhealthy configures thresholds and HTTP status
-                          codes to mark targets unhealthy.
+                        description: |-
+                          Unhealthy configures thresholds and HTTP status codes
+                          to mark targets unhealthy.
                         properties:
                           http_failures:
                             minimum: 0
@@ -938,7 +1069,8 @@ spec:
                     type: number
                 type: object
               host_header:
-                description: HostHeader is The hostname to be used as Host header
+                description: |-
+                  HostHeader is The hostname to be used as Host header
                   when proxying requests through Kong.
                 type: string
               slots:
@@ -963,7 +1095,220 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1006,25 +1351,28 @@ spec:
         description: KongPlugin is the Schema for the kongplugins API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           config:
-            description: Config contains the plugin configuration. It's a list of
-              keys and values required to configure the plugin. Please read the documentation
-              of the plugin being configured to set values in here. For any plugin
-              in Kong, anything that goes in the `config` JSON key in the Admin API
-              request, goes into this property. Only one of `config` or `configFrom`
-              may be used in a KongPlugin, not both at once.
+            description: |-
+              Config contains the plugin configuration. It's a list of keys and values
+              required to configure the plugin.
+              Please read the documentation of the plugin being configured to set values
+              in here. For any plugin in Kong, anything that goes in the `config` JSON
+              key in the Admin API request, goes into this property.
+              Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once.
             type: object
             x-kubernetes-preserve-unknown-fields: true
           configFrom:
-            description: ConfigFrom references a secret containing the plugin configuration.
-              This should be used when the plugin configuration contains sensitive
-              information, such as AWS credentials in the Lambda plugin or the client
-              secret in the OIDC plugin. Only one of `config` or `configFrom` may
-              be used in a KongPlugin, not both at once.
+            description: |-
+              ConfigFrom references a secret containing the plugin configuration.
+              This should be used when the plugin configuration contains sensitive information,
+              such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin.
+              Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once.
             properties:
               secretKeyRef:
                 description: Specifies a name and a key of a secret to refer to. The
@@ -1040,7 +1388,54 @@ spec:
                 - key
                 - name
                 type: object
+            required:
+            - secretKeyRef
             type: object
+          configPatches:
+            description: |-
+              ConfigPatches represents JSON patches to the configuration of the plugin.
+              Each item means a JSON patch to add something in the configuration,
+              where path is specified in `path` and value is in `valueFrom` referencing
+              a key in a secret.
+              When Config is specified, patches will be applied to the configuration in Config.
+              Otherwise, patches will be applied to an empty object.
+            items:
+              description: |-
+                ConfigPatch is a JSON patch (RFC6902) to add values from Secret to the generated configuration.
+                It is an equivalent of the following patch:
+                `{"op": "add", "path": {.Path}, "value": {.ComputedValueFrom}}`.
+              properties:
+                path:
+                  description: Path is the JSON-Pointer value (RFC6901) that references
+                    a location within the target configuration.
+                  type: string
+                valueFrom:
+                  description: ValueFrom is the reference to a key of a secret where
+                    the patched value comes from.
+                  properties:
+                    secretKeyRef:
+                      description: Specifies a name and a key of a secret to refer
+                        to. The namespace is implicitly set to the one of referring
+                        object.
+                      properties:
+                        key:
+                          description: The key containing the value.
+                          type: string
+                        name:
+                          description: The secret containing the key.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                  required:
+                  - secretKeyRef
+                  type: object
+              required:
+              - path
+              - valueFrom
+              type: object
+            type: array
           consumerRef:
             description: ConsumerRef is a reference to a particular consumer.
             type: string
@@ -1048,25 +1443,27 @@ spec:
             description: Disabled set if the plugin is disabled or not.
             type: boolean
           instance_name:
-            description: InstanceName is an optional custom name to identify an instance
-              of the plugin. This is useful when running the same plugin in multiple
-              contexts, for example, on multiple services.
+            description: |-
+              InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the
+              same plugin in multiple contexts, for example, on multiple services.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           ordering:
-            description: 'Ordering overrides the normal plugin execution order. It''s
-              only available on Kong Enterprise. `<phase>` is a request processing
-              phase (for example, `access` or `body_filter`) and `<plugin>` is the
-              name of the plugin that will run before or after the KongPlugin. For
-              example, a KongPlugin with `plugin: rate-limiting` and `before.access:
-              ["key-auth"]` will create a rate limiting plugin that limits requests
-              _before_ they are authenticated.'
+            description: |-
+              Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise.
+              `<phase>` is a request processing phase (for example, `access` or `body_filter`) and
+              `<plugin>` is the name of the plugin that will run before or after the KongPlugin.
+              For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]`
+              will create a rate limiting plugin that limits requests _before_ they are authenticated.
             properties:
               after:
                 additionalProperties:
@@ -1090,11 +1487,13 @@ spec:
               config.
             type: string
           protocols:
-            description: Protocols configures plugin to run on requests received on
-              specific protocols.
+            description: |-
+              Protocols configures plugin to run on requests received on specific
+              protocols.
             items:
-              description: KongProtocol is a valid Kong protocol. This alias is necessary
-                to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+              description: |-
+                KongProtocol is a valid Kong protocol.
+                This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
               enum:
               - http
               - https
@@ -1106,8 +1505,9 @@ spec:
               type: string
             type: array
           run_on:
-            description: RunOn configures the plugin to run on the first or the second
-              or both nodes in case of a service mesh deployment.
+            description: |-
+              RunOn configures the plugin to run on the first or the second or both
+              nodes in case of a service mesh deployment.
             enum:
             - first
             - second
@@ -1123,46 +1523,52 @@ spec:
                   reason: Pending
                   status: Unknown
                   type: Programmed
-                description: "Conditions describe the current conditions of the KongPluginStatus.
-                  \n Known condition types are: \n * \"Programmed\""
+                description: |-
+                  Conditions describe the current conditions of the KongPluginStatus.
+
+
+                  Known condition types are:
+
+
+                  * "Programmed"
                 items:
                   description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -1176,11 +1582,12 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1200,6 +1607,13 @@ spec:
         required:
         - plugin
         type: object
+        x-kubernetes-validations:
+        - message: Using both config and configFrom fields is not allowed.
+          rule: '!(has(self.config) && has(self.configFrom))'
+        - message: Using both configFrom and configPatches fields is not allowed.
+          rule: '!(has(self.configFrom) && has(self.configPatches))'
+        - message: The plugin field is immutable
+          rule: self.plugin == oldSelf.plugin
     served: true
     storage: true
     subresources:
@@ -1209,7 +1623,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gateway.networking.k8s.io/policy: direct
   name: kongupstreampolicies.configuration.konghq.com
@@ -1229,33 +1643,45 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: "KongUpstreamPolicy allows configuring algorithm that should
-          be used for load balancing traffic between Kong Upstream's Targets. It also
-          allows configuring health checks for Kong Upstream's Targets. \n Its configuration
-          is similar to Kong Upstream object (https://docs.konghq.com/gateway/latest/admin-api/#upstream-object),
-          and it is applied to Kong Upstream objects created by the controller. \n
-          It can be attached to Services. To attach it to a Service, it has to be
-          annotated with `konghq.com/upstream-policy: <name>`, where `<name>` is the
-          name of the KongUpstreamPolicy object in the same namespace as the Service.
-          \n When attached to a Service, it will affect all Kong Upstreams created
-          for the Service. \n When attached to a Service used in a Gateway API *Route
-          rule with multiple BackendRefs, all of its Services MUST be configured with
-          the same KongUpstreamPolicy. Otherwise, the controller will *ignore* the
-          KongUpstreamPolicy. \n Note: KongUpstreamPolicy doesn't implement Gateway
-          API's GEP-713 strictly. In particular, it doesn't use the TargetRef for
-          attaching to Services and Gateway API *Routes - annotations are used instead.
-          This is to allow reusing the same KongUpstreamPolicy for multiple Services
-          and Gateway API *Routes."
+        description: |-
+          KongUpstreamPolicy allows configuring algorithm that should be used for load balancing traffic between Kong
+          Upstream's Targets. It also allows configuring health checks for Kong Upstream's Targets.
+
+
+          Its configuration is similar to Kong Upstream object (https://docs.konghq.com/gateway/latest/admin-api/#upstream-object),
+          and it is applied to Kong Upstream objects created by the controller.
+
+
+          It can be attached to Services. To attach it to a Service, it has to be annotated with
+          `konghq.com/upstream-policy: <name>`, where `<name>` is the name of the KongUpstreamPolicy
+          object in the same namespace as the Service.
+
+
+          When attached to a Service, it will affect all Kong Upstreams created for the Service.
+
+
+          When attached to a Service used in a Gateway API *Route rule with multiple BackendRefs, all of its Services MUST
+          be configured with the same KongUpstreamPolicy. Otherwise, the controller will *ignore* the KongUpstreamPolicy.
+
+
+          Note: KongUpstreamPolicy doesn't implement Gateway API's GEP-713 strictly.
+          In particular, it doesn't use the TargetRef for attaching to Services and Gateway API *Routes - annotations are
+          used instead. This is to allow reusing the same KongUpstreamPolicy for multiple Services and Gateway API *Routes.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -1263,9 +1689,9 @@ spec:
             description: Spec contains the configuration of the Kong upstream.
             properties:
               algorithm:
-                description: 'Algorithm is the load balancing algorithm to use. Accepted
-                  values are: "round-robin", "consistent-hashing", "least-connections",
-                  "latency".'
+                description: |-
+                  Algorithm is the load balancing algorithm to use.
+                  Accepted values are: "round-robin", "consistent-hashing", "least-connections", "latency".
                 enum:
                 - round-robin
                 - consistent-hashing
@@ -1273,9 +1699,9 @@ spec:
                 - latency
                 type: string
               hashOn:
-                description: HashOn defines how to calculate hash for consistent-hashing
-                  load balancing algorithm. Algorithm must be set to "consistent-hashing"
-                  for this field to have effect.
+                description: |-
+                  HashOn defines how to calculate hash for consistent-hashing load balancing algorithm.
+                  Algorithm must be set to "consistent-hashing" for this field to have effect.
                 properties:
                   cookie:
                     description: Cookie is the name of the cookie to use as hash input.
@@ -1288,9 +1714,9 @@ spec:
                     description: Header is the name of the header to use as hash input.
                     type: string
                   input:
-                    description: Input allows using one of the predefined inputs (ip,
-                      consumer, path). For other parametrized inputs, use one of the
-                      fields below.
+                    description: |-
+                      Input allows using one of the predefined inputs (ip, consumer, path).
+                      For other parametrized inputs, use one of the fields below.
                     enum:
                     - ip
                     - consumer
@@ -1306,9 +1732,10 @@ spec:
                     type: string
                 type: object
               hashOnFallback:
-                description: HashOnFallback defines how to calculate hash for consistent-hashing
-                  load balancing algorithm if the primary hash function fails. Algorithm
-                  must be set to "consistent-hashing" for this field to have effect.
+                description: |-
+                  HashOnFallback defines how to calculate hash for consistent-hashing load balancing algorithm if the primary hash
+                  function fails.
+                  Algorithm must be set to "consistent-hashing" for this field to have effect.
                 properties:
                   cookie:
                     description: Cookie is the name of the cookie to use as hash input.
@@ -1321,9 +1748,9 @@ spec:
                     description: Header is the name of the header to use as hash input.
                     type: string
                   input:
-                    description: Input allows using one of the predefined inputs (ip,
-                      consumer, path). For other parametrized inputs, use one of the
-                      fields below.
+                    description: |-
+                      Input allows using one of the predefined inputs (ip, consumer, path).
+                      For other parametrized inputs, use one of the fields below.
                     enum:
                     - ip
                     - consumer
@@ -1401,8 +1828,8 @@ spec:
                         minimum: 0
                         type: integer
                       type:
-                        description: Type determines whether to perform active health
-                          checks using HTTP or HTTPS, or just attempt a TCP connection.
+                        description: |-
+                          Type determines whether to perform active health checks using HTTP or HTTPS, or just attempt a TCP connection.
                           Accepted values are "http", "https", "tcp", "grpc", "grpcs".
                         enum:
                         - http
@@ -1476,10 +1903,10 @@ spec:
                             type: integer
                         type: object
                       type:
-                        description: Type determines whether to perform passive health
-                          checks interpreting HTTP/HTTPS statuses, or just check for
-                          TCP connection success. Accepted values are "http", "https",
-                          "tcp", "grpc", "grpcs".
+                        description: |-
+                          Type determines whether to perform passive health checks interpreting HTTP/HTTPS statuses,
+                          or just check for TCP connection success.
+                          Accepted values are "http", "https", "tcp", "grpc", "grpcs".
                         enum:
                         - http
                         - https
@@ -1524,17 +1951,366 @@ spec:
                         type: object
                     type: object
                   threshold:
-                    description: Threshold is the minimum percentage of the upstream’s
-                      targets’ weight that must be available for the whole upstream
-                      to be considered healthy.
+                    description: |-
+                      Threshold is the minimum percentage of the upstream’s targets’ weight that must be available for the whole
+                      upstream to be considered healthy.
                     type: integer
                 type: object
               slots:
-                description: Slots is the number of slots in the load balancer algorithm.
+                description: |-
+                  Slots is the number of slots in the load balancer algorithm.
                   If not set, the default value in Kong for the algorithm is used.
                 maximum: 65536
                 minimum: 10
                 type: integer
+            type: object
+          status:
+            description: Status defines the current state of KongUpstreamPolicy
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+
+                            There are two kinds of parent resources with "Core" support:
+
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, experimental, ClusterIP Services only)
+
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+
+                            <gateway:experimental:description>
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+                            </gateway:experimental:description>
+
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+
+                            <gateway:experimental:description>
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+                            </gateway:experimental:description>
+
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+
+                            Support: Extended
+
+
+                            <gateway:experimental>
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+
+                            * Gateway: Listener Name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port Name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values. Note that attaching Routes to Services as Parents
+                            is part of experimental Mesh support and is not supported for any other
+                            purpose.
+
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: "Condition contains details for one aspect of
+                          the current state of this API Resource.\n---\nThis struct
+                          is intended for direct use as an array at the field path
+                          .status.conditions.  For example,\n\n\n\ttype FooStatus
+                          struct{\n\t    // Represents the observations of a foo's
+                          current state.\n\t    // Known .status.conditions.type are:
+                          \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                          +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    //
+                          +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                          []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                          patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                          \   // other fields\n\t}"
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: |-
+                              type of condition in CamelCase or in foo.example.com/CamelCase.
+                              ---
+                              Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                              useful (see .node.status.conditions), the ability to deconflict is important.
+                              The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+
+                        Example: "example.net/gateway-controller".
+
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
             type: object
         type: object
         x-kubernetes-validations:
@@ -1590,7 +2366,204 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: kongvaults.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongVault
+    listKind: KongVaultList
+    plural: kongvaults
+    shortNames:
+    - kv
+    singular: kongvault
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the backend of the vault
+      jsonPath: .spec.backend
+      name: Backend Type
+      type: string
+    - description: Prefix of vault URI to reference the values in the vault
+      jsonPath: .spec.prefix
+      name: Prefix
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Description
+      jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KongVault is the schema for kongvaults API which defines a custom Kong vault.
+          A Kong vault is a storage to store sensitive data, where the values can be referenced in configuration of plugins.
+          See: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongVaultSpec defines specification of a custom Kong vault.
+            properties:
+              backend:
+                description: |-
+                  Backend is the type of the backend storing the secrets in the vault.
+                  The supported backends of Kong is listed here:
+                  https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/backends/
+                minLength: 1
+                type: string
+              config:
+                description: Config is the configuration of the vault. Varies for
+                  different backends.
+                x-kubernetes-preserve-unknown-fields: true
+              description:
+                description: Description is the additional information about the vault.
+                type: string
+              prefix:
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
+                minLength: 1
+                type: string
+            required:
+            - backend
+            - prefix
+            type: object
+          status:
+            description: KongVaultStatus represents the current status of the KongVault
+              resource.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the KongVaultStatus.
+
+
+                  Known condition types are:
+
+
+                  * "Programmed"
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            required:
+            - conditions
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: tcpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1618,14 +2591,19 @@ spec:
         description: TCPIngress is the Schema for the tcpingresses API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -1635,13 +2613,14 @@ spec:
               rules:
                 description: A list of rules used to configure the Ingress.
                 items:
-                  description: IngressRule represents a rule to apply against incoming
-                    requests. Matching is performed based on an (optional) SNI and
-                    port.
+                  description: |-
+                    IngressRule represents a rule to apply against incoming requests.
+                    Matching is performed based on an (optional) SNI and port.
                   properties:
                     backend:
-                      description: Backend defines the referenced service endpoint
-                        to which the traffic will be forwarded to.
+                      description: |-
+                        Backend defines the referenced service endpoint to which the traffic
+                        will be forwarded to.
                       properties:
                         serviceName:
                           description: Specifies the name of the referenced service.
@@ -1658,19 +2637,20 @@ spec:
                       - servicePort
                       type: object
                     host:
-                      description: Host is the fully qualified domain name of a network
-                        host, as defined by RFC 3986. If a Host is not specified,
-                        then port-based TCP routing is performed. Kong doesn't care
-                        about the content of the TCP stream in this case. If a Host
-                        is specified, the protocol must be TLS over TCP. A plain-text
-                        TCP request cannot be routed based on Host. It can only be
-                        routed based on Port.
+                      description: |-
+                        Host is the fully qualified domain name of a network host, as defined
+                        by RFC 3986.
+                        If a Host is not specified, then port-based TCP routing is performed. Kong
+                        doesn't care about the content of the TCP stream in this case.
+                        If a Host is specified, the protocol must be TLS over TCP.
+                        A plain-text TCP request cannot be routed based on Host. It can only
+                        be routed based on Port.
                       type: string
                     port:
-                      description: Port is the port on which to accept TCP or TLS
-                        over TCP sessions and route. It is a required field. If a
-                        Host is not specified, the requested are routed based only
-                        on Port.
+                      description: |-
+                        Port is the port on which to accept TCP or TLS over TCP sessions and
+                        route. It is a required field. If a Host is not specified, the requested
+                        are routed based only on Port.
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -1681,19 +2661,22 @@ spec:
                   type: object
                 type: array
               tls:
-                description: TLS configuration. This is similar to the `tls` section
-                  in the Ingress resource in networking.v1beta1 group. The mapping
-                  of SNIs to TLS cert-key pair defined here will be used for HTTP
-                  Ingress rules as well. Once can define the mapping in this resource
-                  or the original Ingress resource, both have the same effect.
+                description: |-
+                  TLS configuration. This is similar to the `tls` section in the
+                  Ingress resource in networking.v1beta1 group.
+                  The mapping of SNIs to TLS cert-key pair defined here will be
+                  used for HTTP Ingress rules as well. Once can define the mapping in
+                  this resource or the original Ingress resource, both have the same
+                  effect.
                 items:
                   description: IngressTLS describes the transport layer security.
                   properties:
                     hosts:
-                      description: Hosts are a list of hosts included in the TLS certificate.
-                        The values in this list must match the name/s used in the
-                        tlsSecret. Defaults to the wildcard host setting for the loadbalancer
-                        controller fulfilling this Ingress, if left unspecified.
+                      description: |-
+                        Hosts are a list of hosts included in the TLS certificate. The values in
+                        this list must match the name/s used in the tlsSecret. Defaults to the
+                        wildcard host setting for the loadbalancer controller fulfilling this
+                        Ingress, if left unspecified.
                       items:
                         type: string
                       type: array
@@ -1711,37 +2694,49 @@ spec:
                 description: LoadBalancer contains the current status of the load-balancer.
                 properties:
                   ingress:
-                    description: Ingress is a list containing ingress points for the
-                      load-balancer. Traffic intended for the service should be sent
-                      to these ingress points.
+                    description: |-
+                      Ingress is a list containing ingress points for the load-balancer.
+                      Traffic intended for the service should be sent to these ingress points.
                     items:
-                      description: 'LoadBalancerIngress represents the status of a
-                        load-balancer ingress point: traffic intended for the service
-                        should be sent to an ingress point.'
+                      description: |-
+                        LoadBalancerIngress represents the status of a load-balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
                       properties:
                         hostname:
-                          description: Hostname is set for load-balancer ingress points
-                            that are DNS based (typically AWS load-balancers)
+                          description: |-
+                            Hostname is set for load-balancer ingress points that are DNS based
+                            (typically AWS load-balancers)
                           type: string
                         ip:
-                          description: IP is set for load-balancer ingress points
-                            that are IP based (typically GCE or OpenStack load-balancers)
+                          description: |-
+                            IP is set for load-balancer ingress points that are IP based
+                            (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ipMode:
+                          description: |-
+                            IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                            Setting this to "VIP" indicates that traffic is delivered to the node with
+                            the destination set to the load-balancer's IP and port.
+                            Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                            the destination set to the node's IP and node port or the pod's IP and port.
+                            Service implementations may use this information to adjust traffic routing.
                           type: string
                         ports:
-                          description: Ports is a list of records of service ports
-                            If used, every port defined in the service should have
-                            an entry in it
+                          description: |-
+                            Ports is a list of records of service ports
+                            If used, every port defined in the service should have an entry in it
                           items:
                             properties:
                               error:
-                                description: 'Error is to record the problem with
-                                  the service port The format of the error shall comply
-                                  with the following rules: - built-in error values
-                                  shall be specified in this file and those shall
-                                  use CamelCase names - cloud provider specific error
-                                  values must have names that comply with the format
-                                  foo.example.com/CamelCase. --- The regex it matches
-                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                description: |-
+                                  Error is to record the problem with the service port
+                                  The format of the error shall comply with the following rules:
+                                  - built-in error values shall be specified in this file and those shall use
+                                    CamelCase names
+                                  - cloud provider specific error values must have names that comply with the
+                                    format foo.example.com/CamelCase.
+                                  ---
+                                  The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                                 maxLength: 316
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                 type: string
@@ -1752,9 +2747,9 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: 'Protocol is the protocol of the service
-                                  port of which status is recorded here The supported
-                                  values are: "TCP", "UDP", "SCTP"'
+                                description: |-
+                                  Protocol is the protocol of the service port of which status is recorded here
+                                  The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
                             - port
@@ -1776,7 +2771,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: udpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1804,14 +2799,19 @@ spec:
         description: UDPIngress is the Schema for the udpingresses API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -1821,13 +2821,15 @@ spec:
               rules:
                 description: A list of rules used to configure the Ingress.
                 items:
-                  description: UDPIngressRule represents a rule to apply against incoming
-                    requests wherein no Host matching is available for request routing,
-                    only the port is used to match requests.
+                  description: |-
+                    UDPIngressRule represents a rule to apply against incoming requests
+                    wherein no Host matching is available for request routing, only the port
+                    is used to match requests.
                   properties:
                     backend:
-                      description: Backend defines the Kubernetes service which accepts
-                        traffic from the listening Port defined above.
+                      description: |-
+                        Backend defines the Kubernetes service which accepts traffic from the
+                        listening Port defined above.
                       properties:
                         serviceName:
                           description: Specifies the name of the referenced service.
@@ -1844,9 +2846,9 @@ spec:
                       - servicePort
                       type: object
                     port:
-                      description: Port indicates the port for the Kong proxy to accept
-                        incoming traffic on, which will then be routed to the service
-                        Backend.
+                      description: |-
+                        Port indicates the port for the Kong proxy to accept incoming traffic
+                        on, which will then be routed to the service Backend.
                       format: int32
                       maximum: 65535
                       minimum: 1
@@ -1864,37 +2866,49 @@ spec:
                 description: LoadBalancer contains the current status of the load-balancer.
                 properties:
                   ingress:
-                    description: Ingress is a list containing ingress points for the
-                      load-balancer. Traffic intended for the service should be sent
-                      to these ingress points.
+                    description: |-
+                      Ingress is a list containing ingress points for the load-balancer.
+                      Traffic intended for the service should be sent to these ingress points.
                     items:
-                      description: 'LoadBalancerIngress represents the status of a
-                        load-balancer ingress point: traffic intended for the service
-                        should be sent to an ingress point.'
+                      description: |-
+                        LoadBalancerIngress represents the status of a load-balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
                       properties:
                         hostname:
-                          description: Hostname is set for load-balancer ingress points
-                            that are DNS based (typically AWS load-balancers)
+                          description: |-
+                            Hostname is set for load-balancer ingress points that are DNS based
+                            (typically AWS load-balancers)
                           type: string
                         ip:
-                          description: IP is set for load-balancer ingress points
-                            that are IP based (typically GCE or OpenStack load-balancers)
+                          description: |-
+                            IP is set for load-balancer ingress points that are IP based
+                            (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ipMode:
+                          description: |-
+                            IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                            Setting this to "VIP" indicates that traffic is delivered to the node with
+                            the destination set to the load-balancer's IP and port.
+                            Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                            the destination set to the node's IP and node port or the pod's IP and port.
+                            Service implementations may use this information to adjust traffic routing.
                           type: string
                         ports:
-                          description: Ports is a list of records of service ports
-                            If used, every port defined in the service should have
-                            an entry in it
+                          description: |-
+                            Ports is a list of records of service ports
+                            If used, every port defined in the service should have an entry in it
                           items:
                             properties:
                               error:
-                                description: 'Error is to record the problem with
-                                  the service port The format of the error shall comply
-                                  with the following rules: - built-in error values
-                                  shall be specified in this file and those shall
-                                  use CamelCase names - cloud provider specific error
-                                  values must have names that comply with the format
-                                  foo.example.com/CamelCase. --- The regex it matches
-                                  is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
+                                description: |-
+                                  Error is to record the problem with the service port
+                                  The format of the error shall comply with the following rules:
+                                  - built-in error values shall be specified in this file and those shall use
+                                    CamelCase names
+                                  - cloud provider specific error values must have names that comply with the
+                                    format foo.example.com/CamelCase.
+                                  ---
+                                  The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                                 maxLength: 316
                                 pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                                 type: string
@@ -1905,9 +2919,9 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: 'Protocol is the protocol of the service
-                                  port of which status is recorded here The supported
-                                  values are: "TCP", "UDP", "SCTP"'
+                                description: |-
+                                  Protocol is the protocol of the service port of which status is recorded here
+                                  The supported values are: "TCP", "UDP", "SCTP"
                                 type: string
                             required:
                             - port

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -130,7 +130,7 @@ extraLabels: {}
 # Specify Kong's Docker image and repository details here
 image:
   repository: kong
-  tag: "3.5"
+  tag: "3.6"
   # Kong Enterprise
   # repository: kong/kong-gateway
   # tag: "3.5"
@@ -525,7 +525,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "3.0"
+    tag: "3.1"
     # Optionally set a semantic version for version-gated features. This can normally
     # be left unset. You only need to set this if your tag is not a semver string,
     # such as when you are using a "next" tag. Set this to the effective semantic


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps KIC default tag to 3.1 and updates CRDs to match it.

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/5443.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
