### PR TITLE
fix(proxy): Add appProtocol as optional field to kong service TLS port

### DIFF
--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller
         namespace: default
     spec:
@@ -108,7 +108,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: controller
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: controller-2.37.0
+                    helm.sh/chart: controller-2.37.1
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -164,7 +164,7 @@ SnapShot = """
                           name: cmetrics
                           protocol: TCP
                         - containerPort: 10254
-                          name: status
+                          name: cstatus
                           protocol: TCP
                       readinessProbe:
                         failureThreshold: 3
@@ -240,7 +240,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: gateway
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: gateway-2.37.0
+            helm.sh/chart: gateway-2.37.1
         name: chartsnap-gateway
         namespace: default
     spec:
@@ -263,7 +263,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: gateway
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: gateway-2.37.0
+                    helm.sh/chart: gateway-2.37.1
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -491,7 +491,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller
     rules:
         - apiGroups:
@@ -771,7 +771,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -790,7 +790,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller
         namespace: default
     rules:
@@ -854,7 +854,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller
         namespace: default
     roleRef:
@@ -877,7 +877,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller-admin-api-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -893,7 +893,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller-admin-api-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -909,7 +909,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -925,7 +925,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -938,7 +938,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller-validation-webhook
         namespace: default
     spec:
@@ -953,7 +953,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
 - object:
     apiVersion: v1
     kind: Service
@@ -963,7 +963,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: gateway
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: gateway-2.37.0
+            helm.sh/chart: gateway-2.37.1
         name: chartsnap-gateway-admin
         namespace: default
     spec:
@@ -987,7 +987,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: gateway
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: gateway-2.37.0
+            helm.sh/chart: gateway-2.37.1
         name: chartsnap-gateway-manager
         namespace: default
     spec:
@@ -1015,7 +1015,7 @@ SnapShot = """
             app.kubernetes.io/name: gateway
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: gateway-2.37.0
+            helm.sh/chart: gateway-2.37.1
         name: chartsnap-gateway-proxy
         namespace: default
     spec:
@@ -1042,7 +1042,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: controller
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.37.0
+            helm.sh/chart: controller-2.37.1
         name: chartsnap-controller
         namespace: default
 - object:
