### PR TITLE
feat(services)  use servicePort=0 to disable http port on service for tls terminated at LB

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -210,6 +210,7 @@ spec:
   ports:
   {{- if .http }}
   {{- if .http.enabled }}
+  {{- if ne ( .http.servicePort | toString ) "0" }}
   - name: kong-{{ .serviceName }}
     port: {{ .http.servicePort }}
     targetPort: {{ .http.containerPort }}
@@ -220,6 +221,7 @@ spec:
     nodePort: {{ .http.nodePort }}
   {{- end }}
     protocol: TCP
+  {{- end }}
   {{- end }}
   {{- end }}
   {{- if .tls.enabled }}
@@ -329,7 +331,9 @@ Parameters: takes a service (e.g. .Values.proxy) as its argument and returns KON
   {{- $portMaps := list -}}
 
   {{- if .http.enabled -}}
+  {{- if ne (.http.servicePort | toString ) "0" -}}
         {{- $portMaps = append $portMaps (printf "%d:%d" (int64 .http.servicePort) (int64 .http.containerPort)) -}}
+  {{- end -}}
   {{- end -}}
 
   {{- if .tls.enabled -}}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -297,6 +297,9 @@ proxy:
   http:
     # Enable plaintext HTTP listen for the proxy
     enabled: true
+    # Set the servicePort: 0 to skip exposing in the service but still
+    # let the port open in container to allow https to http mapping for
+    # tls terminated at LB.
     servicePort: 80
     containerPort: 8000
     # Set a nodePort which is available if service type is NodePort


### PR DESCRIPTION
#### What this PR does / why we need it:
With this change, servicePort=0 can be used to disable http port on service for the services exposed by LoadBalancer(for ex: proxy-service) and TLS is terminated at LB.
This is helpful in the below scenario:
- SSL/TLS terminated at Load Balancer and therefore LB sends HTTP traffic to service.
- We use overrideServiceTargetPort to map service TLS port to container HTTP port.
- However, service still keeps exposing HTTP port which is not desired however its required to expose the http port on container.
-  where its desired to only enable TLS in service however the TLS port in service is mapped to http port in container. 

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
