### PR TITLE
kgo: remove controllers related defaults

### DIFF
--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.1.1
+version: 0.1.2
 appVersion: "1.2.0"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/disable-gateway-controller-values.yaml
+++ b/charts/gateway-operator/ci/disable-gateway-controller-values.yaml
@@ -1,0 +1,3 @@
+env:
+  # gateway controller
+  enable_gateway_controller: false

--- a/charts/gateway-operator/templates/_helpers.tpl
+++ b/charts/gateway-operator/templates/_helpers.tpl
@@ -49,15 +49,28 @@ app.kubernetes.io/instance: "{{ .Release.Name }}"
 {{- end -}}
 
 {{- define "kong.env" -}}
+
 {{- $userEnv := dict -}}
 {{- range $key, $val := .Values.env }}
   {{- $upper := upper $key -}}
-  {{- $_ := set $userEnv $upper $val -}}
+  {{- $var := printf "GATEWAY_OPERATOR_%s" $upper -}}
+  {{- $_ := set $userEnv $var $val -}}
 {{- end -}}
 {{- range $key, $val := $userEnv }}
 - name: {{ $key }}
   value: {{ $val | quote }}
 {{- end -}}
+
+{{- $customEnv := dict -}}
+{{- range $key, $val := .Values.customEnv }}
+  {{- $upper := upper $key -}}
+  {{- $_ := set $customEnv $upper $val -}}
+{{- end -}}
+{{- range $key, $val := $customEnv }}
+- name: {{ $key }}
+  value: {{ $val | quote }}
+{{- end -}}
+
 {{- end -}}
 
 {{- define "kong.volumes" -}}

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -31,23 +31,6 @@ spec:
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
-        {{- if .Values.controllers }}
-        {{- if .Values.controllers.controlplaneController }}
-        - --enable-controller-controlplane={{ .Values.controllers.controlplaneController.enabled }}
-        {{- end }}
-        {{- if .Values.controllers.gatewayController }}
-        - --enable-controller-gateway={{ .Values.controllers.gatewayController.enabled }}
-        {{- end }}
-        {{- if .Values.controllers.dataplaneController }}
-        - --enable-controller-dataplane={{ .Values.controllers.dataplaneController.enabled }}
-        {{- end }}
-        {{- if .Values.controllers.dataplaneBlueGreenController }}
-        - --enable-controller-dataplane-bluegreen={{ .Values.controllers.dataplaneBlueGreenController.enabled }}
-        {{- end }}
-        {{- if .Values.controllers.aiGatewayController }}
-        - --enable-controller-aigateway={{ .Values.controllers.aiGatewayController.enabled }}
-        {{- end }}
-        {{- end }}
         env:
         {{- include "kong.env" . | nindent 8 }}
         - name: POD_NAMESPACE

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -44,26 +44,23 @@ resources:
     cpu: 10m
     memory: 128Mi
 
-# use this section to enable or disable the controllers
-controllers:
-  # controlPlane controller
-  controlplaneController:
-    enabled: true
-  # gateway controller
-  gatewayController:
-    enabled: true
-  # dataplane controller. mutually exclusive with dataplane bluegreen controller
-  dataplaneController:
-    enabled: false
-  # dataplane bluegreen controller. mutually exclusive with dataplane controller
-  dataplaneBlueGreenController:
-    enabled: true
-  # aigateway controller. (experimental)
-  aiGatewayController:
-    enabled: false
-
 # Use this section to add environment variables to operator's container
 env: {}
+  # # gateway controller
+  # enable_gateway_controller: true
+  # # controlPlane controller
+  # enable_controlplane_controller: true
+  # # dataplane controller. mutually exclusive with dataplane bluegreen controller
+  # enable_dataplane_controller: true
+  # # dataplane bluegreen controller. mutually exclusive with dataplane controller
+  # enable_dataplanebluegreen_controller: true
+  # # aigateway controller. (experimental)
+  # enable_aigateway_controller: true
+
+# This section is any customer specific environments variables that doesn't require CONTROLLER_ prefix.
+# Example as below, uncomment if required and add additional attributes as required.
+# customEnv:
+#   TZ: "Europe/Berlin"
 
 # Use this section to change the certs-dir emptyDir size
 certsDir:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds the `env` section handling with `GATEWAY_OPERATOR_` prefix similarly as it's done in other charts (e.g. `CONTROLLER_` prefix for KIC in `kong` chart).

This also removes the default flags for enabling and disabling controllers.

Enabling and disabling controllers is now done via `env` section like so:

```yaml
env:
  # gateway controller
  enable_gateway_controller: false
  # dataplane controller. mutually exclusive with dataplane bluegreen controller
  enable_dataplane_controller: true
```