@@ -1054,7 +1054,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: gateway
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: gateway-2.37.0
+            helm.sh/chart: gateway-2.37.1
         name: chartsnap-gateway
         namespace: default
 """

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.38.0
+
+### Changes
+
+* Allowed setting `SVC.tls.appProtocol` that will set the Kubernetes Service's TLS port
+  `appProtocol` field to a configured value. This can be useful when integrating with
+  external load balancers that require the `appProtocol` field to be set (e.g. GCP).
+  [#1018](https://github.com/Kong/charts/pull/1018)
+
 ## 2.37.1
 
 * Rename the controller status port. This fixes a collision with the proxy status port in the Prometheus ServiceMonitor.

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### Changes
 
-* Allowed setting `SVC.tls.appProtocol` that will set the Kubernetes Service's TLS port
-  `appProtocol` field to a configured value. This can be useful when integrating with
-  external load balancers that require the `appProtocol` field to be set (e.g. GCP).
+* Added support for setting `SVC.tls.appProtocol` and `SVC.http.appProtocol` values to configure the appProtocol fields
+  for Kubernetes Service HTTP and TLS ports. It might be useful for integration with external load balancers like GCP.
   [#1018](https://github.com/Kong/charts/pull/1018)
 
 ## 2.37.1

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.37.1
+version: 2.38.0
 appVersion: "3.6"
 dependencies:
   - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -666,41 +666,42 @@ nodes.
 mixed TCP/UDP LoadBalancer Services). It _does not_ support the `http`, `tls`,
 or `ingress` sections, as it is used only for stream listens.
 
-| Parameter                         | Description                                                                        | Default                  |
-|-----------------------------------|------------------------------------------------------------------------------------|--------------------------|
-| SVC.enabled                       | Create Service resource for SVC (admin, proxy, manager, etc.)                      |                          |
-| SVC.http.enabled                  | Enables http on the service                                                        |                          |
-| SVC.http.servicePort              | Service port to use for http                                                       |                          |
-| SVC.http.containerPort            | Container port to use for http                                                     |                          |
-| SVC.http.nodePort                 | Node port to use for http                                                          |                          |
-| SVC.http.hostPort                 | Host port to use for http                                                          |                          |
-| SVC.http.parameters               | Array of additional listen parameters                                              | `[]`                     |
-| SVC.tls.enabled                   | Enables TLS on the service                                                         |                          |
-| SVC.tls.containerPort             | Container port to use for TLS                                                      |                          |
-| SVC.tls.servicePort               | Service port to use for TLS                                                        |                          |
-| SVC.tls.nodePort                  | Node port to use for TLS                                                           |                          |
-| SVC.tls.hostPort                  | Host port to use for TLS                                                           |                          |
-| SVC.tls.overrideServiceTargetPort | Override service port to use for TLS without touching Kong containerPort           |                          |
-| SVC.tls.parameters                | Array of additional listen parameters                                              | `["http2"]`              |
-| SVC.tls.appProtocol               | `appProtocol` to be set in a Service. If left empty, no `appProtocol` will be set. |                          |
-| SVC.type                          | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                       |                          |
-| SVC.clusterIP                     | k8s service clusterIP                                                              |                          |
-| SVC.loadBalancerClass             | loadBalancerClass to use for LoadBalancer provisionning                            |                          |
-| SVC.loadBalancerSourceRanges      | Limit service access to CIDRs if set and service type is `LoadBalancer`            | `[]`                     |
-| SVC.loadBalancerIP                | Reuse an existing ingress static IP for the service                                |                          |
-| SVC.externalIPs                   | IPs for which nodes in the cluster will also accept traffic for the servic         | `[]`                     |
-| SVC.externalTrafficPolicy         | k8s service's externalTrafficPolicy. Options: Cluster, Local                       |                          |
-| SVC.ingress.enabled               | Enable ingress resource creation (works with SVC.type=ClusterIP)                   | `false`                  |
-| SVC.ingress.ingressClassName      | Set the ingressClassName to associate this Ingress with an IngressClass            |                          |
-| SVC.ingress.hostname              | Ingress hostname                                                                   | `""`                     |
-| SVC.ingress.path                  | Ingress path.                                                                      | `/`                      |
-| SVC.ingress.pathType              | Ingress pathType. One of `ImplementationSpecific`, `Exact` or `Prefix`             | `ImplementationSpecific` |
-| SVC.ingress.hosts                 | Slice of hosts configurations, including `hostname`, `path` and `pathType` keys    | `[]`                     |
-| SVC.ingress.tls                   | Name of secret resource or slice of `secretName` and `hosts` keys                  |                          |
-| SVC.ingress.annotations           | Ingress annotations. See documentation for your ingress controller for details     | `{}`                     |
-| SVC.ingress.labels                | Ingress labels. Additional custom labels to add to the ingress.                    | `{}`                     |
-| SVC.annotations                   | Service annotations                                                                | `{}`                     |
-| SVC.labels                        | Service labels                                                                     | `{}`                     |
+| Parameter                         | Description                                                                               | Default                  |
+|-----------------------------------|-------------------------------------------------------------------------------------------|--------------------------|
+| SVC.enabled                       | Create Service resource for SVC (admin, proxy, manager, etc.)                             |                          |
+| SVC.http.enabled                  | Enables http on the service                                                               |                          |
+| SVC.http.servicePort              | Service port to use for http                                                              |                          |
+| SVC.http.containerPort            | Container port to use for http                                                            |                          |
+| SVC.http.nodePort                 | Node port to use for http                                                                 |                          |
+| SVC.http.hostPort                 | Host port to use for http                                                                 |                          |
+| SVC.http.parameters               | Array of additional listen parameters                                                     | `[]`                     |
+| SVC.http.appProtocol              | `appProtocol` to be set in a Service's port. If left empty, no `appProtocol` will be set. |                          |
+| SVC.tls.enabled                   | Enables TLS on the service                                                                |                          |
+| SVC.tls.containerPort             | Container port to use for TLS                                                             |                          |
+| SVC.tls.servicePort               | Service port to use for TLS                                                               |                          |
+| SVC.tls.nodePort                  | Node port to use for TLS                                                                  |                          |
+| SVC.tls.hostPort                  | Host port to use for TLS                                                                  |                          |
+| SVC.tls.overrideServiceTargetPort | Override service port to use for TLS without touching Kong containerPort                  |                          |
+| SVC.tls.parameters                | Array of additional listen parameters                                                     | `["http2"]`              |
+| SVC.tls.appProtocol               | `appProtocol` to be set in a Service's port. If left empty, no `appProtocol` will be set. |                          |
+| SVC.type                          | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                              |                          |
+| SVC.clusterIP                     | k8s service clusterIP                                                                     |                          |
+| SVC.loadBalancerClass             | loadBalancerClass to use for LoadBalancer provisionning                                   |                          |
+| SVC.loadBalancerSourceRanges      | Limit service access to CIDRs if set and service type is `LoadBalancer`                   | `[]`                     |
+| SVC.loadBalancerIP                | Reuse an existing ingress static IP for the service                                       |                          |
+| SVC.externalIPs                   | IPs for which nodes in the cluster will also accept traffic for the servic                | `[]`                     |
+| SVC.externalTrafficPolicy         | k8s service's externalTrafficPolicy. Options: Cluster, Local                              |                          |
+| SVC.ingress.enabled               | Enable ingress resource creation (works with SVC.type=ClusterIP)                          | `false`                  |
+| SVC.ingress.ingressClassName      | Set the ingressClassName to associate this Ingress with an IngressClass                   |                          |
+| SVC.ingress.hostname              | Ingress hostname                                                                          | `""`                     |
+| SVC.ingress.path                  | Ingress path.                                                                             | `/`                      |
+| SVC.ingress.pathType              | Ingress pathType. One of `ImplementationSpecific`, `Exact` or `Prefix`                    | `ImplementationSpecific` |
+| SVC.ingress.hosts                 | Slice of hosts configurations, including `hostname`, `path` and `pathType` keys           | `[]`                     |
+| SVC.ingress.tls                   | Name of secret resource or slice of `secretName` and `hosts` keys                         |                          |
+| SVC.ingress.annotations           | Ingress annotations. See documentation for your ingress controller for details            | `{}`                     |
+| SVC.ingress.labels                | Ingress labels. Additional custom labels to add to the ingress.                           | `{}`                     |
+| SVC.annotations                   | Service annotations                                                                       | `{}`                     |
+| SVC.labels                        | Service labels                                                                            | `{}`                     |
 
 #### Admin Service mTLS
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -666,40 +666,41 @@ nodes.
 mixed TCP/UDP LoadBalancer Services). It _does not_ support the `http`, `tls`,
 or `ingress` sections, as it is used only for stream listens.
 
-| Parameter                          | Description                                                                           | Default                  |
-|------------------------------------|---------------------------------------------------------------------------------------|--------------------------|
-| SVC.enabled                        | Create Service resource for SVC (admin, proxy, manager, etc.)                         |                          |
-| SVC.http.enabled                   | Enables http on the service                                                           |                          |
-| SVC.http.servicePort               | Service port to use for http                                                          |                          |
-| SVC.http.containerPort             | Container port to use for http                                                        |                          |
-| SVC.http.nodePort                  | Node port to use for http                                                             |                          |
-| SVC.http.hostPort                  | Host port to use for http                                                             |                          |
-| SVC.http.parameters                | Array of additional listen parameters                                                 | `[]`                     |
-| SVC.tls.enabled                    | Enables TLS on the service                                                            |                          |
-| SVC.tls.containerPort              | Container port to use for TLS                                                         |                          |
-| SVC.tls.servicePort                | Service port to use for TLS                                                           |                          |
-| SVC.tls.nodePort                   | Node port to use for TLS                                                              |                          |
-| SVC.tls.hostPort                   | Host port to use for TLS                                                              |                          |
-| SVC.tls.overrideServiceTargetPort  | Override service port to use for TLS without touching Kong containerPort              |                          |
-| SVC.tls.parameters                 | Array of additional listen parameters                                                 | `["http2"]`              |
-| SVC.type                           | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                          |                          |
-| SVC.clusterIP                      | k8s service clusterIP                                                                 |                          |
-| SVC.loadBalancerClass              | loadBalancerClass to use for LoadBalancer provisionning                               |                          |
-| SVC.loadBalancerSourceRanges       | Limit service access to CIDRs if set and service type is `LoadBalancer`               | `[]`                     |
-| SVC.loadBalancerIP                 | Reuse an existing ingress static IP for the service                                   |                          |
-| SVC.externalIPs                    | IPs for which nodes in the cluster will also accept traffic for the servic            | `[]`                     |
-| SVC.externalTrafficPolicy          | k8s service's externalTrafficPolicy. Options: Cluster, Local                          |                          |
-| SVC.ingress.enabled                | Enable ingress resource creation (works with SVC.type=ClusterIP)                      | `false`                  |
-| SVC.ingress.ingressClassName       | Set the ingressClassName to associate this Ingress with an IngressClass               |                          |
-| SVC.ingress.hostname               | Ingress hostname                                                                      | `""`                     |
-| SVC.ingress.path                   | Ingress path.                                                                         | `/`                      |
-| SVC.ingress.pathType               | Ingress pathType. One of `ImplementationSpecific`, `Exact` or `Prefix`                | `ImplementationSpecific` |
-| SVC.ingress.hosts                  | Slice of hosts configurations, including `hostname`, `path` and `pathType` keys       | `[]`                     |
-| SVC.ingress.tls                    | Name of secret resource or slice of `secretName` and `hosts` keys                     |                          |
-| SVC.ingress.annotations            | Ingress annotations. See documentation for your ingress controller for details        | `{}`                     |
-| SVC.ingress.labels                 | Ingress labels. Additional custom labels to add to the ingress.                       | `{}`                     |
-| SVC.annotations                    | Service annotations                                                                   | `{}`                     |
-| SVC.labels                         | Service labels                                                                        | `{}`                     |
+| Parameter                         | Description                                                                        | Default                  |
+|-----------------------------------|------------------------------------------------------------------------------------|--------------------------|
+| SVC.enabled                       | Create Service resource for SVC (admin, proxy, manager, etc.)                      |                          |
+| SVC.http.enabled                  | Enables http on the service                                                        |                          |
+| SVC.http.servicePort              | Service port to use for http                                                       |                          |
+| SVC.http.containerPort            | Container port to use for http                                                     |                          |
+| SVC.http.nodePort                 | Node port to use for http                                                          |                          |
+| SVC.http.hostPort                 | Host port to use for http                                                          |                          |
+| SVC.http.parameters               | Array of additional listen parameters                                              | `[]`                     |
+| SVC.tls.enabled                   | Enables TLS on the service                                                         |                          |
+| SVC.tls.containerPort             | Container port to use for TLS                                                      |                          |
+| SVC.tls.servicePort               | Service port to use for TLS                                                        |                          |
+| SVC.tls.nodePort                  | Node port to use for TLS                                                           |                          |
+| SVC.tls.hostPort                  | Host port to use for TLS                                                           |                          |
+| SVC.tls.overrideServiceTargetPort | Override service port to use for TLS without touching Kong containerPort           |                          |
+| SVC.tls.parameters                | Array of additional listen parameters                                              | `["http2"]`              |
+| SVC.tls.appProtocol               | `appProtocol` to be set in a Service. If left empty, no `appProtocol` will be set. |                          |
+| SVC.type                          | k8s service type. Options: NodePort, ClusterIP, LoadBalancer                       |                          |
+| SVC.clusterIP                     | k8s service clusterIP                                                              |                          |
+| SVC.loadBalancerClass             | loadBalancerClass to use for LoadBalancer provisionning                            |                          |
+| SVC.loadBalancerSourceRanges      | Limit service access to CIDRs if set and service type is `LoadBalancer`            | `[]`                     |
+| SVC.loadBalancerIP                | Reuse an existing ingress static IP for the service                                |                          |
+| SVC.externalIPs                   | IPs for which nodes in the cluster will also accept traffic for the servic         | `[]`                     |
+| SVC.externalTrafficPolicy         | k8s service's externalTrafficPolicy. Options: Cluster, Local                       |                          |
+| SVC.ingress.enabled               | Enable ingress resource creation (works with SVC.type=ClusterIP)                   | `false`                  |
+| SVC.ingress.ingressClassName      | Set the ingressClassName to associate this Ingress with an IngressClass            |                          |
+| SVC.ingress.hostname              | Ingress hostname                                                                   | `""`                     |
+| SVC.ingress.path                  | Ingress path.                                                                      | `/`                      |
+| SVC.ingress.pathType              | Ingress pathType. One of `ImplementationSpecific`, `Exact` or `Prefix`             | `ImplementationSpecific` |
+| SVC.ingress.hosts                 | Slice of hosts configurations, including `hostname`, `path` and `pathType` keys    | `[]`                     |
+| SVC.ingress.tls                   | Name of secret resource or slice of `secretName` and `hosts` keys                  |                          |
+| SVC.ingress.annotations           | Ingress annotations. See documentation for your ingress controller for details     | `{}`                     |
+| SVC.ingress.labels                | Ingress labels. Additional custom labels to add to the ingress.                    | `{}`                     |
+| SVC.annotations                   | Service annotations                                                                | `{}`                     |
+| SVC.labels                        | Service labels                                                                     | `{}`                     |
 
 #### Admin Service mTLS
 

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -275,7 +275,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -287,7 +287,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-admin
         namespace: default
     spec:
@@ -310,7 +310,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -338,7 +338,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -365,7 +365,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -85,7 +85,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -109,7 +109,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -409,7 +409,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -690,7 +690,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -710,7 +710,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -775,7 +775,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -799,7 +799,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -816,7 +816,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -830,7 +830,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -859,7 +859,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -887,7 +887,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -903,7 +903,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -914,7 +914,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -431,7 +431,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -711,7 +711,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -730,7 +730,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -794,7 +794,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -817,7 +817,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -833,7 +833,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -855,7 +855,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -883,7 +883,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -910,7 +910,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -925,7 +925,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -935,7 +935,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -433,7 +433,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -713,7 +713,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -732,7 +732,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -796,7 +796,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -819,7 +819,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -835,7 +835,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -857,7 +857,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -885,7 +885,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -912,7 +912,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -927,7 +927,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -937,7 +937,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -429,7 +429,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -709,7 +709,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -728,7 +728,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -792,7 +792,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -815,7 +815,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -831,7 +831,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -844,7 +844,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -872,7 +872,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -899,7 +899,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -914,7 +914,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -924,7 +924,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -464,7 +464,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -744,7 +744,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -763,7 +763,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -827,7 +827,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -850,7 +850,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -866,7 +866,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -897,7 +897,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -925,7 +925,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -952,7 +952,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -967,7 +967,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -977,7 +977,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -411,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -691,7 +691,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -710,7 +710,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -774,7 +774,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -797,7 +797,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -813,7 +813,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -826,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -854,7 +854,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -881,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -896,7 +896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -906,7 +906,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -1,4 +1,4 @@
-[proxy-tls-appprotocol-values]
+[proxy-appprotocol-values]
 SnapShot = """
 - object:
     apiVersion: admissionregistration.k8s.io/v1
