### PR TITLE
support customized service name

### DIFF
--- a/charts/kong/templates/service-kong-admin.yaml
+++ b/charts/kong/templates/service-kong-admin.yaml
@@ -7,7 +7,11 @@
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- if .Values.admin.serviceName }}
+{{- $_ := set $serviceConfig "serviceName" .Values.admin.serviceName -}}
+{{- else }}
 {{- $_ := set $serviceConfig "serviceName" "admin" -}}
+{{- end -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.admin.ingress.enabled }}
 ---

--- a/charts/kong/templates/service-kong-cluster-telemetry.yaml
+++ b/charts/kong/templates/service-kong-cluster-telemetry.yaml
@@ -7,7 +7,11 @@
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- if .Values.clustertelemetry.serviceName }}
+{{- $_ := set $serviceConfig "serviceName" .Values.clustertelemetry.serviceName -}}
+{{- else }}
 {{- $_ := set $serviceConfig "serviceName" "clustertelemetry" -}}
+{{- end -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.clustertelemetry.ingress.enabled }}
 ---

--- a/charts/kong/templates/service-kong-cluster.yaml
+++ b/charts/kong/templates/service-kong-cluster.yaml
@@ -7,7 +7,11 @@
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- if .Values.cluster.serviceName }}
+{{- $_ := set $serviceConfig "serviceName" .Values.cluster.serviceName -}}
+{{- else }}
 {{- $_ := set $serviceConfig "serviceName" "cluster" -}}
+{{- end -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.cluster.ingress.enabled }}
 ---

--- a/charts/kong/templates/service-kong-manager.yaml
+++ b/charts/kong/templates/service-kong-manager.yaml
@@ -7,7 +7,11 @@
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- if .Values.manager.serviceName }}
+{{- $_ := set $serviceConfig "serviceName" .Values.manager.serviceName -}}
+{{- else }}
 {{- $_ := set $serviceConfig "serviceName" "manager" -}}
+{{- end -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.manager.ingress.enabled }}
 ---

--- a/charts/kong/templates/service-kong-portal-api.yaml
+++ b/charts/kong/templates/service-kong-portal-api.yaml
@@ -8,7 +8,11 @@
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- if .Values.portalapi.serviceName }}
+{{- $_ := set $serviceConfig "serviceName" .Values.portalapi.serviceName -}}
+{{- else }}
 {{- $_ := set $serviceConfig "serviceName" "portalapi" -}}
+{{- end -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.portalapi.ingress.enabled }}
 ---

--- a/charts/kong/templates/service-kong-portal.yaml
+++ b/charts/kong/templates/service-kong-portal.yaml
@@ -8,7 +8,11 @@
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- if .Values.portal.serviceName }}
+{{- $_ := set $serviceConfig "serviceName" .Values.portal.serviceName -}}
+{{- else }}
 {{- $_ := set $serviceConfig "serviceName" "portal" -}}
+{{- end -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.portal.ingress.enabled }}
 ---

--- a/charts/kong/templates/service-kong-proxy.yaml
+++ b/charts/kong/templates/service-kong-proxy.yaml
@@ -6,7 +6,11 @@
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- if .Values.proxy.serviceName }}
+{{- $_ := set $serviceConfig "serviceName" .Values.proxy.serviceName -}}
+{{- else }}
 {{- $_ := set $serviceConfig "serviceName" "proxy" -}}
+{{- end -}}
 {{- include "kong.service" $serviceConfig }}
 {{ if .Values.proxy.ingress.enabled }}
 ---

--- a/charts/kong/templates/service-kong-udp-proxy.yaml
+++ b/charts/kong/templates/service-kong-udp-proxy.yaml
@@ -7,7 +7,11 @@
 {{- $_ := set $serviceConfig "namespace" (include "kong.namespace" .) -}}
 {{- $_ := set $serviceConfig "metaLabels" (include "kong.metaLabels" .) -}}
 {{- $_ := set $serviceConfig "selectorLabels" (include "kong.selectorLabels" .) -}}
+{{- if .Values.udpProxy.serviceName }}
+{{- $_ := set $serviceConfig "serviceName" .Values.udpProxy.serviceName -}}
+{{- else }}
 {{- $_ := set $serviceConfig "serviceName" "udp-proxy" -}}
+{{- end -}}
 {{- $_ := set $serviceConfig "tls" (dict "enabled" false) -}}
 {{- $_ := set $serviceConfig "http" (dict "enabled" false) -}}
 {{- include "kong.service" $serviceConfig }}


### PR DESCRIPTION


#### What this PR does / why we need it:

We'd like to customize the service name for the different kong gateway components because we're running the kong gateway in kong mesh, but the  kuma sidecar just picked up the Kong Gateway service name alphabetically. 

we just want to use the kong-proxy service name to be the 1st one in the alphabet order to keep it consistent even after we enabled kong-admin service.

e.g we will change admin to zadmin.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
