### PR TITLE
fix(kgo): add missing cert-manager Certificate watch RBAC policy rule

### DIFF
--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.1.3
+version: 0.1.4
 appVersion: "1.2.0"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/templates/rbac-resources.yaml
+++ b/charts/gateway-operator/templates/rbac-resources.yaml
@@ -120,6 +120,7 @@ rules:
   - list
   - patch
   - update
+  - watch
 - apiGroups:
   - configuration.konghq.com
   resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Add changes add to KGO EE role in https://github.com/Kong/gateway-operator-enterprise/pull/105