@@ -853,7 +853,8 @@ SnapShot = """
         namespace: default
     spec:
         ports:
-            - name: kong-proxy
+            - appProtocol: http
+              name: kong-proxy
               port: 80
               protocol: TCP
               targetPort: 8000

--- a/charts/kong/ci/__snapshots__/proxy-tls-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-tls-appprotocol-values.snap
@@ -1,4 +1,4 @@
-[default-values]
+[proxy-tls-appprotocol-values]
 SnapShot = """
 - object:
     apiVersion: admissionregistration.k8s.io/v1
@@ -125,8 +125,6 @@ SnapShot = """
                                 fieldPath: metadata.namespace
                         - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
                           value: 0.0.0.0:8080
-                        - name: CONTROLLER_ANONYMOUS_REPORTS
-                          value: \"false\"
                         - name: CONTROLLER_ELECTION_ID
                           value: kong-ingress-controller-leader-kong
                         - name: CONTROLLER_INGRESS_CLASS
@@ -199,8 +197,6 @@ SnapShot = """
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
                           value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -313,8 +309,6 @@ SnapShot = """
                           value: /dev/stderr
                         - name: KONG_ADMIN_LISTEN
                           value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
                         - name: KONG_CLUSTER_LISTEN
                           value: \"off\"
                         - name: KONG_DATABASE
@@ -863,7 +857,8 @@ SnapShot = """
               port: 80
               protocol: TCP
               targetPort: 8000
