### PR TITLE
ingress: bump kong/kong dependency, release 0.11.1

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.11.1
+
+### Improvements
+
+- Bumped dependencies on `kong/kong` chart to `>=2.37.1`. This includes a fix for
+  controller's status port being scraped by Prometheus unnecessarily.
+  [#1013](
+
 ## 0.11.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.37.0
+  version: 2.37.1
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.37.0
-digest: sha256:a5f3ec207495551c68808b3449a6c911db4dcbdca8d0c4810fecf36b429346f4
-generated: "2024-02-19T14:20:29.764917+01:00"
+  version: 2.37.1
+digest: sha256:c5db342a0485e0775d4971d7f72496dffba7c37d95d18024022267df1af659ee
+generated: "2024-02-21T10:38:16.722926+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.11.0
+version: 0.11.1
 appVersion: "3.6"
 dependencies:
   - name: kong
-    version: ">=2.37.0"
+    version: ">=2.37.1"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.37.0"
+    version: ">=2.37.1"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps `kong/ingress` dependencies on `kong/kong` to the latest patch that includes fix for controller's status port being scraped by Prometheus (https://github.com/Kong/charts/commit/42f06344f10351e3813132c1538ee551423cee3e).

#### Which issue this PR fixes

Part of https://github.com/Kong/charts/issues/1005.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
