### PR TITLE
kgo: fix webhook

### DIFF
--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
+        control-plane: controller-manager
         {{- include "kong.metaLabels" . | nindent 8 }}
         app.kubernetes.io/component: kgo
         app: {{ template "kong.fullname" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

KGO creates its webhook with hardcoded label: https://github.com/Kong/gateway-operator/blob/05d19d708ee88c4c55213b51de2741518304902d/pkg/utils/kubernetes/resources/services.go#L42

That's why we need to add this label to KGO's Pods to be able to select them. This is what this PR is for.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
