### PR TITLE
kgo: unpin 1.2.0 and set the default tag to 1.2

### DIFF
--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,8 +8,8 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.1.4
-appVersion: "1.2.0"
+version: 0.1.5
+appVersion: "1.2"
 annotations:
   artifacthub.io/prerelease: "false"
 

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/kong/gateway-operator
-  tag: 1.2.0
+  tag: 1.2
 
  # Override namespace for gateway-operator chart resources. By default, the chart creates resources in the release namespace.
 # namespace: kong-system


### PR DESCRIPTION
#### What this PR does / why we need it:

We've set the default KGO tag as 1.2.0 by accident (setting precedent) where all the other charts in this repo use `<major>.<minor>` tags.

This will allow users to automatically use the newest patch from 1.2.x. (currently 1.2.1)