-            - name: kong-proxy-tls
+            - appProtocol: https
+              name: kong-proxy-tls
               port: 443
               protocol: TCP
               targetPort: 8443

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -405,7 +405,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -685,7 +685,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -704,7 +704,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -768,7 +768,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -791,7 +791,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -807,7 +807,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -820,7 +820,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -848,7 +848,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -875,7 +875,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -890,7 +890,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -900,7 +900,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: my-kong-sa
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -411,7 +411,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -691,7 +691,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -710,7 +710,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -774,7 +774,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -797,7 +797,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -813,7 +813,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -826,7 +826,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -854,7 +854,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -881,7 +881,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -896,7 +896,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -906,7 +906,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -33,7 +33,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -250,7 +250,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -278,7 +278,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -305,7 +305,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -106,7 +106,7 @@ SnapShot = """
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
                     environment: test
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -448,7 +448,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -474,7 +474,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -498,7 +498,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -778,7 +778,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -797,7 +797,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -861,7 +861,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -884,7 +884,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -900,7 +900,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -913,7 +913,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -941,7 +941,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -968,7 +968,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -983,7 +983,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: ServiceAccount
@@ -993,7 +993,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -84,7 +84,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -112,7 +112,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -725,7 +725,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -741,7 +741,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -978,7 +978,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -994,7 +994,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1233,7 +1233,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1249,7 +1249,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1482,7 +1482,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1506,7 +1506,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1565,7 +1565,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1584,7 +1584,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1648,7 +1648,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-default
         namespace: default
     rules:
@@ -1882,7 +1882,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1902,7 +1902,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-default
         namespace: default
     roleRef:
@@ -1928,7 +1928,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1950,7 +1950,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1966,7 +1966,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1994,7 +1994,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -2022,7 +2022,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -2057,7 +2057,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -2072,7 +2072,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: Service
@@ -2132,7 +2132,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -296,7 +296,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -308,7 +308,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -336,7 +336,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -363,7 +363,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -10,7 +10,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -34,7 +34,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -272,7 +272,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -305,7 +305,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-custom-dbless-config
         namespace: default
 - object:
@@ -317,7 +317,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -345,7 +345,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -380,7 +380,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -9,7 +9,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validations
         namespace: default
     webhooks:
@@ -83,7 +83,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     spec:
@@ -111,7 +111,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                     version: \"3.6\"
             spec:
                 automountServiceAccountToken: false
@@ -695,7 +695,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-init-migrations
         namespace: default
     spec:
@@ -711,7 +711,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                 name: kong-init-migrations
             spec:
                 automountServiceAccountToken: false
@@ -933,7 +933,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-post-upgrade-migrations
         namespace: default
     spec:
@@ -949,7 +949,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                 name: kong-post-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1173,7 +1173,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-pre-upgrade-migrations
         namespace: default
     spec:
@@ -1189,7 +1189,7 @@ SnapShot = """
                     app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: kong
                     app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.37.1
