### PR TITLE
chore(RBAC) disable session conf secret if not set

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+* Updated handling of `session_conf_secret` to accommodate Kong 3.6.
+  It can now be omitted [when using OIDC](https://docs.konghq.com/gateway/3.6.x/kong-manager/auth/oidc/migrate/).
+
 ## 2.38.0
 
 ### Changes

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1115,8 +1115,10 @@ the template that it itself is using form the above sections.
       {{- $_ := set $autoEnv "KONG_ADMIN_GUI_AUTH_CONF" $guiAuthConf -}}
     {{- end }}
 
-    {{- $guiSessionConf := include "secretkeyref" (dict "name" .Values.enterprise.rbac.session_conf_secret "key" "admin_gui_session_conf") -}}
-    {{- $_ := set $autoEnv "KONG_ADMIN_GUI_SESSION_CONF" $guiSessionConf -}}
+    {{- if .Values.enterprise.rbac.session_conf_secret }}
+      {{- $guiSessionConf := include "secretkeyref" (dict "name" .Values.enterprise.rbac.session_conf_secret "key" "admin_gui_session_conf") -}}
+      {{- $_ := set $autoEnv "KONG_ADMIN_GUI_SESSION_CONF" $guiSessionConf -}}
+    {{- end }}
   {{- end }}
 
   {{- if .Values.enterprise.smtp.enabled }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -1028,7 +1028,9 @@ enterprise:
     # If RBAC is enabled, this Secret must contain an admin_gui_session_conf key
     # The key value must be a secret configuration, following the example at
     # https://docs.konghq.com/enterprise/latest/kong-manager/authentication/sessions
-    session_conf_secret: kong-session-config
+    # If using 3.6+ and OIDC, session configuration is instead handled in the auth configuration,
+    # and this field can be left empty.
+    session_conf_secret: ""  # CHANGEME
     # If admin_gui_auth is not set to basic-auth, provide a secret name which
     # has an admin_gui_auth_conf key containing the plugin config JSON
     admin_gui_auth_conf_secret: CHANGEME-admin-gui-auth-conf-secret


### PR DESCRIPTION
#### What this PR does / why we need it:

Replace the default placeholder value for `enterprise.rbac.session_conf_secret` with an empty string.

Disable configuring a session conf envvar if `session_conf_secret` is not set.

From https://docs.konghq.com/gateway/changelog/#3600 and https://docs.konghq.com/gateway/3.6.x/kong-manager/auth/oidc/migrate/, Kong 3.6+ uses only `KONG_ADMIN_GUI_AUTH_CONF` when using OIDC for Manager.

Prior to 3.6, Kong required `KONG_ADMIN_GUI_SESSION_CONF` when using RBAC. The original chart design effectively required users set `session_conf_secret` as it would try to reference a nonexistent placeholder Secret name otherwise.

#### Special notes for your reviewer:

Waiting for confirmation from the reporter that we don't actually need anything else to handle 3.6 properly.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
