### PR TITLE
fix(kgo): add missing RBAC policy rules for cert-manager's `Certificate` resources

### DIFF
--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.2.0"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/templates/rbac-resources.yaml
+++ b/charts/gateway-operator/templates/rbac-resources.yaml
@@ -110,6 +110,17 @@ rules:
   - delete
   - get
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
   - configuration.konghq.com
   resources:
   - ingressclassparameterses


### PR DESCRIPTION
#### What this PR does / why we need it:

Noticed when running KGO EE locally.

This PR adds the missing policy rules for cert-manager resources.