+                    helm.sh/chart: kong-2.38.0
                 name: kong-pre-upgrade-migrations
             spec:
                 automountServiceAccountToken: false
@@ -1407,7 +1407,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1431,7 +1431,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     rules:
         - apiGroups:
@@ -1711,7 +1711,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
     roleRef:
         apiGroup: rbac.authorization.k8s.io
@@ -1730,7 +1730,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     rules:
@@ -1794,7 +1794,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
     roleRef:
@@ -1820,7 +1820,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-bash-wait-for-postgres
         namespace: default
 - object:
@@ -1835,7 +1835,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-ca-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1851,7 +1851,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook-keypair
         namespace: default
     type: kubernetes.io/tls
@@ -1879,7 +1879,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-manager
         namespace: default
     spec:
@@ -1907,7 +1907,7 @@ SnapShot = """
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
             enable-metrics: \"true\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-proxy
         namespace: default
     spec:
@@ -1934,7 +1934,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong-validation-webhook
         namespace: default
     spec:
@@ -1949,7 +1949,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
 - object:
     apiVersion: v1
     kind: Service
@@ -2009,7 +2009,7 @@ SnapShot = """
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: kong
             app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.37.1
+            helm.sh/chart: kong-2.38.0
         name: chartsnap-kong
         namespace: default
 """

--- a/charts/kong/ci/proxy-appprotocol-values.yaml
+++ b/charts/kong/ci/proxy-appprotocol-values.yaml
@@ -1,0 +1,7 @@
+# This values test that the `proxy.*.appProtocol` can be set to a custom value.
+
+proxy:
+  http:
+    appProtocol: "http"
+  tls:
+    appProtocol: "https"

--- a/charts/kong/ci/proxy-tls-appprotocol-values.yaml
+++ b/charts/kong/ci/proxy-tls-appprotocol-values.yaml
@@ -1,0 +1,5 @@
+# This values test that the `SVC.tls.appProtocol` can be set to a custom value.
+
+proxy:
+  tls:
+    appProtocol: "https"

--- a/charts/kong/ci/proxy-tls-appprotocol-values.yaml
+++ b/charts/kong/ci/proxy-tls-appprotocol-values.yaml
@@ -1,5 +1,0 @@
-# This values test that the `SVC.tls.appProtocol` can be set to a custom value.
-
-proxy:
-  tls:
-    appProtocol: "https"

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -222,7 +222,10 @@ spec:
   {{- if .tls.enabled }}
   - name: kong-{{ .serviceName }}-tls
     port: {{ .tls.servicePort }}
-    targetPort: {{ .tls.overrideServiceTargetPort | default .tls.containerPort }}
+    targetPort: {{ .tls.overrideServiceTargetPort | default .tls.containerPort 
+  {{- if .tls.appProtocol }}
+    appProtocol: {{ .tls.appProtocol }}
+  {{- end }}
   {{- if (and (or (eq .type "LoadBalancer") (eq .type "NodePort")) (not (empty .tls.nodePort))) }}
     nodePort: {{ .tls.nodePort }}
   {{- end }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -222,7 +222,7 @@ spec:
   {{- if .tls.enabled }}
   - name: kong-{{ .serviceName }}-tls
     port: {{ .tls.servicePort }}
-    targetPort: {{ .tls.overrideServiceTargetPort | default .tls.containerPort 
+    targetPort: {{ .tls.overrideServiceTargetPort | default .tls.containerPort }}
   {{- if .tls.appProtocol }}
     appProtocol: {{ .tls.appProtocol }}
   {{- end }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -213,6 +213,9 @@ spec:
   - name: kong-{{ .serviceName }}
     port: {{ .http.servicePort }}
     targetPort: {{ .http.containerPort }}
+  {{- if .http.appProtocol }}
+    appProtocol: {{ .http.appProtocol }}
+  {{- end }}
   {{- if (and (or (eq .type "LoadBalancer") (eq .type "NodePort")) (not (empty .http.nodePort))) }}
     nodePort: {{ .http.nodePort }}
   {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -317,6 +317,10 @@ proxy:
     parameters:
     - http2
 
+    # Specify the Service's TLS port's appProtocol. This can be useful when integrating with
+    # external load balancers that require the `appProtocol` field to be set (e.g. GCP).
+    appProtocol: ""
+
   # Define stream (TCP) listen
   # To enable, remove "[]", uncomment the section below, and select your desired
   # ports and parameters. Listens are dynamically named after their containerPort,


### PR DESCRIPTION
Raised case no. 00042199

When configuring a GCP internal application load balancer for Kong via the networking.gke.io/v1 API, the appProtocol field for the kong service needs to set for GCP to correctly set the backend protocol to HTTPS. I have verified this by editing the chart and can confirm that this fixes the issue. Unfortunately, appProtocol was removed from the chart on 19/01/23 to fix AKS loadbalancer: https://github.com/Kong/charts/pull/705/files.

This change would allow the appProtocol field to be set optionally, so that both cases would work.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
