### PR TITLE
chore: pin chartsnap version to latest v0.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+CHARTSNAP_VERSION ?= v0.3.1
 
 .PHONY: _download_tool
 _download_tool:
@@ -16,7 +17,7 @@ kube-linter:
 .PHONY: chartsnap
 chartsnap:
 	@helm plugin list | grep chartsnap > /dev/null || \
-	helm plugin install https://github.com/jlandowner/helm-chartsnap
+	helm plugin install https://github.com/jlandowner/helm-chartsnap --version $(CHARTSNAP_VERSION)
 
 .PHONY: lint
 lint: tools lint.charts.kong lint.shellcheck

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -1,1060 +1,1056 @@
-[gateway-discovery-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: gateway-2.38.0
+  name: chartsnap-gateway
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller-admin-api-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller-admin-api-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-controller
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-controller
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-controller
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-controller
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: gateway-2.38.0
+  name: chartsnap-gateway-admin
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+    - name: kong-admin-tls
+      port: 8444
+      protocol: TCP
+      targetPort: 8444
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: gateway
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: gateway-2.38.0
+  name: chartsnap-gateway-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: gateway
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: gateway-2.38.0
+  name: chartsnap-gateway-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: gateway
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: controller
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-controller-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-controller-token
+        traffic.kuma.io/exclude-outbound-ports: "8444"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "8444"
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-controller
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: controller
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: controller-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: controller
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-controller-token
-                    traffic.kuma.io/exclude-outbound-ports: \"8444\"
-                    traffic.sidecar.istio.io/excludeOutboundPorts: \"8444\"
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-controller
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: controller
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: controller-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ANONYMOUS_REPORTS
-                          value: \"false\"
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_SVC
-                          value: default/chartsnap-gateway-admin
-                        - name: CONTROLLER_KONG_ADMIN_TLS_CLIENT_CERT_FILE
-                          value: /etc/secrets/admin-api-cert/tls.crt
-                        - name: CONTROLLER_KONG_ADMIN_TLS_CLIENT_KEY_FILE
-                          value: /etc/secrets/admin-api-cert/tls.key
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-gateway-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-controller-token
-                          readOnly: true
-                        - mountPath: /etc/secrets/admin-api-cert
-                          name: admin-api-cert
-                          readOnly: true
-                securityContext: {}
-                serviceAccountName: chartsnap-controller
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-controller-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-controller-tmp
-                    - name: chartsnap-controller-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-controller-validation-webhook-keypair
-                    - name: admin-api-cert
-                      secret:
-                        secretName: chartsnap-controller-admin-api-keypair
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_SVC
+              value: default/chartsnap-gateway-admin
+            - name: CONTROLLER_KONG_ADMIN_TLS_CLIENT_CERT_FILE
+              value: /etc/secrets/admin-api-cert/tls.crt
+            - name: CONTROLLER_KONG_ADMIN_TLS_CLIENT_KEY_FILE
+              value: /etc/secrets/admin-api-cert/tls.key
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-gateway-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
+              protocol: TCP
+            - containerPort: 10255
+              name: cmetrics
+              protocol: TCP
+            - containerPort: 10254
+              name: cstatus
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-controller-token
+              readOnly: true
+            - mountPath: /etc/secrets/admin-api-cert
+              name: admin-api-cert
+              readOnly: true
+      securityContext: {}
+      serviceAccountName: chartsnap-controller
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-controller-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-controller-tmp
+        - name: chartsnap-controller-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-controller-validation-webhook-keypair
+        - name: admin-api-cert
+          secret:
+            secretName: chartsnap-controller-admin-api-keypair
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: gateway-2.38.0
+  name: chartsnap-gateway
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: gateway
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: gateway
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: gateway-2.38.0
-        name: chartsnap-gateway
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-gateway-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-gateway
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: gateway
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: gateway-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: gateway
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-gateway-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-gateway
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: gateway
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: gateway-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROLE
-                          value: traditional
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8444
-                          name: admin-tls
-                          protocol: TCP
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-gateway-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-gateway-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROLE
-                          value: traditional
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-gateway-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-gateway-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-gateway
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-gateway-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-gateway-tmp
-                    - name: chartsnap-gateway-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-controller
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-controller
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-controller
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-controller
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller-admin-api-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller-admin-api-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROLE
+              value: traditional
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8444
+              name: admin-tls
+              protocol: TCP
+            - containerPort: 8000
+              name: proxy
+              protocol: TCP
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-gateway-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-gateway-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROLE
+              value: traditional
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-gateway-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-gateway-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-gateway
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-gateway-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-gateway-tmp
+        - name: chartsnap-gateway-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.38.0
+  name: chartsnap-controller-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-controller-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: gateway
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: gateway-2.38.0
-        name: chartsnap-gateway-admin
-        namespace: default
-    spec:
-        clusterIP: None
-        ports:
-            - name: kong-admin-tls
-              port: 8444
-              protocol: TCP
-              targetPort: 8444
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: gateway
-        type: ClusterIP
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: gateway
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: gateway-2.38.0
-        name: chartsnap-gateway-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
-              protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
-              protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: gateway
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: gateway
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: gateway-2.38.0
-        name: chartsnap-gateway-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
-              protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
-              protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: gateway
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: controller
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: controller-2.38.0
-        name: chartsnap-controller
-        namespace: default
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: gateway
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: gateway-2.38.0
-        name: chartsnap-gateway
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -1,371 +1,367 @@
-[admin-api-service-clusterip-values]
-SnapShot = """
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  kong.yml: |
+    _format_version: "1.1"
+    services:
+    - name: example.com
+      url: http://example.com
+      routes:
+      - name: example
+        paths:
+        - "/example"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-custom-dbless-config
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-admin
+  namespace: default
+spec:
+  ports:
+    - name: kong-admin-tls
+      port: 8444
+      protocol: TCP
+      targetPort: 8444
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        checksum/dbless.config: 626be043e4a43b0d55af934d06216254abe132b29af82450379439ecd927219a
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    checksum/dbless.config: 626be043e4a43b0d55af934d06216254abe132b29af82450379439ecd927219a
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_DECLARATIVE_CONFIG
-                          value: /kong_dbless/kong.yml
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8444
-                          name: admin-tls
-                          protocol: TCP
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                        - mountPath: /kong_dbless/
-                          name: kong-custom-dbless-config-volume
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_DECLARATIVE_CONFIG
-                          value: /kong_dbless/kong.yml
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                        - mountPath: /kong_dbless/
-                          name: kong-custom-dbless-config-volume
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        name: chartsnap-kong-custom-dbless-config
-                      name: kong-custom-dbless-config-volume
-- object:
-    apiVersion: v1
-    data:
-        kong.yml: |
-            _format_version: \"1.1\"
-            services:
-            - name: example.com
-              url: http://example.com
-              routes:
-              - name: example
-                paths:
-                - \"/example\"
-    kind: ConfigMap
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-custom-dbless-config
-        namespace: default
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-admin
-        namespace: default
-    spec:
-        ports:
-            - name: kong-admin-tls
-              port: 8444
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /kong_dbless/kong.yml
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8444
+              name: admin-tls
               protocol: TCP
-              targetPort: 8444
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: ClusterIP
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 8443
+              name: proxy-tls
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 8100
+              name: status
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
-              protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+            - mountPath: /kong_dbless/
+              name: kong-custom-dbless-config-volume
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /kong_dbless/kong.yml
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+            - mountPath: /kong_dbless/
+              name: kong-custom-dbless-config-volume
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            name: chartsnap-kong-custom-dbless-config
+          name: kong-custom-dbless-config-volume

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -1,920 +1,916 @@
-[custom-labels-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    acme.com/some-key: some-value
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        acme.com/some-key: some-value
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    acme.com/some-key: some-value
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            acme.com/some-key: some-value
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            acme.com/some-key: some-value
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -1,912 +1,908 @@
-[default-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ANONYMOUS_REPORTS
-                          value: \"false\"
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -1,941 +1,937 @@
-[kong-ingress-1-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURoakNDQW00Q0NRQ0tyTDdSS1Y0NTBEQU5CZ2txaGtpRzl3MEJBUXNGQURDQmhERUxNQWtHQTFVRUJoTUMKV0ZneEVqQVFCZ05WQkFnTUNWTjBZWFJsVG1GdFpURVJNQThHQTFVRUJ3d0lRMmwwZVU1aGJXVXhGREFTQmdOVgpCQW9NQzBOdmJYQmhibmxPWVcxbE1Sc3dHUVlEVlFRTERCSkRiMjF3WVc1NVUyVmpkR2x2Yms1aGJXVXhHekFaCkJnTlZCQU1NRW5CeWIzaDVMbXR2Ym1jdVpYaGhiWEJzWlRBZUZ3MHlNekEyTWprd09ERTBNekJhRncwek16QTIKTWpZd09ERTBNekJhTUlHRU1Rc3dDUVlEVlFRR0V3SllXREVTTUJBR0ExVUVDQXdKVTNSaGRHVk9ZVzFsTVJFdwpEd1lEVlFRSERBaERhWFI1VG1GdFpURVVNQklHQTFVRUNnd0xRMjl0Y0dGdWVVNWhiV1V4R3pBWkJnTlZCQXNNCkVrTnZiWEJoYm5sVFpXTjBhVzl1VG1GdFpURWJNQmtHQTFVRUF3d1NjSEp2ZUhrdWEyOXVaeTVsZUdGdGNHeGwKTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE4Wmd4czI1RXdtaXRsRG1HMitWVwpscUZ4R3lkVHU2dWlCVldFZjNoV0h2R3YvUWpYZHBBWXlkc3ZpNS92b1FtcjNUeVJBb3VaR1lCR3RuVEF0cU5rCnFLUmFVaWppVlN3TTNzeUl1cHluMlRjSjk1N2RLUCtUYTRaL0VNUlRwSCtya1psV01LNVYrNUszTmFIL21leDUKVWRRWkl4WUxNM0xIM0t0cmt2OWZRNlhSZ2dkeXo0MEt2YUV6SW1scEVoQnBoS0g5UWJiL3RFRE0vdFFqbC9FUApmbUF5M2Y5WE1uRDNSeFY3TnFrZktpUjNXZ1JDMnFyNWtPbXlJTGp1YWxERk1Zb3lDZUlmSnd1WmVDaEpGb3ZHClFKUFY2WU9xTG5aRWN3MU9BaVBXQnMycXVmWmlsNXplekRDZUFGZDV3eXVrS1dPZ3pTZ3Q2VzZvN2FBRTBDK3YKclFJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNGZHhFOFVsMVorcWxBbW1lTk5BdlAyZVVxSElTbQpHWXZidzdGdW82bXNJY3V3cjZKeENBWjIwako5UkphalMzWS9TS3BteXM2OXZxU21ic25oeUJzc01mL1ZtenFSClBVLzVkUUZiblNybUJqMnFBNWxtRCtENDVLUEtrTjc1V21NeDRQWkZseEw3WHVLYnZhYVZBUjFFUmRNZy90NisKUXpPV3BVWVZrcFJnQmlxTDBTTjhvTStOTjdScGFESFNkZjlTY1FtUmhNVklNNDdVZ1ZXNWhta21mQjBkUTFhQQo5NWdTQ3E0cGVwUFRzY3NsbVBzM0lOck5BTk45KytyMnM1bXRTWnp5VktRU0cwRjQ0Y1puWjdTdkdTVFJORDlUCnRKVzNTcko3elBwS0JqWi9qVDRRVnpBdGtHN3FSV2ZhYnlWTmVrK29wMTgwSVY5Um9IR1JDU0kyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRRHhtREd6YmtUQ2FLMlUKT1liYjVWYVdvWEViSjFPN3E2SUZWWVIvZUZZZThhLzlDTmQya0JqSjJ5K0xuKytoQ2F2ZFBKRUNpNWtaZ0VhMgpkTUMybzJTb3BGcFNLT0pWTEF6ZXpJaTZuS2ZaTnduM250MG8vNU5yaG44UXhGT2tmNnVSbVZZd3JsWDdrcmMxCm9mK1o3SGxSMUJrakZnc3pjc2ZjcTJ1Uy8xOURwZEdDQjNMUGpRcTlvVE1pYVdrU0VHbUVvZjFCdHYrMFFNeisKMUNPWDhROStZRExkLzFjeWNQZEhGWHMycVI4cUpIZGFCRUxhcXZtUTZiSWd1TzVxVU1VeGlqSUo0aDhuQzVsNApLRWtXaThaQWs5WHBnNm91ZGtSekRVNENJOVlHemFxNTltS1huTjdNTUo0QVYzbkRLNlFwWTZETktDM3BicWp0Cm9BVFFMNit0QWdNQkFBRUNnZ0VCQUs3N1I0d3BJcDRZU1JoaGJoN1loWldHQ3JEYkZCZUtZVWd4djB5LzhNaHEKenNlYlhzdGQ1TVpXL2FISVRqdzZFQU9tT1hVNWZNTHVtTWpQMlVDdktWbkg2QzgzczI1ekFFTmlxdWxXUzIvVgpJRi83N1Qwamx6ZTY2MDlPa3pKQzBoWWJsRVNnRUdDc3pBdUpjT0tnVnVLQWwxQkZTQW1VYWRPWFNNdm9NS3lDCkJlekZaVEhOcGRWQ2xwUHVLNGQrWFJJZ1hHWS84RzNmWlFXRWNjV2tTYmRjQUlLdVYvWktHQ0IyT2dXS1VzSHgKTStscEw1TTZ3aXdYOEFNdUVWVHJsMWNwKzAzTjdOaUYwMFpYdCszZzVZUkJmRitYWjZ1b3hmbENQZ3VHdzh6bgpvN2tFRVNKZ2YycHZyZWYveHBjSVFSM090aHZjSzR5RldOcndPbExHQk9FQ2dZRUErNmJBREF0bDAvRlpzV08zCnVvNlBRNXZTL0tqbS9XaUkzeUo5TUdLNzQxTFZpMlRMUGpVZ092SDdkZUVjNVJjUmoxV1Nna3d1bUdzZWE2WkQKWXRWSTRZTDdMM1NUQ3JyZUNFTDRhOUJPcFB0azcxWWw3TmhxZktEaXhzU1FnNmt4dDJ1TlYvZXNSQ1JPeENoWgp5bk9JTmkvN3lOeFpVek4zcndyVjBCMUFNYVVDZ1lFQTljVDBZNkJWRHZLdFFaV1gvR1REZ2pUUzN6QWlPWmFNCjVFM3NleHh6MXY4eDF0N3JvWDV3aHNaVjlzQ05nNlJaNjIyT3hJejhHQnVvMnU1M2h2WFJabmdDaG1PcHYwRjgKcm5STWFNR0tIeGN2TmNrVUZUMW9TdDJCeEhNT1FNZTM2cERVTnZ0S3pvNGJoakpVUU94Mm14RU9TNERscm4rMApRU3FqVFpyWGwya0NnWUJ1UmIyMkNYQ1BsUjBHbkhtd0tEUWpIaTh3UkJza1JDQm1Gc2pnNFFNUU5BWWJWUW15CnNyankyNEtqUHdmWVkybHdjOEVGazdoL1ZjRTR6dHlNZklXNVBCb3h5MVY3eURMdlQ5bG45Um5oTmNBZkdKTDUKM0VPZFpTcTZpdndBbGEyUmdIR3BjSUJ1UTdLNFJpNUNocW5UaE9kQ056eDFOd0psRTh4cHE4ZXJlUUtCZ1FEeQppV3B3UXRLT0ROa0VCdi9WT1E5am1JT2RjOS9pbXZyeGR5RHZvWFdENzVXY3FhTTVYUkRwUUNPbmZnQnBzREI0CjBFWjdHM0xReThNSVF4czcyYXpMaFpWZ1VFdzlEUUJoSFM0bWx4Q2FmQU8vL1c3UFF5bC84RGJXeW9CL1YxamQKcUExMU1PcHpDdlNJcTNSUUdjczJYaytRSFdVTW5zUWhKMVcvQ1JiSE9RS0JnRTVQZ0hrbW1PY1VXZkJBZUtzTApvb2FNNzBINVN1YUNYN1Y1enBhM3hFMW5WVWMxend5aldOdkdWbTA5WkpEOFFMR1ZDV2U0R1o5R1NvV2tqSUMvCklFKzA0M29kUERuL2JwSDlTMDF2a0s1ZDRJSGc3QUcwWXI5SW1zS0paT0djT1dmdUdKSlZ5em1CRXhaSU9pbnoKVFFuaFdhZWs0NE1hdVJYOC9pRjZyZWorCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  name: kong.proxy.example.secret
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        rules:
-            - http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /
-                      pathType: ImplementationSpecific
-        tls:
-            - hosts: null
-              secretName: kong.proxy.example.secret
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURoakNDQW00Q0NRQ0tyTDdSS1Y0NTBEQU5CZ2txaGtpRzl3MEJBUXNGQURDQmhERUxNQWtHQTFVRUJoTUMKV0ZneEVqQVFCZ05WQkFnTUNWTjBZWFJsVG1GdFpURVJNQThHQTFVRUJ3d0lRMmwwZVU1aGJXVXhGREFTQmdOVgpCQW9NQzBOdmJYQmhibmxPWVcxbE1Sc3dHUVlEVlFRTERCSkRiMjF3WVc1NVUyVmpkR2x2Yms1aGJXVXhHekFaCkJnTlZCQU1NRW5CeWIzaDVMbXR2Ym1jdVpYaGhiWEJzWlRBZUZ3MHlNekEyTWprd09ERTBNekJhRncwek16QTIKTWpZd09ERTBNekJhTUlHRU1Rc3dDUVlEVlFRR0V3SllXREVTTUJBR0ExVUVDQXdKVTNSaGRHVk9ZVzFsTVJFdwpEd1lEVlFRSERBaERhWFI1VG1GdFpURVVNQklHQTFVRUNnd0xRMjl0Y0dGdWVVNWhiV1V4R3pBWkJnTlZCQXNNCkVrTnZiWEJoYm5sVFpXTjBhVzl1VG1GdFpURWJNQmtHQTFVRUF3d1NjSEp2ZUhrdWEyOXVaeTVsZUdGdGNHeGwKTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE4Wmd4czI1RXdtaXRsRG1HMitWVwpscUZ4R3lkVHU2dWlCVldFZjNoV0h2R3YvUWpYZHBBWXlkc3ZpNS92b1FtcjNUeVJBb3VaR1lCR3RuVEF0cU5rCnFLUmFVaWppVlN3TTNzeUl1cHluMlRjSjk1N2RLUCtUYTRaL0VNUlRwSCtya1psV01LNVYrNUszTmFIL21leDUKVWRRWkl4WUxNM0xIM0t0cmt2OWZRNlhSZ2dkeXo0MEt2YUV6SW1scEVoQnBoS0g5UWJiL3RFRE0vdFFqbC9FUApmbUF5M2Y5WE1uRDNSeFY3TnFrZktpUjNXZ1JDMnFyNWtPbXlJTGp1YWxERk1Zb3lDZUlmSnd1WmVDaEpGb3ZHClFKUFY2WU9xTG5aRWN3MU9BaVBXQnMycXVmWmlsNXplekRDZUFGZDV3eXVrS1dPZ3pTZ3Q2VzZvN2FBRTBDK3YKclFJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNGZHhFOFVsMVorcWxBbW1lTk5BdlAyZVVxSElTbQpHWXZidzdGdW82bXNJY3V3cjZKeENBWjIwako5UkphalMzWS9TS3BteXM2OXZxU21ic25oeUJzc01mL1ZtenFSClBVLzVkUUZiblNybUJqMnFBNWxtRCtENDVLUEtrTjc1V21NeDRQWkZseEw3WHVLYnZhYVZBUjFFUmRNZy90NisKUXpPV3BVWVZrcFJnQmlxTDBTTjhvTStOTjdScGFESFNkZjlTY1FtUmhNVklNNDdVZ1ZXNWhta21mQjBkUTFhQQo5NWdTQ3E0cGVwUFRzY3NsbVBzM0lOck5BTk45KytyMnM1bXRTWnp5VktRU0cwRjQ0Y1puWjdTdkdTVFJORDlUCnRKVzNTcko3elBwS0JqWi9qVDRRVnpBdGtHN3FSV2ZhYnlWTmVrK29wMTgwSVY5Um9IR1JDU0kyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
-        tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRRHhtREd6YmtUQ2FLMlUKT1liYjVWYVdvWEViSjFPN3E2SUZWWVIvZUZZZThhLzlDTmQya0JqSjJ5K0xuKytoQ2F2ZFBKRUNpNWtaZ0VhMgpkTUMybzJTb3BGcFNLT0pWTEF6ZXpJaTZuS2ZaTnduM250MG8vNU5yaG44UXhGT2tmNnVSbVZZd3JsWDdrcmMxCm9mK1o3SGxSMUJrakZnc3pjc2ZjcTJ1Uy8xOURwZEdDQjNMUGpRcTlvVE1pYVdrU0VHbUVvZjFCdHYrMFFNeisKMUNPWDhROStZRExkLzFjeWNQZEhGWHMycVI4cUpIZGFCRUxhcXZtUTZiSWd1TzVxVU1VeGlqSUo0aDhuQzVsNApLRWtXaThaQWs5WHBnNm91ZGtSekRVNENJOVlHemFxNTltS1huTjdNTUo0QVYzbkRLNlFwWTZETktDM3BicWp0Cm9BVFFMNit0QWdNQkFBRUNnZ0VCQUs3N1I0d3BJcDRZU1JoaGJoN1loWldHQ3JEYkZCZUtZVWd4djB5LzhNaHEKenNlYlhzdGQ1TVpXL2FISVRqdzZFQU9tT1hVNWZNTHVtTWpQMlVDdktWbkg2QzgzczI1ekFFTmlxdWxXUzIvVgpJRi83N1Qwamx6ZTY2MDlPa3pKQzBoWWJsRVNnRUdDc3pBdUpjT0tnVnVLQWwxQkZTQW1VYWRPWFNNdm9NS3lDCkJlekZaVEhOcGRWQ2xwUHVLNGQrWFJJZ1hHWS84RzNmWlFXRWNjV2tTYmRjQUlLdVYvWktHQ0IyT2dXS1VzSHgKTStscEw1TTZ3aXdYOEFNdUVWVHJsMWNwKzAzTjdOaUYwMFpYdCszZzVZUkJmRitYWjZ1b3hmbENQZ3VHdzh6bgpvN2tFRVNKZ2YycHZyZWYveHBjSVFSM090aHZjSzR5RldOcndPbExHQk9FQ2dZRUErNmJBREF0bDAvRlpzV08zCnVvNlBRNXZTL0tqbS9XaUkzeUo5TUdLNzQxTFZpMlRMUGpVZ092SDdkZUVjNVJjUmoxV1Nna3d1bUdzZWE2WkQKWXRWSTRZTDdMM1NUQ3JyZUNFTDRhOUJPcFB0azcxWWw3TmhxZktEaXhzU1FnNmt4dDJ1TlYvZXNSQ1JPeENoWgp5bk9JTmkvN3lOeFpVek4zcndyVjBCMUFNYVVDZ1lFQTljVDBZNkJWRHZLdFFaV1gvR1REZ2pUUzN6QWlPWmFNCjVFM3NleHh6MXY4eDF0N3JvWDV3aHNaVjlzQ05nNlJaNjIyT3hJejhHQnVvMnU1M2h2WFJabmdDaG1PcHYwRjgKcm5STWFNR0tIeGN2TmNrVUZUMW9TdDJCeEhNT1FNZTM2cERVTnZ0S3pvNGJoakpVUU94Mm14RU9TNERscm4rMApRU3FqVFpyWGwya0NnWUJ1UmIyMkNYQ1BsUjBHbkhtd0tEUWpIaTh3UkJza1JDQm1Gc2pnNFFNUU5BWWJWUW15CnNyankyNEtqUHdmWVkybHdjOEVGazdoL1ZjRTR6dHlNZklXNVBCb3h5MVY3eURMdlQ5bG45Um5oTmNBZkdKTDUKM0VPZFpTcTZpdndBbGEyUmdIR3BjSUJ1UTdLNFJpNUNocW5UaE9kQ056eDFOd0psRTh4cHE4ZXJlUUtCZ1FEeQppV3B3UXRLT0ROa0VCdi9WT1E5am1JT2RjOS9pbXZyeGR5RHZvWFdENzVXY3FhTTVYUkRwUUNPbmZnQnBzREI0CjBFWjdHM0xReThNSVF4czcyYXpMaFpWZ1VFdzlEUUJoSFM0bWx4Q2FmQU8vL1c3UFF5bC84RGJXeW9CL1YxamQKcUExMU1PcHpDdlNJcTNSUUdjczJYaytRSFdVTW5zUWhKMVcvQ1JiSE9RS0JnRTVQZ0hrbW1PY1VXZkJBZUtzTApvb2FNNzBINVN1YUNYN1Y1enBhM3hFMW5WVWMxend5aldOdkdWbTA5WkpEOFFMR1ZDV2U0R1o5R1NvV2tqSUMvCklFKzA0M29kUERuL2JwSDlTMDF2a0s1ZDRJSGc3QUcwWXI5SW1zS0paT0djT1dmdUdKSlZ5em1CRXhaSU9pbnoKVFFuaFdhZWs0NE1hdVJYOC9pRjZyZWorCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
-    kind: Secret
-    metadata:
-        name: kong.proxy.example.secret
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts: null
+      secretName: kong.proxy.example.secret
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -1,943 +1,939 @@
-[kong-ingress-2-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURoakNDQW00Q0NRQ0tyTDdSS1Y0NTBEQU5CZ2txaGtpRzl3MEJBUXNGQURDQmhERUxNQWtHQTFVRUJoTUMKV0ZneEVqQVFCZ05WQkFnTUNWTjBZWFJsVG1GdFpURVJNQThHQTFVRUJ3d0lRMmwwZVU1aGJXVXhGREFTQmdOVgpCQW9NQzBOdmJYQmhibmxPWVcxbE1Sc3dHUVlEVlFRTERCSkRiMjF3WVc1NVUyVmpkR2x2Yms1aGJXVXhHekFaCkJnTlZCQU1NRW5CeWIzaDVMbXR2Ym1jdVpYaGhiWEJzWlRBZUZ3MHlNekEyTWprd09ERTBNekJhRncwek16QTIKTWpZd09ERTBNekJhTUlHRU1Rc3dDUVlEVlFRR0V3SllXREVTTUJBR0ExVUVDQXdKVTNSaGRHVk9ZVzFsTVJFdwpEd1lEVlFRSERBaERhWFI1VG1GdFpURVVNQklHQTFVRUNnd0xRMjl0Y0dGdWVVNWhiV1V4R3pBWkJnTlZCQXNNCkVrTnZiWEJoYm5sVFpXTjBhVzl1VG1GdFpURWJNQmtHQTFVRUF3d1NjSEp2ZUhrdWEyOXVaeTVsZUdGdGNHeGwKTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE4Wmd4czI1RXdtaXRsRG1HMitWVwpscUZ4R3lkVHU2dWlCVldFZjNoV0h2R3YvUWpYZHBBWXlkc3ZpNS92b1FtcjNUeVJBb3VaR1lCR3RuVEF0cU5rCnFLUmFVaWppVlN3TTNzeUl1cHluMlRjSjk1N2RLUCtUYTRaL0VNUlRwSCtya1psV01LNVYrNUszTmFIL21leDUKVWRRWkl4WUxNM0xIM0t0cmt2OWZRNlhSZ2dkeXo0MEt2YUV6SW1scEVoQnBoS0g5UWJiL3RFRE0vdFFqbC9FUApmbUF5M2Y5WE1uRDNSeFY3TnFrZktpUjNXZ1JDMnFyNWtPbXlJTGp1YWxERk1Zb3lDZUlmSnd1WmVDaEpGb3ZHClFKUFY2WU9xTG5aRWN3MU9BaVBXQnMycXVmWmlsNXplekRDZUFGZDV3eXVrS1dPZ3pTZ3Q2VzZvN2FBRTBDK3YKclFJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNGZHhFOFVsMVorcWxBbW1lTk5BdlAyZVVxSElTbQpHWXZidzdGdW82bXNJY3V3cjZKeENBWjIwako5UkphalMzWS9TS3BteXM2OXZxU21ic25oeUJzc01mL1ZtenFSClBVLzVkUUZiblNybUJqMnFBNWxtRCtENDVLUEtrTjc1V21NeDRQWkZseEw3WHVLYnZhYVZBUjFFUmRNZy90NisKUXpPV3BVWVZrcFJnQmlxTDBTTjhvTStOTjdScGFESFNkZjlTY1FtUmhNVklNNDdVZ1ZXNWhta21mQjBkUTFhQQo5NWdTQ3E0cGVwUFRzY3NsbVBzM0lOck5BTk45KytyMnM1bXRTWnp5VktRU0cwRjQ0Y1puWjdTdkdTVFJORDlUCnRKVzNTcko3elBwS0JqWi9qVDRRVnpBdGtHN3FSV2ZhYnlWTmVrK29wMTgwSVY5Um9IR1JDU0kyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRRHhtREd6YmtUQ2FLMlUKT1liYjVWYVdvWEViSjFPN3E2SUZWWVIvZUZZZThhLzlDTmQya0JqSjJ5K0xuKytoQ2F2ZFBKRUNpNWtaZ0VhMgpkTUMybzJTb3BGcFNLT0pWTEF6ZXpJaTZuS2ZaTnduM250MG8vNU5yaG44UXhGT2tmNnVSbVZZd3JsWDdrcmMxCm9mK1o3SGxSMUJrakZnc3pjc2ZjcTJ1Uy8xOURwZEdDQjNMUGpRcTlvVE1pYVdrU0VHbUVvZjFCdHYrMFFNeisKMUNPWDhROStZRExkLzFjeWNQZEhGWHMycVI4cUpIZGFCRUxhcXZtUTZiSWd1TzVxVU1VeGlqSUo0aDhuQzVsNApLRWtXaThaQWs5WHBnNm91ZGtSekRVNENJOVlHemFxNTltS1huTjdNTUo0QVYzbkRLNlFwWTZETktDM3BicWp0Cm9BVFFMNit0QWdNQkFBRUNnZ0VCQUs3N1I0d3BJcDRZU1JoaGJoN1loWldHQ3JEYkZCZUtZVWd4djB5LzhNaHEKenNlYlhzdGQ1TVpXL2FISVRqdzZFQU9tT1hVNWZNTHVtTWpQMlVDdktWbkg2QzgzczI1ekFFTmlxdWxXUzIvVgpJRi83N1Qwamx6ZTY2MDlPa3pKQzBoWWJsRVNnRUdDc3pBdUpjT0tnVnVLQWwxQkZTQW1VYWRPWFNNdm9NS3lDCkJlekZaVEhOcGRWQ2xwUHVLNGQrWFJJZ1hHWS84RzNmWlFXRWNjV2tTYmRjQUlLdVYvWktHQ0IyT2dXS1VzSHgKTStscEw1TTZ3aXdYOEFNdUVWVHJsMWNwKzAzTjdOaUYwMFpYdCszZzVZUkJmRitYWjZ1b3hmbENQZ3VHdzh6bgpvN2tFRVNKZ2YycHZyZWYveHBjSVFSM090aHZjSzR5RldOcndPbExHQk9FQ2dZRUErNmJBREF0bDAvRlpzV08zCnVvNlBRNXZTL0tqbS9XaUkzeUo5TUdLNzQxTFZpMlRMUGpVZ092SDdkZUVjNVJjUmoxV1Nna3d1bUdzZWE2WkQKWXRWSTRZTDdMM1NUQ3JyZUNFTDRhOUJPcFB0azcxWWw3TmhxZktEaXhzU1FnNmt4dDJ1TlYvZXNSQ1JPeENoWgp5bk9JTmkvN3lOeFpVek4zcndyVjBCMUFNYVVDZ1lFQTljVDBZNkJWRHZLdFFaV1gvR1REZ2pUUzN6QWlPWmFNCjVFM3NleHh6MXY4eDF0N3JvWDV3aHNaVjlzQ05nNlJaNjIyT3hJejhHQnVvMnU1M2h2WFJabmdDaG1PcHYwRjgKcm5STWFNR0tIeGN2TmNrVUZUMW9TdDJCeEhNT1FNZTM2cERVTnZ0S3pvNGJoakpVUU94Mm14RU9TNERscm4rMApRU3FqVFpyWGwya0NnWUJ1UmIyMkNYQ1BsUjBHbkhtd0tEUWpIaTh3UkJza1JDQm1Gc2pnNFFNUU5BWWJWUW15CnNyankyNEtqUHdmWVkybHdjOEVGazdoL1ZjRTR6dHlNZklXNVBCb3h5MVY3eURMdlQ5bG45Um5oTmNBZkdKTDUKM0VPZFpTcTZpdndBbGEyUmdIR3BjSUJ1UTdLNFJpNUNocW5UaE9kQ056eDFOd0psRTh4cHE4ZXJlUUtCZ1FEeQppV3B3UXRLT0ROa0VCdi9WT1E5am1JT2RjOS9pbXZyeGR5RHZvWFdENzVXY3FhTTVYUkRwUUNPbmZnQnBzREI0CjBFWjdHM0xReThNSVF4czcyYXpMaFpWZ1VFdzlEUUJoSFM0bWx4Q2FmQU8vL1c3UFF5bC84RGJXeW9CL1YxamQKcUExMU1PcHpDdlNJcTNSUUdjczJYaytRSFdVTW5zUWhKMVcvQ1JiSE9RS0JnRTVQZ0hrbW1PY1VXZkJBZUtzTApvb2FNNzBINVN1YUNYN1Y1enBhM3hFMW5WVWMxend5aldOdkdWbTA5WkpEOFFMR1ZDV2U0R1o5R1NvV2tqSUMvCklFKzA0M29kUERuL2JwSDlTMDF2a0s1ZDRJSGc3QUcwWXI5SW1zS0paT0djT1dmdUdKSlZ5em1CRXhaSU9pbnoKVFFuaFdhZWs0NE1hdVJYOC9pRjZyZWorCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  name: kong.proxy.example.secret
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        rules:
-            - host: proxy.kong.example
-              http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /
-                      pathType: ImplementationSpecific
-        tls:
-            - hosts:
-                - proxy.kong.example
-              secretName: kong.proxy.example.secret
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURoakNDQW00Q0NRQ0tyTDdSS1Y0NTBEQU5CZ2txaGtpRzl3MEJBUXNGQURDQmhERUxNQWtHQTFVRUJoTUMKV0ZneEVqQVFCZ05WQkFnTUNWTjBZWFJsVG1GdFpURVJNQThHQTFVRUJ3d0lRMmwwZVU1aGJXVXhGREFTQmdOVgpCQW9NQzBOdmJYQmhibmxPWVcxbE1Sc3dHUVlEVlFRTERCSkRiMjF3WVc1NVUyVmpkR2x2Yms1aGJXVXhHekFaCkJnTlZCQU1NRW5CeWIzaDVMbXR2Ym1jdVpYaGhiWEJzWlRBZUZ3MHlNekEyTWprd09ERTBNekJhRncwek16QTIKTWpZd09ERTBNekJhTUlHRU1Rc3dDUVlEVlFRR0V3SllXREVTTUJBR0ExVUVDQXdKVTNSaGRHVk9ZVzFsTVJFdwpEd1lEVlFRSERBaERhWFI1VG1GdFpURVVNQklHQTFVRUNnd0xRMjl0Y0dGdWVVNWhiV1V4R3pBWkJnTlZCQXNNCkVrTnZiWEJoYm5sVFpXTjBhVzl1VG1GdFpURWJNQmtHQTFVRUF3d1NjSEp2ZUhrdWEyOXVaeTVsZUdGdGNHeGwKTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE4Wmd4czI1RXdtaXRsRG1HMitWVwpscUZ4R3lkVHU2dWlCVldFZjNoV0h2R3YvUWpYZHBBWXlkc3ZpNS92b1FtcjNUeVJBb3VaR1lCR3RuVEF0cU5rCnFLUmFVaWppVlN3TTNzeUl1cHluMlRjSjk1N2RLUCtUYTRaL0VNUlRwSCtya1psV01LNVYrNUszTmFIL21leDUKVWRRWkl4WUxNM0xIM0t0cmt2OWZRNlhSZ2dkeXo0MEt2YUV6SW1scEVoQnBoS0g5UWJiL3RFRE0vdFFqbC9FUApmbUF5M2Y5WE1uRDNSeFY3TnFrZktpUjNXZ1JDMnFyNWtPbXlJTGp1YWxERk1Zb3lDZUlmSnd1WmVDaEpGb3ZHClFKUFY2WU9xTG5aRWN3MU9BaVBXQnMycXVmWmlsNXplekRDZUFGZDV3eXVrS1dPZ3pTZ3Q2VzZvN2FBRTBDK3YKclFJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNGZHhFOFVsMVorcWxBbW1lTk5BdlAyZVVxSElTbQpHWXZidzdGdW82bXNJY3V3cjZKeENBWjIwako5UkphalMzWS9TS3BteXM2OXZxU21ic25oeUJzc01mL1ZtenFSClBVLzVkUUZiblNybUJqMnFBNWxtRCtENDVLUEtrTjc1V21NeDRQWkZseEw3WHVLYnZhYVZBUjFFUmRNZy90NisKUXpPV3BVWVZrcFJnQmlxTDBTTjhvTStOTjdScGFESFNkZjlTY1FtUmhNVklNNDdVZ1ZXNWhta21mQjBkUTFhQQo5NWdTQ3E0cGVwUFRzY3NsbVBzM0lOck5BTk45KytyMnM1bXRTWnp5VktRU0cwRjQ0Y1puWjdTdkdTVFJORDlUCnRKVzNTcko3elBwS0JqWi9qVDRRVnpBdGtHN3FSV2ZhYnlWTmVrK29wMTgwSVY5Um9IR1JDU0kyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
-        tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRRHhtREd6YmtUQ2FLMlUKT1liYjVWYVdvWEViSjFPN3E2SUZWWVIvZUZZZThhLzlDTmQya0JqSjJ5K0xuKytoQ2F2ZFBKRUNpNWtaZ0VhMgpkTUMybzJTb3BGcFNLT0pWTEF6ZXpJaTZuS2ZaTnduM250MG8vNU5yaG44UXhGT2tmNnVSbVZZd3JsWDdrcmMxCm9mK1o3SGxSMUJrakZnc3pjc2ZjcTJ1Uy8xOURwZEdDQjNMUGpRcTlvVE1pYVdrU0VHbUVvZjFCdHYrMFFNeisKMUNPWDhROStZRExkLzFjeWNQZEhGWHMycVI4cUpIZGFCRUxhcXZtUTZiSWd1TzVxVU1VeGlqSUo0aDhuQzVsNApLRWtXaThaQWs5WHBnNm91ZGtSekRVNENJOVlHemFxNTltS1huTjdNTUo0QVYzbkRLNlFwWTZETktDM3BicWp0Cm9BVFFMNit0QWdNQkFBRUNnZ0VCQUs3N1I0d3BJcDRZU1JoaGJoN1loWldHQ3JEYkZCZUtZVWd4djB5LzhNaHEKenNlYlhzdGQ1TVpXL2FISVRqdzZFQU9tT1hVNWZNTHVtTWpQMlVDdktWbkg2QzgzczI1ekFFTmlxdWxXUzIvVgpJRi83N1Qwamx6ZTY2MDlPa3pKQzBoWWJsRVNnRUdDc3pBdUpjT0tnVnVLQWwxQkZTQW1VYWRPWFNNdm9NS3lDCkJlekZaVEhOcGRWQ2xwUHVLNGQrWFJJZ1hHWS84RzNmWlFXRWNjV2tTYmRjQUlLdVYvWktHQ0IyT2dXS1VzSHgKTStscEw1TTZ3aXdYOEFNdUVWVHJsMWNwKzAzTjdOaUYwMFpYdCszZzVZUkJmRitYWjZ1b3hmbENQZ3VHdzh6bgpvN2tFRVNKZ2YycHZyZWYveHBjSVFSM090aHZjSzR5RldOcndPbExHQk9FQ2dZRUErNmJBREF0bDAvRlpzV08zCnVvNlBRNXZTL0tqbS9XaUkzeUo5TUdLNzQxTFZpMlRMUGpVZ092SDdkZUVjNVJjUmoxV1Nna3d1bUdzZWE2WkQKWXRWSTRZTDdMM1NUQ3JyZUNFTDRhOUJPcFB0azcxWWw3TmhxZktEaXhzU1FnNmt4dDJ1TlYvZXNSQ1JPeENoWgp5bk9JTmkvN3lOeFpVek4zcndyVjBCMUFNYVVDZ1lFQTljVDBZNkJWRHZLdFFaV1gvR1REZ2pUUzN6QWlPWmFNCjVFM3NleHh6MXY4eDF0N3JvWDV3aHNaVjlzQ05nNlJaNjIyT3hJejhHQnVvMnU1M2h2WFJabmdDaG1PcHYwRjgKcm5STWFNR0tIeGN2TmNrVUZUMW9TdDJCeEhNT1FNZTM2cERVTnZ0S3pvNGJoakpVUU94Mm14RU9TNERscm4rMApRU3FqVFpyWGwya0NnWUJ1UmIyMkNYQ1BsUjBHbkhtd0tEUWpIaTh3UkJza1JDQm1Gc2pnNFFNUU5BWWJWUW15CnNyankyNEtqUHdmWVkybHdjOEVGazdoL1ZjRTR6dHlNZklXNVBCb3h5MVY3eURMdlQ5bG45Um5oTmNBZkdKTDUKM0VPZFpTcTZpdndBbGEyUmdIR3BjSUJ1UTdLNFJpNUNocW5UaE9kQ056eDFOd0psRTh4cHE4ZXJlUUtCZ1FEeQppV3B3UXRLT0ROa0VCdi9WT1E5am1JT2RjOS9pbXZyeGR5RHZvWFdENzVXY3FhTTVYUkRwUUNPbmZnQnBzREI0CjBFWjdHM0xReThNSVF4czcyYXpMaFpWZ1VFdzlEUUJoSFM0bWx4Q2FmQU8vL1c3UFF5bC84RGJXeW9CL1YxamQKcUExMU1PcHpDdlNJcTNSUUdjczJYaytRSFdVTW5zUWhKMVcvQ1JiSE9RS0JnRTVQZ0hrbW1PY1VXZkJBZUtzTApvb2FNNzBINVN1YUNYN1Y1enBhM3hFMW5WVWMxend5aldOdkdWbTA5WkpEOFFMR1ZDV2U0R1o5R1NvV2tqSUMvCklFKzA0M29kUERuL2JwSDlTMDF2a0s1ZDRJSGc3QUcwWXI5SW1zS0paT0djT1dmdUdKSlZ5em1CRXhaSU9pbnoKVFFuaFdhZWs0NE1hdVJYOC9pRjZyZWorCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
-    kind: Secret
-    metadata:
-        name: kong.proxy.example.secret
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  rules:
+    - host: proxy.kong.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - proxy.kong.example
+      secretName: kong.proxy.example.secret
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -1,930 +1,926 @@
-[kong-ingress-3-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        rules:
-            - host: proxy.kong.example
-              http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /
-                      pathType: ImplementationSpecific
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  rules:
+    - host: proxy.kong.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: ImplementationSpecific
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -1,983 +1,979 @@
-[kong-ingress-4-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURoakNDQW00Q0NRQ0tyTDdSS1Y0NTBEQU5CZ2txaGtpRzl3MEJBUXNGQURDQmhERUxNQWtHQTFVRUJoTUMKV0ZneEVqQVFCZ05WQkFnTUNWTjBZWFJsVG1GdFpURVJNQThHQTFVRUJ3d0lRMmwwZVU1aGJXVXhGREFTQmdOVgpCQW9NQzBOdmJYQmhibmxPWVcxbE1Sc3dHUVlEVlFRTERCSkRiMjF3WVc1NVUyVmpkR2x2Yms1aGJXVXhHekFaCkJnTlZCQU1NRW5CeWIzaDVMbXR2Ym1jdVpYaGhiWEJzWlRBZUZ3MHlNekEyTWprd09ERTBNekJhRncwek16QTIKTWpZd09ERTBNekJhTUlHRU1Rc3dDUVlEVlFRR0V3SllXREVTTUJBR0ExVUVDQXdKVTNSaGRHVk9ZVzFsTVJFdwpEd1lEVlFRSERBaERhWFI1VG1GdFpURVVNQklHQTFVRUNnd0xRMjl0Y0dGdWVVNWhiV1V4R3pBWkJnTlZCQXNNCkVrTnZiWEJoYm5sVFpXTjBhVzl1VG1GdFpURWJNQmtHQTFVRUF3d1NjSEp2ZUhrdWEyOXVaeTVsZUdGdGNHeGwKTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE4Wmd4czI1RXdtaXRsRG1HMitWVwpscUZ4R3lkVHU2dWlCVldFZjNoV0h2R3YvUWpYZHBBWXlkc3ZpNS92b1FtcjNUeVJBb3VaR1lCR3RuVEF0cU5rCnFLUmFVaWppVlN3TTNzeUl1cHluMlRjSjk1N2RLUCtUYTRaL0VNUlRwSCtya1psV01LNVYrNUszTmFIL21leDUKVWRRWkl4WUxNM0xIM0t0cmt2OWZRNlhSZ2dkeXo0MEt2YUV6SW1scEVoQnBoS0g5UWJiL3RFRE0vdFFqbC9FUApmbUF5M2Y5WE1uRDNSeFY3TnFrZktpUjNXZ1JDMnFyNWtPbXlJTGp1YWxERk1Zb3lDZUlmSnd1WmVDaEpGb3ZHClFKUFY2WU9xTG5aRWN3MU9BaVBXQnMycXVmWmlsNXplekRDZUFGZDV3eXVrS1dPZ3pTZ3Q2VzZvN2FBRTBDK3YKclFJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNGZHhFOFVsMVorcWxBbW1lTk5BdlAyZVVxSElTbQpHWXZidzdGdW82bXNJY3V3cjZKeENBWjIwako5UkphalMzWS9TS3BteXM2OXZxU21ic25oeUJzc01mL1ZtenFSClBVLzVkUUZiblNybUJqMnFBNWxtRCtENDVLUEtrTjc1V21NeDRQWkZseEw3WHVLYnZhYVZBUjFFUmRNZy90NisKUXpPV3BVWVZrcFJnQmlxTDBTTjhvTStOTjdScGFESFNkZjlTY1FtUmhNVklNNDdVZ1ZXNWhta21mQjBkUTFhQQo5NWdTQ3E0cGVwUFRzY3NsbVBzM0lOck5BTk45KytyMnM1bXRTWnp5VktRU0cwRjQ0Y1puWjdTdkdTVFJORDlUCnRKVzNTcko3elBwS0JqWi9qVDRRVnpBdGtHN3FSV2ZhYnlWTmVrK29wMTgwSVY5Um9IR1JDU0kyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRRHhtREd6YmtUQ2FLMlUKT1liYjVWYVdvWEViSjFPN3E2SUZWWVIvZUZZZThhLzlDTmQya0JqSjJ5K0xuKytoQ2F2ZFBKRUNpNWtaZ0VhMgpkTUMybzJTb3BGcFNLT0pWTEF6ZXpJaTZuS2ZaTnduM250MG8vNU5yaG44UXhGT2tmNnVSbVZZd3JsWDdrcmMxCm9mK1o3SGxSMUJrakZnc3pjc2ZjcTJ1Uy8xOURwZEdDQjNMUGpRcTlvVE1pYVdrU0VHbUVvZjFCdHYrMFFNeisKMUNPWDhROStZRExkLzFjeWNQZEhGWHMycVI4cUpIZGFCRUxhcXZtUTZiSWd1TzVxVU1VeGlqSUo0aDhuQzVsNApLRWtXaThaQWs5WHBnNm91ZGtSekRVNENJOVlHemFxNTltS1huTjdNTUo0QVYzbkRLNlFwWTZETktDM3BicWp0Cm9BVFFMNit0QWdNQkFBRUNnZ0VCQUs3N1I0d3BJcDRZU1JoaGJoN1loWldHQ3JEYkZCZUtZVWd4djB5LzhNaHEKenNlYlhzdGQ1TVpXL2FISVRqdzZFQU9tT1hVNWZNTHVtTWpQMlVDdktWbkg2QzgzczI1ekFFTmlxdWxXUzIvVgpJRi83N1Qwamx6ZTY2MDlPa3pKQzBoWWJsRVNnRUdDc3pBdUpjT0tnVnVLQWwxQkZTQW1VYWRPWFNNdm9NS3lDCkJlekZaVEhOcGRWQ2xwUHVLNGQrWFJJZ1hHWS84RzNmWlFXRWNjV2tTYmRjQUlLdVYvWktHQ0IyT2dXS1VzSHgKTStscEw1TTZ3aXdYOEFNdUVWVHJsMWNwKzAzTjdOaUYwMFpYdCszZzVZUkJmRitYWjZ1b3hmbENQZ3VHdzh6bgpvN2tFRVNKZ2YycHZyZWYveHBjSVFSM090aHZjSzR5RldOcndPbExHQk9FQ2dZRUErNmJBREF0bDAvRlpzV08zCnVvNlBRNXZTL0tqbS9XaUkzeUo5TUdLNzQxTFZpMlRMUGpVZ092SDdkZUVjNVJjUmoxV1Nna3d1bUdzZWE2WkQKWXRWSTRZTDdMM1NUQ3JyZUNFTDRhOUJPcFB0azcxWWw3TmhxZktEaXhzU1FnNmt4dDJ1TlYvZXNSQ1JPeENoWgp5bk9JTmkvN3lOeFpVek4zcndyVjBCMUFNYVVDZ1lFQTljVDBZNkJWRHZLdFFaV1gvR1REZ2pUUzN6QWlPWmFNCjVFM3NleHh6MXY4eDF0N3JvWDV3aHNaVjlzQ05nNlJaNjIyT3hJejhHQnVvMnU1M2h2WFJabmdDaG1PcHYwRjgKcm5STWFNR0tIeGN2TmNrVUZUMW9TdDJCeEhNT1FNZTM2cERVTnZ0S3pvNGJoakpVUU94Mm14RU9TNERscm4rMApRU3FqVFpyWGwya0NnWUJ1UmIyMkNYQ1BsUjBHbkhtd0tEUWpIaTh3UkJza1JDQm1Gc2pnNFFNUU5BWWJWUW15CnNyankyNEtqUHdmWVkybHdjOEVGazdoL1ZjRTR6dHlNZklXNVBCb3h5MVY3eURMdlQ5bG45Um5oTmNBZkdKTDUKM0VPZFpTcTZpdndBbGEyUmdIR3BjSUJ1UTdLNFJpNUNocW5UaE9kQ056eDFOd0psRTh4cHE4ZXJlUUtCZ1FEeQppV3B3UXRLT0ROa0VCdi9WT1E5am1JT2RjOS9pbXZyeGR5RHZvWFdENzVXY3FhTTVYUkRwUUNPbmZnQnBzREI0CjBFWjdHM0xReThNSVF4czcyYXpMaFpWZ1VFdzlEUUJoSFM0bWx4Q2FmQU8vL1c3UFF5bC84RGJXeW9CL1YxamQKcUExMU1PcHpDdlNJcTNSUUdjczJYaytRSFdVTW5zUWhKMVcvQ1JiSE9RS0JnRTVQZ0hrbW1PY1VXZkJBZUtzTApvb2FNNzBINVN1YUNYN1Y1enBhM3hFMW5WVWMxend5aldOdkdWbTA5WkpEOFFMR1ZDV2U0R1o5R1NvV2tqSUMvCklFKzA0M29kUERuL2JwSDlTMDF2a0s1ZDRJSGc3QUcwWXI5SW1zS0paT0djT1dmdUdKSlZ5em1CRXhaSU9pbnoKVFFuaFdhZWs0NE1hdVJYOC9pRjZyZWorCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  name: kong.proxy.example.secret
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURmakNDQW1ZQ0NRREVtWjF0cnJwaURqQU5CZ2txaGtpRzl3MEJBUXNGQURDQmdERUxNQWtHQTFVRUJoTUMKV0ZneEVqQVFCZ05WQkFnTUNWTjBZWFJsVG1GdFpURVJNQThHQTFVRUJ3d0lRMmwwZVU1aGJXVXhGREFTQmdOVgpCQW9NQzBOdmJYQmhibmxPWVcxbE1Sc3dHUVlEVlFRTERCSkRiMjF3WVc1NVUyVmpkR2x2Yms1aGJXVXhGekFWCkJnTlZCQU1NRGlvdWEyOXVaeTVsZUdGdGNHeGxNQjRYRFRJek1EWXlPVEE0TVRjek4xb1hEVE16TURZeU5qQTQKTVRjek4xb3dnWUF4Q3pBSkJnTlZCQVlUQWxoWU1SSXdFQVlEVlFRSURBbFRkR0YwWlU1aGJXVXhFVEFQQmdOVgpCQWNNQ0VOcGRIbE9ZVzFsTVJRd0VnWURWUVFLREF0RGIyMXdZVzU1VG1GdFpURWJNQmtHQTFVRUN3d1NRMjl0CmNHRnVlVk5sWTNScGIyNU9ZVzFsTVJjd0ZRWURWUVFEREE0cUxtdHZibWN1WlhoaGJYQnNaVENDQVNJd0RRWUoKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDlSR1g1VytsRW8wcGg2eTJqeHN6TGZOcjMvNlpFOQpPR0pPMGl1WmpwRml2dHBya24ydDlqYTRaNUdYOGh4NUczS1FsRkhrVFBmV01BWmUzdldINTF0alZzYjZwY2UwCjlkMUo4WXNxWkh5RHVlUzBrS3RUbEFmc0F5MnVjL3ZvUUdmOTdZeUI2TlJ4TEJmNHBnSVJ4eHpGM3o0Q1ZOSTgKTzE5Ym1PYVo1Vkk1QWZpbENSMUI1ekxuN2VoeEJHOHhTQmRtQUg0eWFob2t5RXk2a0ZtRzJCaEtJWjdsL1BZYQpqbU1yQ3cwekRVampvblBublZTWTkxL0EwNUJVTVk5OEZsME00QVV5T1V3enBaajhqMXhLMTNqUVlGeXJwUHQwCklHNUdLR044akVCcnRkdGVlcGZIdFZuekFWYnhoT0hkcXZoUWhrSDJDSGVwOStIQkNIL25VL1VDQXdFQUFUQU4KQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQkcxVVYyUFRJekhrNEt4cjBHT0NXalhjTTdKUU9hbUJQM3dZSCswRgpyc09YUG9IOHVLV25XYjhSSGE1MDhMenU4MGNzS1lYcnZ4SEhDcmcxdXJjRnl3bnNMaUtMNGhsQklTd2ZMNzFFClVXODhQdGYyWTdjTnJZRzNLc2MvMWVpait1RWd5bVdCbjkraVYzbzE5VERwRjlZZWZwYzNUUDJqMGhNUHcwMlgKa1gzSlh3b250NnBQaDhlQjhXRU1OZkF5NzZmb0lMcytVd0Fjck56QkpjSVZSTERoZWFNMFNFd0xCNUpuaWZ5ZwplRE1aSE56MkhLais0NU1wTzFOSDBtd3ZJRTRLQjNITUNSSlMybmZFbWVMcFdCMWpmZTV6T2o1bWhTeS82M0RVCldDQll1aUhtelFWaGxJS21lQzBlVmd3bGtkMTFrUDRNM1hoWnB6V09aQ1BoaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+  tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQy9VUmwrVnZwUktOS1kKZXN0bzhiTXkzemE5LyttUlBUaGlUdElybVk2UllyN2FhNUo5cmZZMnVHZVJsL0ljZVJ0eWtKUlI1RXozMWpBRwpYdDcxaCtkYlkxYkcrcVhIdFBYZFNmR0xLbVI4Zzdua3RKQ3JVNVFIN0FNdHJuUDc2RUJuL2UyTWdlalVjU3dYCitLWUNFY2NjeGQ4K0FsVFNQRHRmVzVqbW1lVlNPUUg0cFFrZFFlY3k1KzNvY1FSdk1VZ1haZ0IrTW1vYUpNaE0KdXBCWmh0Z1lTaUdlNWZ6MkdvNWpLd3NOTXcxSTQ2Sno1NTFVbVBkZndOT1FWREdQZkJaZERPQUZNamxNTTZXWQovSTljU3RkNDBHQmNxNlQ3ZENCdVJpaGpmSXhBYTdYYlhucVh4N1ZaOHdGVzhZVGgzYXI0VUlaQjlnaDNxZmZoCndRaC81MVAxQWdNQkFBRUNnZ0VCQUlCZ0l3TXJ5ZnY3c0pTd2tSMXlVaFNvdzByckZnZG5WUlppWFpUMERUNXgKVEMrMFR6QVdNMGkwcElxRnN1aDRPM3E4bVVuNkw4dDk1ZXZnYlN2RWJmSmN6alhtcXFjL1BsdW02blcvbEg0WQp4Znc1VFhvcE13Tzkwc1FzYzVkdFdRcHUwWitlN0dUaEsvMUowOXMvb3FRa0FwRFJiNmxDMFhSRE9tNUNoaWFNCi95Z2M2dGUzUHkrRXpzSmRMRm9YWndFQnVQWTB2KzlBclhpNmlUMllaN1ZacE9iZzQxcm1ocHNObTFLNmdJajUKZFZKNGZYa2Z5V0hsSmJBYzVTRDkrVWMrTGFjUEcxSjVJUWx6eTM0WlM0ZG9VQ2lmODZuVHFzSnFVTU1sNXYxcAp3SFFUZFI2MkdnWnRPM1grOU4vdHE3SExqU0tHY0JEd3E4bEM4QXZ0VHdFQ2dZRUErWWpVdzI1em42aWhjaXFpCmo3dDJiQVdLdzdlbng1RXFzU25ZOG1PYzR2TDdNa1YyN2ZhYXp1cW8wUEtOeWJOa1grUlhIMDN4S0NDd0x0N0UKLzRDUlFHMGNkQmhBQ2szMkpadllrQmxESUZ3VmtnMHVnNGk4Snp6VjVCT2hEeWdwZUhJTDVVTkx2eGJDbVh6MAo1bXNYRktPYW1HYkFCbE9KTEZsR1R4WWdzeWtDZ1lFQXhFWWI0dFVmRmhiTmpJTUMyd1hFRXdWZkJYOFJqNzVqCjN6SkwxV3o4YWxUQmxFemZYOTZiNmg3VjFNT1NHcmlabFJ1cGpEaUFsUkhPZytDSXlPbmdISFkwd2xTaHNmemQKSDluL2dOdUZsanFuQkF3OVpaSW9hbE1zUVVER3RLSnVIejhEYzlVNzRFMGM3WldQWk1Ub0pNdFV2Zkl5T0pZSgpQODh1YnYvam4rMENnWUJaNmpzNFhKRmZRNFZCUFNtc2Z4RXg1V0ZXR3RSakxlVGpSNy83djNjbHRBWmQyL2Y1CjBUV0JQNzhxNDJ2QjlWbEMwR1d3U3dhTnZoR2VJZmw4VTVpRFRZM0dLNExQODcyeFdaSFVnclhVY0RuNWtiUmsKQXg1QlNVT05WcUZmYzhwVnMwcWtCdmJCV1hNdm1YNHBsUWNSRWM3QUFhNUoyVW9CWi8zVXU1VjIyUUtCZ0ZnVQpKanQ2N0lKYkpVN2pGQXI1NFcydndWNlVFV3R5UXh0TVZOK29FdlljcHVwSVBRMm10azB3SFVGbnFrODNmQ1IvCnoyeFBodFJlczFCWEdNc2d1U1BNb0F4OU1qclBnT1BrVGxhakxLV29HSDhtaHY3bndoOUV4OTFZbGxORmVTbW8KZTRJbHRNTUpsK3UrYkNVS2dDclMzR3FKSDZScElDbDBiaC85MFVaWkFvR0FaUEsrdldLQ0N6aHNhSnVWak1VSQpiTEJlMi9CM0xxTVBhakFLTjVTNU9GYlpBZm5NeE9BT1lnd25iWmdpZGVkcVk2QkIyLytVVGt4MW1IUjhKcmpGCnRyN20wS2VvRFY4dmQxSENvSkF3b2hqQ1B6SkJhSW9WYWNkRFNsMDNIOVFEck4yd0RFYUxoWFBlVkRoNGZ2NmQKa3d6V3FZWUlETzRKQlp5L21Wa0t4NFU9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
+kind: Secret
+metadata:
+  name: kong.proxy.example.secret2
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        rules:
-            - host: proxy.kong.example
-              http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /
-                      pathType: ImplementationSpecific
-            - host: proxy2.kong.example
-              http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /foo
-                      pathType: Prefix
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /bar
-                      pathType: Prefix
-            - host: proxy3.kong.example
-              http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /baz
-                      pathType: Prefix
-        tls:
-            - hosts:
-                - proxy.kong.example
-              secretName: proxy.kong.example.secret
-            - hosts:
-                - proxy2.kong.example
-                - proxy3.kong.example
-              secretName: proxy.kong.example.secret2
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURoakNDQW00Q0NRQ0tyTDdSS1Y0NTBEQU5CZ2txaGtpRzl3MEJBUXNGQURDQmhERUxNQWtHQTFVRUJoTUMKV0ZneEVqQVFCZ05WQkFnTUNWTjBZWFJsVG1GdFpURVJNQThHQTFVRUJ3d0lRMmwwZVU1aGJXVXhGREFTQmdOVgpCQW9NQzBOdmJYQmhibmxPWVcxbE1Sc3dHUVlEVlFRTERCSkRiMjF3WVc1NVUyVmpkR2x2Yms1aGJXVXhHekFaCkJnTlZCQU1NRW5CeWIzaDVMbXR2Ym1jdVpYaGhiWEJzWlRBZUZ3MHlNekEyTWprd09ERTBNekJhRncwek16QTIKTWpZd09ERTBNekJhTUlHRU1Rc3dDUVlEVlFRR0V3SllXREVTTUJBR0ExVUVDQXdKVTNSaGRHVk9ZVzFsTVJFdwpEd1lEVlFRSERBaERhWFI1VG1GdFpURVVNQklHQTFVRUNnd0xRMjl0Y0dGdWVVNWhiV1V4R3pBWkJnTlZCQXNNCkVrTnZiWEJoYm5sVFpXTjBhVzl1VG1GdFpURWJNQmtHQTFVRUF3d1NjSEp2ZUhrdWEyOXVaeTVsZUdGdGNHeGwKTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUE4Wmd4czI1RXdtaXRsRG1HMitWVwpscUZ4R3lkVHU2dWlCVldFZjNoV0h2R3YvUWpYZHBBWXlkc3ZpNS92b1FtcjNUeVJBb3VaR1lCR3RuVEF0cU5rCnFLUmFVaWppVlN3TTNzeUl1cHluMlRjSjk1N2RLUCtUYTRaL0VNUlRwSCtya1psV01LNVYrNUszTmFIL21leDUKVWRRWkl4WUxNM0xIM0t0cmt2OWZRNlhSZ2dkeXo0MEt2YUV6SW1scEVoQnBoS0g5UWJiL3RFRE0vdFFqbC9FUApmbUF5M2Y5WE1uRDNSeFY3TnFrZktpUjNXZ1JDMnFyNWtPbXlJTGp1YWxERk1Zb3lDZUlmSnd1WmVDaEpGb3ZHClFKUFY2WU9xTG5aRWN3MU9BaVBXQnMycXVmWmlsNXplekRDZUFGZDV3eXVrS1dPZ3pTZ3Q2VzZvN2FBRTBDK3YKclFJREFRQUJNQTBHQ1NxR1NJYjNEUUVCQ3dVQUE0SUJBUUNGZHhFOFVsMVorcWxBbW1lTk5BdlAyZVVxSElTbQpHWXZidzdGdW82bXNJY3V3cjZKeENBWjIwako5UkphalMzWS9TS3BteXM2OXZxU21ic25oeUJzc01mL1ZtenFSClBVLzVkUUZiblNybUJqMnFBNWxtRCtENDVLUEtrTjc1V21NeDRQWkZseEw3WHVLYnZhYVZBUjFFUmRNZy90NisKUXpPV3BVWVZrcFJnQmlxTDBTTjhvTStOTjdScGFESFNkZjlTY1FtUmhNVklNNDdVZ1ZXNWhta21mQjBkUTFhQQo5NWdTQ3E0cGVwUFRzY3NsbVBzM0lOck5BTk45KytyMnM1bXRTWnp5VktRU0cwRjQ0Y1puWjdTdkdTVFJORDlUCnRKVzNTcko3elBwS0JqWi9qVDRRVnpBdGtHN3FSV2ZhYnlWTmVrK29wMTgwSVY5Um9IR1JDU0kyCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
-        tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRRHhtREd6YmtUQ2FLMlUKT1liYjVWYVdvWEViSjFPN3E2SUZWWVIvZUZZZThhLzlDTmQya0JqSjJ5K0xuKytoQ2F2ZFBKRUNpNWtaZ0VhMgpkTUMybzJTb3BGcFNLT0pWTEF6ZXpJaTZuS2ZaTnduM250MG8vNU5yaG44UXhGT2tmNnVSbVZZd3JsWDdrcmMxCm9mK1o3SGxSMUJrakZnc3pjc2ZjcTJ1Uy8xOURwZEdDQjNMUGpRcTlvVE1pYVdrU0VHbUVvZjFCdHYrMFFNeisKMUNPWDhROStZRExkLzFjeWNQZEhGWHMycVI4cUpIZGFCRUxhcXZtUTZiSWd1TzVxVU1VeGlqSUo0aDhuQzVsNApLRWtXaThaQWs5WHBnNm91ZGtSekRVNENJOVlHemFxNTltS1huTjdNTUo0QVYzbkRLNlFwWTZETktDM3BicWp0Cm9BVFFMNit0QWdNQkFBRUNnZ0VCQUs3N1I0d3BJcDRZU1JoaGJoN1loWldHQ3JEYkZCZUtZVWd4djB5LzhNaHEKenNlYlhzdGQ1TVpXL2FISVRqdzZFQU9tT1hVNWZNTHVtTWpQMlVDdktWbkg2QzgzczI1ekFFTmlxdWxXUzIvVgpJRi83N1Qwamx6ZTY2MDlPa3pKQzBoWWJsRVNnRUdDc3pBdUpjT0tnVnVLQWwxQkZTQW1VYWRPWFNNdm9NS3lDCkJlekZaVEhOcGRWQ2xwUHVLNGQrWFJJZ1hHWS84RzNmWlFXRWNjV2tTYmRjQUlLdVYvWktHQ0IyT2dXS1VzSHgKTStscEw1TTZ3aXdYOEFNdUVWVHJsMWNwKzAzTjdOaUYwMFpYdCszZzVZUkJmRitYWjZ1b3hmbENQZ3VHdzh6bgpvN2tFRVNKZ2YycHZyZWYveHBjSVFSM090aHZjSzR5RldOcndPbExHQk9FQ2dZRUErNmJBREF0bDAvRlpzV08zCnVvNlBRNXZTL0tqbS9XaUkzeUo5TUdLNzQxTFZpMlRMUGpVZ092SDdkZUVjNVJjUmoxV1Nna3d1bUdzZWE2WkQKWXRWSTRZTDdMM1NUQ3JyZUNFTDRhOUJPcFB0azcxWWw3TmhxZktEaXhzU1FnNmt4dDJ1TlYvZXNSQ1JPeENoWgp5bk9JTmkvN3lOeFpVek4zcndyVjBCMUFNYVVDZ1lFQTljVDBZNkJWRHZLdFFaV1gvR1REZ2pUUzN6QWlPWmFNCjVFM3NleHh6MXY4eDF0N3JvWDV3aHNaVjlzQ05nNlJaNjIyT3hJejhHQnVvMnU1M2h2WFJabmdDaG1PcHYwRjgKcm5STWFNR0tIeGN2TmNrVUZUMW9TdDJCeEhNT1FNZTM2cERVTnZ0S3pvNGJoakpVUU94Mm14RU9TNERscm4rMApRU3FqVFpyWGwya0NnWUJ1UmIyMkNYQ1BsUjBHbkhtd0tEUWpIaTh3UkJza1JDQm1Gc2pnNFFNUU5BWWJWUW15CnNyankyNEtqUHdmWVkybHdjOEVGazdoL1ZjRTR6dHlNZklXNVBCb3h5MVY3eURMdlQ5bG45Um5oTmNBZkdKTDUKM0VPZFpTcTZpdndBbGEyUmdIR3BjSUJ1UTdLNFJpNUNocW5UaE9kQ056eDFOd0psRTh4cHE4ZXJlUUtCZ1FEeQppV3B3UXRLT0ROa0VCdi9WT1E5am1JT2RjOS9pbXZyeGR5RHZvWFdENzVXY3FhTTVYUkRwUUNPbmZnQnBzREI0CjBFWjdHM0xReThNSVF4czcyYXpMaFpWZ1VFdzlEUUJoSFM0bWx4Q2FmQU8vL1c3UFF5bC84RGJXeW9CL1YxamQKcUExMU1PcHpDdlNJcTNSUUdjczJYaytRSFdVTW5zUWhKMVcvQ1JiSE9RS0JnRTVQZ0hrbW1PY1VXZkJBZUtzTApvb2FNNzBINVN1YUNYN1Y1enBhM3hFMW5WVWMxend5aldOdkdWbTA5WkpEOFFMR1ZDV2U0R1o5R1NvV2tqSUMvCklFKzA0M29kUERuL2JwSDlTMDF2a0s1ZDRJSGc3QUcwWXI5SW1zS0paT0djT1dmdUdKSlZ5em1CRXhaSU9pbnoKVFFuaFdhZWs0NE1hdVJYOC9pRjZyZWorCi0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
-    kind: Secret
-    metadata:
-        name: kong.proxy.example.secret
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURmakNDQW1ZQ0NRREVtWjF0cnJwaURqQU5CZ2txaGtpRzl3MEJBUXNGQURDQmdERUxNQWtHQTFVRUJoTUMKV0ZneEVqQVFCZ05WQkFnTUNWTjBZWFJsVG1GdFpURVJNQThHQTFVRUJ3d0lRMmwwZVU1aGJXVXhGREFTQmdOVgpCQW9NQzBOdmJYQmhibmxPWVcxbE1Sc3dHUVlEVlFRTERCSkRiMjF3WVc1NVUyVmpkR2x2Yms1aGJXVXhGekFWCkJnTlZCQU1NRGlvdWEyOXVaeTVsZUdGdGNHeGxNQjRYRFRJek1EWXlPVEE0TVRjek4xb1hEVE16TURZeU5qQTQKTVRjek4xb3dnWUF4Q3pBSkJnTlZCQVlUQWxoWU1SSXdFQVlEVlFRSURBbFRkR0YwWlU1aGJXVXhFVEFQQmdOVgpCQWNNQ0VOcGRIbE9ZVzFsTVJRd0VnWURWUVFLREF0RGIyMXdZVzU1VG1GdFpURWJNQmtHQTFVRUN3d1NRMjl0CmNHRnVlVk5sWTNScGIyNU9ZVzFsTVJjd0ZRWURWUVFEREE0cUxtdHZibWN1WlhoaGJYQnNaVENDQVNJd0RRWUoKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDlSR1g1VytsRW8wcGg2eTJqeHN6TGZOcjMvNlpFOQpPR0pPMGl1WmpwRml2dHBya24ydDlqYTRaNUdYOGh4NUczS1FsRkhrVFBmV01BWmUzdldINTF0alZzYjZwY2UwCjlkMUo4WXNxWkh5RHVlUzBrS3RUbEFmc0F5MnVjL3ZvUUdmOTdZeUI2TlJ4TEJmNHBnSVJ4eHpGM3o0Q1ZOSTgKTzE5Ym1PYVo1Vkk1QWZpbENSMUI1ekxuN2VoeEJHOHhTQmRtQUg0eWFob2t5RXk2a0ZtRzJCaEtJWjdsL1BZYQpqbU1yQ3cwekRVampvblBublZTWTkxL0EwNUJVTVk5OEZsME00QVV5T1V3enBaajhqMXhLMTNqUVlGeXJwUHQwCklHNUdLR044akVCcnRkdGVlcGZIdFZuekFWYnhoT0hkcXZoUWhrSDJDSGVwOStIQkNIL25VL1VDQXdFQUFUQU4KQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQkcxVVYyUFRJekhrNEt4cjBHT0NXalhjTTdKUU9hbUJQM3dZSCswRgpyc09YUG9IOHVLV25XYjhSSGE1MDhMenU4MGNzS1lYcnZ4SEhDcmcxdXJjRnl3bnNMaUtMNGhsQklTd2ZMNzFFClVXODhQdGYyWTdjTnJZRzNLc2MvMWVpait1RWd5bVdCbjkraVYzbzE5VERwRjlZZWZwYzNUUDJqMGhNUHcwMlgKa1gzSlh3b250NnBQaDhlQjhXRU1OZkF5NzZmb0lMcytVd0Fjck56QkpjSVZSTERoZWFNMFNFd0xCNUpuaWZ5ZwplRE1aSE56MkhLais0NU1wTzFOSDBtd3ZJRTRLQjNITUNSSlMybmZFbWVMcFdCMWpmZTV6T2o1bWhTeS82M0RVCldDQll1aUhtelFWaGxJS21lQzBlVmd3bGtkMTFrUDRNM1hoWnB6V09aQ1BoaGc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
-        tls.key: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktjd2dnU2pBZ0VBQW9JQkFRQy9VUmwrVnZwUktOS1kKZXN0bzhiTXkzemE5LyttUlBUaGlUdElybVk2UllyN2FhNUo5cmZZMnVHZVJsL0ljZVJ0eWtKUlI1RXozMWpBRwpYdDcxaCtkYlkxYkcrcVhIdFBYZFNmR0xLbVI4Zzdua3RKQ3JVNVFIN0FNdHJuUDc2RUJuL2UyTWdlalVjU3dYCitLWUNFY2NjeGQ4K0FsVFNQRHRmVzVqbW1lVlNPUUg0cFFrZFFlY3k1KzNvY1FSdk1VZ1haZ0IrTW1vYUpNaE0KdXBCWmh0Z1lTaUdlNWZ6MkdvNWpLd3NOTXcxSTQ2Sno1NTFVbVBkZndOT1FWREdQZkJaZERPQUZNamxNTTZXWQovSTljU3RkNDBHQmNxNlQ3ZENCdVJpaGpmSXhBYTdYYlhucVh4N1ZaOHdGVzhZVGgzYXI0VUlaQjlnaDNxZmZoCndRaC81MVAxQWdNQkFBRUNnZ0VCQUlCZ0l3TXJ5ZnY3c0pTd2tSMXlVaFNvdzByckZnZG5WUlppWFpUMERUNXgKVEMrMFR6QVdNMGkwcElxRnN1aDRPM3E4bVVuNkw4dDk1ZXZnYlN2RWJmSmN6alhtcXFjL1BsdW02blcvbEg0WQp4Znc1VFhvcE13Tzkwc1FzYzVkdFdRcHUwWitlN0dUaEsvMUowOXMvb3FRa0FwRFJiNmxDMFhSRE9tNUNoaWFNCi95Z2M2dGUzUHkrRXpzSmRMRm9YWndFQnVQWTB2KzlBclhpNmlUMllaN1ZacE9iZzQxcm1ocHNObTFLNmdJajUKZFZKNGZYa2Z5V0hsSmJBYzVTRDkrVWMrTGFjUEcxSjVJUWx6eTM0WlM0ZG9VQ2lmODZuVHFzSnFVTU1sNXYxcAp3SFFUZFI2MkdnWnRPM1grOU4vdHE3SExqU0tHY0JEd3E4bEM4QXZ0VHdFQ2dZRUErWWpVdzI1em42aWhjaXFpCmo3dDJiQVdLdzdlbng1RXFzU25ZOG1PYzR2TDdNa1YyN2ZhYXp1cW8wUEtOeWJOa1grUlhIMDN4S0NDd0x0N0UKLzRDUlFHMGNkQmhBQ2szMkpadllrQmxESUZ3VmtnMHVnNGk4Snp6VjVCT2hEeWdwZUhJTDVVTkx2eGJDbVh6MAo1bXNYRktPYW1HYkFCbE9KTEZsR1R4WWdzeWtDZ1lFQXhFWWI0dFVmRmhiTmpJTUMyd1hFRXdWZkJYOFJqNzVqCjN6SkwxV3o4YWxUQmxFemZYOTZiNmg3VjFNT1NHcmlabFJ1cGpEaUFsUkhPZytDSXlPbmdISFkwd2xTaHNmemQKSDluL2dOdUZsanFuQkF3OVpaSW9hbE1zUVVER3RLSnVIejhEYzlVNzRFMGM3WldQWk1Ub0pNdFV2Zkl5T0pZSgpQODh1YnYvam4rMENnWUJaNmpzNFhKRmZRNFZCUFNtc2Z4RXg1V0ZXR3RSakxlVGpSNy83djNjbHRBWmQyL2Y1CjBUV0JQNzhxNDJ2QjlWbEMwR1d3U3dhTnZoR2VJZmw4VTVpRFRZM0dLNExQODcyeFdaSFVnclhVY0RuNWtiUmsKQXg1QlNVT05WcUZmYzhwVnMwcWtCdmJCV1hNdm1YNHBsUWNSRWM3QUFhNUoyVW9CWi8zVXU1VjIyUUtCZ0ZnVQpKanQ2N0lKYkpVN2pGQXI1NFcydndWNlVFV3R5UXh0TVZOK29FdlljcHVwSVBRMm10azB3SFVGbnFrODNmQ1IvCnoyeFBodFJlczFCWEdNc2d1U1BNb0F4OU1qclBnT1BrVGxhakxLV29HSDhtaHY3bndoOUV4OTFZbGxORmVTbW8KZTRJbHRNTUpsK3UrYkNVS2dDclMzR3FKSDZScElDbDBiaC85MFVaWkFvR0FaUEsrdldLQ0N6aHNhSnVWak1VSQpiTEJlMi9CM0xxTVBhakFLTjVTNU9GYlpBZm5NeE9BT1lnd25iWmdpZGVkcVk2QkIyLytVVGt4MW1IUjhKcmpGCnRyN20wS2VvRFY4dmQxSENvSkF3b2hqQ1B6SkJhSW9WYWNkRFNsMDNIOVFEck4yd0RFYUxoWFBlVkRoNGZ2NmQKa3d6V3FZWUlETzRKQlp5L21Wa0t4NFU9Ci0tLS0tRU5EIFBSSVZBVEUgS0VZLS0tLS0K
-    kind: Secret
-    metadata:
-        name: kong.proxy.example.secret2
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  rules:
+    - host: proxy.kong.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: ImplementationSpecific
+    - host: proxy2.kong.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /foo
+            pathType: Prefix
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /bar
+            pathType: Prefix
+    - host: proxy3.kong.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /baz
+            pathType: Prefix
+  tls:
+    - hosts:
+        - proxy.kong.example
+      secretName: proxy.kong.example.secret
+    - hosts:
+        - proxy2.kong.example
+        - proxy3.kong.example
+      secretName: proxy.kong.example.secret2
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -1,912 +1,908 @@
-['kong-ingress-5-3.1-rbac-values']
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ANONYMOUS_REPORTS
-                          value: \"false\"
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1.0
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -1,908 +1,904 @@
-[proxy-appprotocol-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - appProtocol: http
+      name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - appProtocol: https
+      name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - appProtocol: http
-              name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - appProtocol: https
-              name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -1,906 +1,902 @@
-[service-account]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: my-kong-sa
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: my-kong-sa
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: my-kong-sa
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: my-kong-sa-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: my-kong-sa-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: my-kong-sa-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: my-kong-sa
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: my-kong-sa-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: my-kong-sa
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: my-kong-sa
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: my-kong-sa-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: my-kong-sa
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: my-kong-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: my-kong-sa
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -1,912 +1,908 @@
-[single-image-default-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ANONYMOUS_REPORTS
-                          value: \"false\"
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.0
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.4.1
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.4.1
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.0
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 10255
+              name: cmetrics
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 10254
+              name: cstatus
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.4.1
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.4.1
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -1,311 +1,307 @@
-['test-enterprise-version-3.4.0.0-values']
-SnapShot = """
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong/kong-gateway:3.4.0.0
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 1
-                        periodSeconds: 1
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong/kong-gateway:3.4.0.0
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong/kong-gateway:3.4.0.0
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 8443
+              name: proxy-tls
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 8100
+              name: status
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
-              protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong/kong-gateway:3.4.0.0
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -1,999 +1,995 @@
-[test1-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        environment: test
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_HEADER
+              value: foo:bar
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
+              protocol: TCP
+            - containerPort: 10255
+              name: cmetrics
+              protocol: TCP
+            - containerPort: 10254
+              name: cstatus
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+            - mountPath: /tmp/foo
+              name: tmpdir
+              readOnly: true
+            - mountPath: /tmp/controller
+              name: controllerdir
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://admin.kong.example
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://admin.kong.example
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
+              protocol: TCP
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+            - mountPath: /tmp/foo
+              name: tmpdir
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://admin.kong.example
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://admin.kong.example
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+        - command:
+            - /bin/sh
+            - -c
+            - "true"
+          image: bash:latest
+          name: bash
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - mountPath: /tmp/foo
+              name: tmpdir
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+        - emptyDir: {}
+          name: tmpdir
+        - emptyDir: {}
+          name: controllerdir
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  maxReplicas: 5
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 80
+          type: Utilization
+      type: Resource
+  minReplicas: 2
+  scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    spec:
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    environment: test
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ANONYMOUS_REPORTS
-                          value: \"false\"
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_HEADER
-                          value: foo:bar
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                        - mountPath: /tmp/foo
-                          name: tmpdir
-                          readOnly: true
-                        - mountPath: /tmp/controller
-                          name: controllerdir
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://admin.kong.example
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://admin.kong.example
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                        - mountPath: /tmp/foo
-                          name: tmpdir
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://admin.kong.example
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://admin.kong.example
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                    - command:
-                        - /bin/sh
-                        - -c
-                        - \"true\"
-                      image: bash:latest
-                      name: bash
-                      resources:
-                        limits:
-                            cpu: 100m
-                            memory: 64Mi
-                        requests:
-                            cpu: 100m
-                            memory: 64Mi
-                      volumeMounts:
-                        - mountPath: /tmp/foo
-                          name: tmpdir
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-                    - emptyDir: {}
-                      name: tmpdir
-                    - emptyDir: {}
-                      name: controllerdir
-- object:
-    apiVersion: autoscaling/v2
-    kind: HorizontalPodAutoscaler
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    spec:
-        maxReplicas: 5
-        metrics:
-            - resource:
-                name: cpu
-                target:
-                    averageUtilization: 80
-                    type: Utilization
-              type: Resource
-        minReplicas: 2
-        scaleTargetRef:
-            apiVersion: apps/v1
-            kind: Deployment
-            name: chartsnap-kong
-- object:
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        rules:
-            - host: proxy.kong.example
-              http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /
-                      pathType: ImplementationSpecific
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
-              protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
-              protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
-              protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
-              protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+    name: chartsnap-kong
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  rules:
+    - host: proxy.kong.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: ImplementationSpecific
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -1,2138 +1,2134 @@
-[test2-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  password: a29uZw==
+  postgres-password: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+type: Opaque
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  test-env: test
+kind: ConfigMap
+metadata:
+  name: env-config
+---
+apiVersion: v1
+data:
+  wait.sh: |
+    until timeout 2 bash -c "9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}"
+      do echo "waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}"
+      sleep 2
+    done
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-bash-wait-for-postgres
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-default
+  namespace: default
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-default
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong-default
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  name: chartsnap-postgresql-hl
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: postgresql
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+spec:
+  ports:
+    - name: tcp-postgresql
+      nodePort: null
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: postgresql
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    - name: stream-9000
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: stream-9001
+      port: 9001
+      protocol: TCP
+      targetPort: 9001
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-          timeoutSeconds: 5
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        strategy:
-            rollingUpdate:
-                maxSurge: 1
-                maxUnavailable: 0
-            type: RollingUpdate
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ANONYMOUS_REPORTS
-                          value: \"false\"
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                        - name: CONTROLLER_WATCH_NAMESPACE
-                          value: default
-                        - name: TZ
-                          value: Europe/Berlin
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 9000
-                          name: stream-9000
-                          protocol: TCP
-                        - containerPort: 9001
-                          name: stream-9001
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                    - command:
-                        - /bin/sh
-                        - -c
-                        - \"true\"
-                      image: bash:latest
-                      name: bash
-                      resources:
-                        limits:
-                            cpu: 100m
-                            memory: 64Mi
-                        requests:
-                            cpu: 100m
-                            memory: 64Mi
-                    - args:
-                        - /bin/bash
-                        - -c
-                        - export KONG_NGINX_DAEMON=on KONG_PREFIX=`mktemp -d` KONG_KEYRING_ENABLED=off; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: wait-for-db
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        defaultMode: 493
-                        name: chartsnap-kong-bash-wait-for-postgres
-                      name: chartsnap-kong-bash-wait-for-postgres
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: apps/v1
-    kind: StatefulSet
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+            - name: CONTROLLER_WATCH_NAMESPACE
+              value: default
+            - name: TZ
+              value: Europe/Berlin
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
+              protocol: TCP
+            - containerPort: 10255
+              name: cmetrics
+              protocol: TCP
+            - containerPort: 10254
+              name: cstatus
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
+              protocol: TCP
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 9000
+              name: stream-9000
+              protocol: TCP
+            - containerPort: 9001
+              name: stream-9001
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+        - command:
+            - /bin/sh
+            - -c
+            - "true"
+          image: bash:latest
+          name: bash
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - args:
+            - /bin/bash
+            - -c
+            - export KONG_NGINX_DAEMON=on KONG_PREFIX=`mktemp -d` KONG_KEYRING_ENABLED=off; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: wait-for-db
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: primary
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: postgresql
+  serviceName: chartsnap-postgresql-hl
+  template:
     metadata:
-        annotations: null
-        labels:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: postgresql
-            helm.sh/chart: postgresql-11.9.13
-        name: chartsnap-postgresql
-        namespace: default
+      annotations: null
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+        helm.sh/chart: postgresql-11.9.13
+      name: chartsnap-postgresql
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: primary
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: postgresql
-        serviceName: chartsnap-postgresql-hl
-        template:
-            metadata:
-                annotations: null
-                labels:
+      affinity:
+        nodeAffinity: null
+        podAffinity: null
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
                     app.kubernetes.io/component: primary
                     app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: postgresql
-                    helm.sh/chart: postgresql-11.9.13
-                name: chartsnap-postgresql
-            spec:
-                affinity:
-                    nodeAffinity: null
-                    podAffinity: null
-                    podAntiAffinity:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                            - podAffinityTerm:
-                                labelSelector:
-                                    matchLabels:
-                                        app.kubernetes.io/component: primary
-                                        app.kubernetes.io/instance: chartsnap
-                                        app.kubernetes.io/name: postgresql
-                                namespaces:
-                                    - default
-                                topologyKey: kubernetes.io/hostname
-                              weight: 1
-                containers:
-                    - env:
-                        - name: BITNAMI_DEBUG
-                          value: \"false\"
-                        - name: POSTGRESQL_PORT_NUMBER
-                          value: \"5432\"
-                        - name: POSTGRESQL_VOLUME_DIR
-                          value: /bitnami/postgresql
-                        - name: PGDATA
-                          value: /bitnami/postgresql/data
-                        - name: POSTGRES_USER
-                          value: kong
-                        - name: POSTGRES_POSTGRES_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: postgres-password
-                                name: chartsnap-postgresql
-                        - name: POSTGRES_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: POSTGRES_DB
-                          value: kong
-                        - name: POSTGRESQL_ENABLE_LDAP
-                          value: \"no\"
-                        - name: POSTGRESQL_ENABLE_TLS
-                          value: \"no\"
-                        - name: POSTGRESQL_LOG_HOSTNAME
-                          value: \"false\"
-                        - name: POSTGRESQL_LOG_CONNECTIONS
-                          value: \"false\"
-                        - name: POSTGRESQL_LOG_DISCONNECTIONS
-                          value: \"false\"
-                        - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
-                          value: \"off\"
-                        - name: POSTGRESQL_CLIENT_MIN_MESSAGES
-                          value: error
-                        - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
-                          value: pgaudit
-                      image: docker.io/bitnami/postgresql:13.11.0-debian-11-r20
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        exec:
-                            command:
-                                - /bin/sh
-                                - -c
-                                - exec pg_isready -U \"kong\" -d \"dbname=kong\" -h 127.0.0.1 -p 5432
-                        failureThreshold: 6
-                        initialDelaySeconds: 30
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: postgresql
-                      ports:
-                        - containerPort: 5432
-                          name: tcp-postgresql
-                      readinessProbe:
-                        exec:
-                            command:
-                                - /bin/sh
-                                - -c
-                                - -e
-                                - |
-                                  exec pg_isready -U \"kong\" -d \"dbname=kong\" -h 127.0.0.1 -p 5432
-                                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
-                        failureThreshold: 6
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources:
-                        limits: {}
-                        requests:
-                            cpu: 250m
-                            memory: 256Mi
-                      securityContext:
-                        runAsUser: 1001
-                      volumeMounts:
-                        - mountPath: /dev/shm
-                          name: dshm
-                        - mountPath: /bitnami/postgresql
-                          name: data
-                hostIPC: false
-                hostNetwork: false
-                initContainers: null
-                securityContext:
-                    fsGroup: 1001
-                serviceAccountName: default
-                volumes:
-                    - emptyDir:
-                        medium: Memory
-                      name: dshm
-        updateStrategy:
-            rollingUpdate: {}
-            type: RollingUpdate
-        volumeClaimTemplates:
-            - metadata:
-                name: data
-              spec:
-                accessModes:
-                    - ReadWriteOnce
-                resources:
-                    requests:
-                        storage: 8Gi
-- object:
-    apiVersion: batch/v1
-    kind: Job
+                namespaces:
+                  - default
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+      containers:
+        - env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: /bitnami/postgresql
+            - name: PGDATA
+              value: /bitnami/postgresql/data
+            - name: POSTGRES_USER
+              value: kong
+            - name: POSTGRES_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: postgres-password
+                  name: chartsnap-postgresql
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: POSTGRES_DB
+              value: kong
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: error
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: pgaudit
+          image: docker.io/bitnami/postgresql:13.11.0-debian-11-r20
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "kong" -d "dbname=kong" -h 127.0.0.1 -p 5432
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: postgresql
+          ports:
+            - containerPort: 5432
+              name: tcp-postgresql
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "kong" -d "dbname=kong" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits: {}
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            runAsUser: 1001
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /bitnami/postgresql
+              name: data
+      hostIPC: false
+      hostNetwork: false
+      initContainers: null
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      volumes:
+        - emptyDir:
+            medium: Memory
+          name: dshm
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 8Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    app.kubernetes.io/component: init-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-init-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
     metadata:
-        annotations:
-            argocd.argoproj.io/hook: Sync
-            argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-        labels:
-            app.kubernetes.io/component: init-migrations
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-init-migrations
-        namespace: default
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: init-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+      name: kong-init-migrations
     spec:
-        backoffLimit: null
-        template:
-            metadata:
-                annotations:
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    sidecar.istio.io/inject: \"false\"
-                labels:
-                    app.kubernetes.io/component: init-migrations
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                name: kong-init-migrations
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args:
-                        - kong
-                        - migrations
-                        - bootstrap
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: kong-migrations
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - /bin/sh
-                        - -c
-                        - \"true\"
-                      image: bash:latest
-                      name: bash
-                      resources:
-                        limits:
-                            cpu: 100m
-                            memory: 64Mi
-                        requests:
-                            cpu: 100m
-                            memory: 64Mi
-                    - command:
-                        - bash
-                        - /wait_postgres/wait.sh
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: wait-for-postgres
-                      resources: {}
-                      volumeMounts:
-                        - mountPath: /wait_postgres
-                          name: chartsnap-kong-bash-wait-for-postgres
-                restartPolicy: OnFailure
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        defaultMode: 493
-                        name: chartsnap-kong-bash-wait-for-postgres
-                      name: chartsnap-kong-bash-wait-for-postgres
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-        annotations:
-            helm.sh/hook: post-upgrade
-            helm.sh/hook-delete-policy: before-hook-creation
-        labels:
-            app.kubernetes.io/component: post-upgrade-migrations
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-post-upgrade-migrations
-        namespace: default
-    spec:
-        backoffLimit: null
-        template:
-            metadata:
-                annotations:
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    sidecar.istio.io/inject: \"false\"
-                labels:
-                    app.kubernetes.io/component: post-upgrade-migrations
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                name: kong-post-upgrade-migrations
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args:
-                        - kong
-                        - migrations
-                        - finish
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: kong-post-upgrade-migrations
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - /bin/sh
-                        - -c
-                        - \"true\"
-                      image: bash:latest
-                      name: bash
-                      resources:
-                        limits:
-                            cpu: 100m
-                            memory: 64Mi
-                        requests:
-                            cpu: 100m
-                            memory: 64Mi
-                    - command:
-                        - bash
-                        - /wait_postgres/wait.sh
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: wait-for-postgres
-                      resources: {}
-                      volumeMounts:
-                        - mountPath: /wait_postgres
-                          name: chartsnap-kong-bash-wait-for-postgres
-                restartPolicy: OnFailure
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        defaultMode: 493
-                        name: chartsnap-kong-bash-wait-for-postgres
-                      name: chartsnap-kong-bash-wait-for-postgres
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-        annotations:
-            argocd.argoproj.io/hook: Sync
-            argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-            helm.sh/hook: pre-upgrade
-            helm.sh/hook-delete-policy: before-hook-creation
-        labels:
-            app.kubernetes.io/component: pre-upgrade-migrations
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-pre-upgrade-migrations
-        namespace: default
-    spec:
-        backoffLimit: null
-        template:
-            metadata:
-                annotations:
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    sidecar.istio.io/inject: \"false\"
-                labels:
-                    app.kubernetes.io/component: pre-upgrade-migrations
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                name: kong-pre-upgrade-migrations
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args:
-                        - kong
-                        - migrations
-                        - up
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: kong-upgrade-migrations
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - /bin/sh
-                        - -c
-                        - \"true\"
-                      image: bash:latest
-                      name: bash
-                      resources:
-                        limits:
-                            cpu: 100m
-                            memory: 64Mi
-                        requests:
-                            cpu: 100m
-                            memory: 64Mi
-                    - command:
-                        - bash
-                        - /wait_postgres/wait.sh
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      envFrom:
-                        - configMapRef:
-                            name: env-config
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: wait-for-postgres
-                      resources: {}
-                      volumeMounts:
-                        - mountPath: /wait_postgres
-                          name: chartsnap-kong-bash-wait-for-postgres
-                restartPolicy: OnFailure
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        defaultMode: 493
-                        name: chartsnap-kong-bash-wait-for-postgres
-                      name: chartsnap-kong-bash-wait-for-postgres
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        rules:
-            - host: proxy.kong.example
-              http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /
-                      pathType: ImplementationSpecific
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - bootstrap
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: kong-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - "true"
+          image: bash:latest
+          name: bash
           resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-default
-        namespace: default
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-default
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong-default
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        wait.sh: |
-            until timeout 2 bash -c \"9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}\"
-              do echo \"waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}\"
-              sleep 2
-            done
-    kind: ConfigMap
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-bash-wait-for-postgres
-        namespace: default
-- object:
-    apiVersion: v1
-    data:
-        test-env: test
-    kind: ConfigMap
-    metadata:
-        name: env-config
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        password: a29uZw==
-        postgres-password: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: postgresql
-            helm.sh/chart: postgresql-11.9.13
-        name: chartsnap-postgresql
-        namespace: default
-    type: Opaque
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
-              protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
-              protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
-              protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
-              protocol: TCP
-              targetPort: 8443
-            - name: stream-9000
-              port: 9000
-              protocol: TCP
-              targetPort: 9000
-            - name: stream-9001
-              port: 9001
-              protocol: TCP
-              targetPort: 9001
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  rules:
+    - host: proxy.kong.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: ImplementationSpecific
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: Service
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None
+    timeoutSeconds: 5
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/component: post-upgrade-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-post-upgrade-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
     metadata:
-        annotations: null
-        labels:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: postgresql
-            helm.sh/chart: postgresql-11.9.13
-        name: chartsnap-postgresql
-        namespace: default
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: post-upgrade-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+      name: kong-post-upgrade-migrations
     spec:
-        ports:
-            - name: tcp-postgresql
-              nodePort: null
-              port: 5432
-              targetPort: tcp-postgresql
-        selector:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: postgresql
-        sessionAffinity: None
-        type: ClusterIP
-- object:
-    apiVersion: v1
-    kind: Service
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - finish
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: kong-post-upgrade-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - "true"
+          image: bash:latest
+          name: bash
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/component: pre-upgrade-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-pre-upgrade-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: postgresql
-            helm.sh/chart: postgresql-11.9.13
-            service.alpha.kubernetes.io/tolerate-unready-endpoints: \"true\"
-        name: chartsnap-postgresql-hl
-        namespace: default
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: pre-upgrade-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+      name: kong-pre-upgrade-migrations
     spec:
-        clusterIP: None
-        ports:
-            - name: tcp-postgresql
-              port: 5432
-              targetPort: tcp-postgresql
-        publishNotReadyAddresses: true
-        selector:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: postgresql
-        type: ClusterIP
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - up
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: kong-upgrade-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - /bin/sh
+            - -c
+            - "true"
+          image: bash:latest
+          name: bash
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          envFrom:
+            - configMapRef:
+                name: env-config
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -1,369 +1,365 @@
-[test3-values]
-SnapShot = """
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  kong.yml: |
+    _format_version: "1.1"
+    services:
+      - name: example.com
+        url: http://example.com
+        routes:
+        - name: example
+          paths:
+          - "/example"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-custom-dbless-config
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        checksum/dbless.config: 95c0309e6b27de23d64edae3a3602472635243f133fba88af3034ed4d5703d4a
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    checksum/dbless.config: 95c0309e6b27de23d64edae3a3602472635243f133fba88af3034ed4d5703d4a
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_DECLARATIVE_CONFIG
-                          value: /kong_dbless/kong.yml
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                        - mountPath: /kong_dbless/
-                          name: kong-custom-dbless-config-volume
-                        - mountPath: /opt/tmp
-                          name: tmpdir
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_DECLARATIVE_CONFIG
-                          value: /kong_dbless/kong.yml
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                        - mountPath: /kong_dbless/
-                          name: kong-custom-dbless-config-volume
-                    - command:
-                        - /bin/sh
-                        - -c
-                        - \"true\"
-                      image: bash:latest
-                      name: bash
-                      resources:
-                        limits:
-                            cpu: 100m
-                            memory: 64Mi
-                        requests:
-                            cpu: 100m
-                            memory: 64Mi
-                      volumeMounts:
-                        - mountPath: /opt/tmp
-                          name: tmpdir
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        name: chartsnap-kong-custom-dbless-config
-                      name: kong-custom-dbless-config-volume
-                    - emptyDir: {}
-                      name: tmpdir
-- object:
-    apiVersion: v1
-    data:
-        kong.yml: |
-            _format_version: \"1.1\"
-            services:
-              - name: example.com
-                url: http://example.com
-                routes:
-                - name: example
-                  paths:
-                  - \"/example\"
-    kind: ConfigMap
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-custom-dbless-config
-        namespace: default
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /kong_dbless/kong.yml
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 8443
+              name: proxy-tls
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 8100
+              name: status
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
-              protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+            - mountPath: /kong_dbless/
+              name: kong-custom-dbless-config-volume
+            - mountPath: /opt/tmp
+              name: tmpdir
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /kong_dbless/kong.yml
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+            - mountPath: /kong_dbless/
+              name: kong-custom-dbless-config-volume
+        - command:
+            - /bin/sh
+            - -c
+            - "true"
+          image: bash:latest
+          name: bash
+          resources:
+            limits:
+              cpu: 100m
+              memory: 64Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - mountPath: /opt/tmp
+              name: tmpdir
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            name: chartsnap-kong-custom-dbless-config
+          name: kong-custom-dbless-config-volume
+        - emptyDir: {}
+          name: tmpdir

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -1,386 +1,382 @@
-[test4-values]
-SnapShot = """
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  kong.yml: |
+    _format_version: "1.1"
+    services:
+      - name: example.com
+        url: http://example.com
+        routes:
+        - name: example
+          paths:
+          - "/example"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-custom-dbless-config
+  namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+    - name: stream-9000
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+    - name: stream-9001
+      port: 9001
+      protocol: TCP
+      targetPort: 9001
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        checksum/dbless.config: 95c0309e6b27de23d64edae3a3602472635243f133fba88af3034ed4d5703d4a
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        template:
-            metadata:
-                annotations:
-                    checksum/dbless.config: 95c0309e6b27de23d64edae3a3602472635243f133fba88af3034ed4d5703d4a
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_DECLARATIVE_CONFIG
-                          value: /kong_dbless/kong.yml
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 9000
-                          name: stream-9000
-                          protocol: TCP
-                        - containerPort: 9001
-                          name: stream-9001
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                        - mountPath: /kong_dbless/
-                          name: kong-custom-dbless-config-volume
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: \"off\"
-                        - name: KONG_DECLARATIVE_CONFIG
-                          value: /kong_dbless/kong.yml
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                        - mountPath: /kong_dbless/
-                          name: kong-custom-dbless-config-volume
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        name: chartsnap-kong-custom-dbless-config
-                      name: kong-custom-dbless-config-volume
-- object:
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        rules:
-            - http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /
-                      pathType: ImplementationSpecific
-- object:
-    apiVersion: v1
-    data:
-        kong.yml: |
-            _format_version: \"1.1\"
-            services:
-              - name: example.com
-                url: http://example.com
-                routes:
-                - name: example
-                  paths:
-                  - \"/example\"
-    kind: ConfigMap
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-custom-dbless-config
-        namespace: default
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /kong_dbless/kong.yml
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
               protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
+            - containerPort: 8443
+              name: proxy-tls
               protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
+            - containerPort: 9000
+              name: stream-9000
               protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
+            - containerPort: 9001
+              name: stream-9001
               protocol: TCP
-              targetPort: 8443
-            - name: stream-9000
-              port: 9000
+            - containerPort: 8100
+              name: status
               protocol: TCP
-              targetPort: 9000
-            - name: stream-9001
-              port: 9001
-              protocol: TCP
-              targetPort: 9001
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+            - mountPath: /kong_dbless/
+              name: kong-custom-dbless-config-volume
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: "off"
+            - name: KONG_DECLARATIVE_CONFIG
+              value: /kong_dbless/kong.yml
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: 0.0.0.0:9000, [::]:9000, 0.0.0.0:9001 ssl, [::]:9001 ssl
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+            - mountPath: /kong_dbless/
+              name: kong-custom-dbless-config-volume
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            name: chartsnap-kong-custom-dbless-config
+          name: kong-custom-dbless-config-volume
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: ImplementationSpecific

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -1,2015 +1,2011 @@
-[test5-values]
-SnapShot = """
-- object:
-    apiVersion: admissionregistration.k8s.io/v1
-    kind: ValidatingWebhookConfiguration
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+---
+apiVersion: v1
+data:
+  password: a29uZw==
+  postgres-password: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+type: Opaque
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  wait.sh: |
+    until timeout 2 bash -c "9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}"
+      do echo "waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}"
+      sleep 2
+    done
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-bash-wait-for-postgres
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongupstreampolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumergroups/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongconsumers/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - tcpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - udpingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongvaults/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongclusterplugins/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resourceNames:
+      - kong-ingress-controller-leader-kong-kong
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+  - kind: ServiceAccount
+    name: chartsnap-kong
+    namespace: default
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  name: chartsnap-postgresql-hl
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: postgresql
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+spec:
+  ports:
+    - name: tcp-postgresql
+      nodePort: null
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: postgresql
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
+  namespace: default
+spec:
+  ports:
+    - name: kong-manager
+      port: 8002
+      protocol: TCP
+      targetPort: 8002
+    - name: kong-manager-tls
+      port: 8445
+      protocol: TCP
+      targetPort: 8445
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: NodePort
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    enable-metrics: "true"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  ports:
+    - name: kong-proxy
+      port: 80
+      protocol: TCP
+      targetPort: 8000
+    - name: kong-proxy-tls
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: kong
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: kong
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validations
-        namespace: default
-    webhooks:
-        - admissionReviewVersions:
-            - v1beta1
-          clientConfig:
-            caBundle: '###DYNAMIC_FIELD###'
-            service:
-                name: chartsnap-kong-validation-webhook
-                namespace: default
-          failurePolicy: Ignore
-          name: validations.kong.konghq.com
-          objectSelector:
-            matchExpressions:
-                - key: owner
-                  operator: NotIn
-                  values:
-                    - helm
-          rules:
-            - apiGroups:
-                - configuration.konghq.com
-              apiVersions:
-                - '*'
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - kongconsumers
-                - kongplugins
-                - kongclusterplugins
-                - kongingresses
-            - apiGroups:
-                - \"\"
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - secrets
-                - services
-            - apiGroups:
-                - networking.k8s.io
-              apiVersions:
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - ingresses
-            - apiGroups:
-                - gateway.networking.k8s.io
-              apiVersions:
-                - v1alpha2
-                - v1beta1
-                - v1
-              operations:
-                - CREATE
-                - UPDATE
-              resources:
-                - gateways
-                - httproutes
-          sideEffects: None
-- object:
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-        labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-kong
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+        version: "3.6"
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: app
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: kong
-        strategy:
-            rollingUpdate:
-                maxSurge: 1
-                maxUnavailable: 0
-            type: RollingUpdate
-        template:
-            metadata:
-                annotations:
-                    kuma.io/gateway: enabled
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    traffic.sidecar.istio.io/includeInboundPorts: \"\"
-                labels:
-                    app: chartsnap-kong
-                    app.kubernetes.io/component: app
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                    version: \"3.6\"
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args: null
-                      env:
-                        - name: POD_NAME
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.name
-                        - name: POD_NAMESPACE
-                          valueFrom:
-                            fieldRef:
-                                apiVersion: v1
-                                fieldPath: metadata.namespace
-                        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
-                          value: 0.0.0.0:8080
-                        - name: CONTROLLER_ANONYMOUS_REPORTS
-                          value: \"false\"
-                        - name: CONTROLLER_ELECTION_ID
-                          value: kong-ingress-controller-leader-kong
-                        - name: CONTROLLER_INGRESS_CLASS
-                          value: kong
-                        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
-                          value: \"true\"
-                        - name: CONTROLLER_KONG_ADMIN_URL
-                          value: https://localhost:8444
-                        - name: CONTROLLER_PUBLISH_SERVICE
-                          value: default/chartsnap-kong-proxy
-                      image: kong/kubernetes-ingress-controller:3.1
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /healthz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: ingress-controller
-                      ports:
-                        - containerPort: 8080
-                          name: webhook
-                          protocol: TCP
-                        - containerPort: 10255
-                          name: cmetrics
-                          protocol: TCP
-                        - containerPort: 10254
-                          name: cstatus
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /readyz
-                            port: 10254
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /admission-webhook
-                          name: webhook-cert
-                          readOnly: true
-                        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-                          name: chartsnap-kong-token
-                          readOnly: true
-                    - env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      lifecycle:
-                        preStop:
-                            exec:
-                                command:
-                                    - kong
-                                    - quit
-                                    - --wait=15
-                      livenessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: proxy
-                      ports:
-                        - containerPort: 8000
-                          name: proxy
-                          protocol: TCP
-                        - containerPort: 8443
-                          name: proxy-tls
-                          protocol: TCP
-                        - containerPort: 8100
-                          name: status
-                          protocol: TCP
-                      readinessProbe:
-                        failureThreshold: 3
-                        httpGet:
-                            path: /status/ready
-                            port: status
-                            scheme: HTTP
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - rm
-                        - -vrf
-                        - $KONG_PREFIX/pids
-                      env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: clear-stale-pid
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                    - args:
-                        - /bin/bash
-                        - -c
-                        - export KONG_NGINX_DAEMON=on KONG_PREFIX=`mktemp -d` KONG_KEYRING_ENABLED=off; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop
-                      env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: wait-for-db
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                terminationGracePeriodSeconds: 30
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        defaultMode: 493
-                        name: chartsnap-kong-bash-wait-for-postgres
-                      name: chartsnap-kong-bash-wait-for-postgres
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: apps/v1
-    kind: StatefulSet
+      automountServiceAccountToken: false
+      containers:
+        - args: null
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+              value: 0.0.0.0:8080
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
+            - name: CONTROLLER_ELECTION_ID
+              value: kong-ingress-controller-leader-kong
+            - name: CONTROLLER_INGRESS_CLASS
+              value: kong
+            - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+              value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
+            - name: CONTROLLER_PUBLISH_SERVICE
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: ingress-controller
+          ports:
+            - containerPort: 8080
+              name: webhook
+              protocol: TCP
+            - containerPort: 10255
+              name: cmetrics
+              protocol: TCP
+            - containerPort: 10254
+              name: cstatus
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /admission-webhook
+              name: webhook-cert
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: chartsnap-kong-token
+              readOnly: true
+        - env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - kong
+                  - quit
+                  - --wait=15
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: proxy
+          ports:
+            - containerPort: 8000
+              name: proxy
+              protocol: TCP
+            - containerPort: 8443
+              name: proxy-tls
+              protocol: TCP
+            - containerPort: 8100
+              name: status
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status/ready
+              port: status
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - rm
+            - -vrf
+            - $KONG_PREFIX/pids
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: clear-stale-pid
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+        - args:
+            - /bin/bash
+            - -c
+            - export KONG_NGINX_DAEMON=on KONG_PREFIX=`mktemp -d` KONG_KEYRING_ENABLED=off; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: wait-for-db
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: primary
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: postgresql
+  serviceName: chartsnap-postgresql-hl
+  template:
     metadata:
-        annotations: null
-        labels:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: postgresql
-            helm.sh/chart: postgresql-11.9.13
-        name: chartsnap-postgresql
-        namespace: default
+      annotations: null
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+        helm.sh/chart: postgresql-11.9.13
+      name: chartsnap-postgresql
     spec:
-        replicas: 1
-        selector:
-            matchLabels:
-                app.kubernetes.io/component: primary
-                app.kubernetes.io/instance: chartsnap
-                app.kubernetes.io/name: postgresql
-        serviceName: chartsnap-postgresql-hl
-        template:
-            metadata:
-                annotations: null
-                labels:
+      affinity:
+        nodeAffinity: null
+        podAffinity: null
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
                     app.kubernetes.io/component: primary
                     app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
                     app.kubernetes.io/name: postgresql
-                    helm.sh/chart: postgresql-11.9.13
-                name: chartsnap-postgresql
-            spec:
-                affinity:
-                    nodeAffinity: null
-                    podAffinity: null
-                    podAntiAffinity:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                            - podAffinityTerm:
-                                labelSelector:
-                                    matchLabels:
-                                        app.kubernetes.io/component: primary
-                                        app.kubernetes.io/instance: chartsnap
-                                        app.kubernetes.io/name: postgresql
-                                namespaces:
-                                    - default
-                                topologyKey: kubernetes.io/hostname
-                              weight: 1
-                containers:
-                    - env:
-                        - name: BITNAMI_DEBUG
-                          value: \"false\"
-                        - name: POSTGRESQL_PORT_NUMBER
-                          value: \"5432\"
-                        - name: POSTGRESQL_VOLUME_DIR
-                          value: /bitnami/postgresql
-                        - name: PGDATA
-                          value: /bitnami/postgresql/data
-                        - name: POSTGRES_USER
-                          value: kong
-                        - name: POSTGRES_POSTGRES_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: postgres-password
-                                name: chartsnap-postgresql
-                        - name: POSTGRES_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: POSTGRES_DB
-                          value: kong
-                        - name: POSTGRESQL_ENABLE_LDAP
-                          value: \"no\"
-                        - name: POSTGRESQL_ENABLE_TLS
-                          value: \"no\"
-                        - name: POSTGRESQL_LOG_HOSTNAME
-                          value: \"false\"
-                        - name: POSTGRESQL_LOG_CONNECTIONS
-                          value: \"false\"
-                        - name: POSTGRESQL_LOG_DISCONNECTIONS
-                          value: \"false\"
-                        - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
-                          value: \"off\"
-                        - name: POSTGRESQL_CLIENT_MIN_MESSAGES
-                          value: error
-                        - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
-                          value: pgaudit
-                      image: docker.io/bitnami/postgresql:13.11.0-debian-11-r20
-                      imagePullPolicy: IfNotPresent
-                      livenessProbe:
-                        exec:
-                            command:
-                                - /bin/sh
-                                - -c
-                                - exec pg_isready -U \"kong\" -d \"dbname=kong\" -h 127.0.0.1 -p 5432
-                        failureThreshold: 6
-                        initialDelaySeconds: 30
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      name: postgresql
-                      ports:
-                        - containerPort: 5432
-                          name: tcp-postgresql
-                      readinessProbe:
-                        exec:
-                            command:
-                                - /bin/sh
-                                - -c
-                                - -e
-                                - |
-                                  exec pg_isready -U \"kong\" -d \"dbname=kong\" -h 127.0.0.1 -p 5432
-                                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
-                        failureThreshold: 6
-                        initialDelaySeconds: 5
-                        periodSeconds: 10
-                        successThreshold: 1
-                        timeoutSeconds: 5
-                      resources:
-                        limits: {}
-                        requests:
-                            cpu: 250m
-                            memory: 256Mi
-                      securityContext:
-                        runAsUser: 1001
-                      volumeMounts:
-                        - mountPath: /dev/shm
-                          name: dshm
-                        - mountPath: /bitnami/postgresql
-                          name: data
-                hostIPC: false
-                hostNetwork: false
-                initContainers: null
-                securityContext:
-                    fsGroup: 1001
-                serviceAccountName: default
-                volumes:
-                    - emptyDir:
-                        medium: Memory
-                      name: dshm
-        updateStrategy:
-            rollingUpdate: {}
-            type: RollingUpdate
-        volumeClaimTemplates:
-            - metadata:
-                name: data
-              spec:
-                accessModes:
-                    - ReadWriteOnce
-                resources:
-                    requests:
-                        storage: 8Gi
-- object:
-    apiVersion: batch/v1
-    kind: Job
+                namespaces:
+                  - default
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+      containers:
+        - env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: /bitnami/postgresql
+            - name: PGDATA
+              value: /bitnami/postgresql/data
+            - name: POSTGRES_USER
+              value: kong
+            - name: POSTGRES_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: postgres-password
+                  name: chartsnap-postgresql
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: POSTGRES_DB
+              value: kong
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: error
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: pgaudit
+          image: docker.io/bitnami/postgresql:13.11.0-debian-11-r20
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "kong" -d "dbname=kong" -h 127.0.0.1 -p 5432
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: postgresql
+          ports:
+            - containerPort: 5432
+              name: tcp-postgresql
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "kong" -d "dbname=kong" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits: {}
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            runAsUser: 1001
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /bitnami/postgresql
+              name: data
+      hostIPC: false
+      hostNetwork: false
+      initContainers: null
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      volumes:
+        - emptyDir:
+            medium: Memory
+          name: dshm
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 8Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    app.kubernetes.io/component: init-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-init-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
     metadata:
-        annotations:
-            argocd.argoproj.io/hook: Sync
-            argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-        labels:
-            app.kubernetes.io/component: init-migrations
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-init-migrations
-        namespace: default
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: init-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+      name: kong-init-migrations
     spec:
-        backoffLimit: null
-        template:
-            metadata:
-                annotations:
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    sidecar.istio.io/inject: \"false\"
-                labels:
-                    app.kubernetes.io/component: init-migrations
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                name: kong-init-migrations
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args:
-                        - kong
-                        - migrations
-                        - bootstrap
-                      env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: kong-migrations
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - bash
-                        - /wait_postgres/wait.sh
-                      env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: wait-for-postgres
-                      resources: {}
-                      volumeMounts:
-                        - mountPath: /wait_postgres
-                          name: chartsnap-kong-bash-wait-for-postgres
-                restartPolicy: OnFailure
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        defaultMode: 493
-                        name: chartsnap-kong-bash-wait-for-postgres
-                      name: chartsnap-kong-bash-wait-for-postgres
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-        annotations:
-            helm.sh/hook: post-upgrade
-            helm.sh/hook-delete-policy: before-hook-creation
-        labels:
-            app.kubernetes.io/component: post-upgrade-migrations
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-post-upgrade-migrations
-        namespace: default
-    spec:
-        backoffLimit: null
-        template:
-            metadata:
-                annotations:
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    sidecar.istio.io/inject: \"false\"
-                labels:
-                    app.kubernetes.io/component: post-upgrade-migrations
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                name: kong-post-upgrade-migrations
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args:
-                        - kong
-                        - migrations
-                        - finish
-                      env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: kong-post-upgrade-migrations
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - bash
-                        - /wait_postgres/wait.sh
-                      env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: wait-for-postgres
-                      resources: {}
-                      volumeMounts:
-                        - mountPath: /wait_postgres
-                          name: chartsnap-kong-bash-wait-for-postgres
-                restartPolicy: OnFailure
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        defaultMode: 493
-                        name: chartsnap-kong-bash-wait-for-postgres
-                      name: chartsnap-kong-bash-wait-for-postgres
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: batch/v1
-    kind: Job
-    metadata:
-        annotations:
-            argocd.argoproj.io/hook: Sync
-            argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-            helm.sh/hook: pre-upgrade
-            helm.sh/hook-delete-policy: before-hook-creation
-        labels:
-            app.kubernetes.io/component: pre-upgrade-migrations
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-pre-upgrade-migrations
-        namespace: default
-    spec:
-        backoffLimit: null
-        template:
-            metadata:
-                annotations:
-                    kuma.io/service-account-token-volume: chartsnap-kong-token
-                    sidecar.istio.io/inject: \"false\"
-                labels:
-                    app.kubernetes.io/component: pre-upgrade-migrations
-                    app.kubernetes.io/instance: chartsnap
-                    app.kubernetes.io/managed-by: Helm
-                    app.kubernetes.io/name: kong
-                    app.kubernetes.io/version: \"3.6\"
-                    helm.sh/chart: kong-2.38.0
-                name: kong-pre-upgrade-migrations
-            spec:
-                automountServiceAccountToken: false
-                containers:
-                    - args:
-                        - kong
-                        - migrations
-                        - up
-                      env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: kong-upgrade-migrations
-                      resources: {}
-                      securityContext:
-                        allowPrivilegeEscalation: false
-                        capabilities:
-                            drop:
-                                - ALL
-                        readOnlyRootFilesystem: true
-                        runAsNonRoot: true
-                        runAsUser: 1000
-                        seccompProfile:
-                            type: RuntimeDefault
-                      volumeMounts:
-                        - mountPath: /kong_prefix/
-                          name: chartsnap-kong-prefix-dir
-                        - mountPath: /tmp
-                          name: chartsnap-kong-tmp
-                initContainers:
-                    - command:
-                        - bash
-                        - /wait_postgres/wait.sh
-                      env:
-                        - name: CLIENT_ID
-                          value: exampleId
-                        - name: KONG_ADMIN_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_API_URI
-                          value: http://
-                        - name: KONG_ADMIN_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_GUI_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_ADMIN_GUI_API_URL
-                          value: http://
-                        - name: KONG_ADMIN_GUI_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ADMIN_LISTEN
-                          value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
-                        - name: KONG_ANONYMOUS_REPORTS
-                          value: \"off\"
-                        - name: KONG_CLUSTER_LISTEN
-                          value: \"off\"
-                        - name: KONG_DATABASE
-                          value: postgres
-                        - name: KONG_KIC
-                          value: \"on\"
-                        - name: KONG_LUA_PACKAGE_PATH
-                          value: /opt/?.lua;/opt/?/init.lua;;
-                        - name: KONG_NGINX_WORKER_PROCESSES
-                          value: \"2\"
-                        - name: KONG_PG_HOST
-                          value: chartsnap-postgresql
-                        - name: KONG_PG_PASSWORD
-                          valueFrom:
-                            secretKeyRef:
-                                key: password
-                                name: chartsnap-postgresql
-                        - name: KONG_PG_PORT
-                          value: \"5432\"
-                        - name: KONG_PORTAL_API_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PORTAL_API_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PORT_MAPS
-                          value: 80:8000, 443:8443
-                        - name: KONG_PREFIX
-                          value: /kong_prefix/
-                        - name: KONG_PROXY_ACCESS_LOG
-                          value: /dev/stdout
-                        - name: KONG_PROXY_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_PROXY_LISTEN
-                          value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
-                        - name: KONG_PROXY_STREAM_ACCESS_LOG
-                          value: /dev/stdout basic
-                        - name: KONG_PROXY_STREAM_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_ROUTER_FLAVOR
-                          value: traditional
-                        - name: KONG_STATUS_ACCESS_LOG
-                          value: \"off\"
-                        - name: KONG_STATUS_ERROR_LOG
-                          value: /dev/stderr
-                        - name: KONG_STATUS_LISTEN
-                          value: 0.0.0.0:8100, [::]:8100
-                        - name: KONG_STREAM_LISTEN
-                          value: \"off\"
-                        - name: KONG_NGINX_DAEMON
-                          value: \"off\"
-                      image: kong:3.6
-                      imagePullPolicy: IfNotPresent
-                      name: wait-for-postgres
-                      resources: {}
-                      volumeMounts:
-                        - mountPath: /wait_postgres
-                          name: chartsnap-kong-bash-wait-for-postgres
-                restartPolicy: OnFailure
-                securityContext: {}
-                serviceAccountName: chartsnap-kong
-                volumes:
-                    - emptyDir:
-                        sizeLimit: 256Mi
-                      name: chartsnap-kong-prefix-dir
-                    - emptyDir:
-                        sizeLimit: 1Gi
-                      name: chartsnap-kong-tmp
-                    - name: chartsnap-kong-token
-                      projected:
-                        sources:
-                            - serviceAccountToken:
-                                expirationSeconds: 3607
-                                path: token
-                            - configMap:
-                                items:
-                                    - key: ca.crt
-                                      path: ca.crt
-                                name: kube-root-ca.crt
-                            - downwardAPI:
-                                items:
-                                    - fieldRef:
-                                        apiVersion: v1
-                                        fieldPath: metadata.namespace
-                                      path: namespace
-                    - configMap:
-                        defaultMode: 493
-                        name: chartsnap-kong-bash-wait-for-postgres
-                      name: chartsnap-kong-bash-wait-for-postgres
-                    - name: webhook-cert
-                      secret:
-                        secretName: chartsnap-kong-validation-webhook-keypair
-- object:
-    apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        rules:
-            - host: proxy.kong.example
-              http:
-                paths:
-                    - backend:
-                        service:
-                            name: chartsnap-kong-proxy
-                            port:
-                                number: 443
-                      path: /
-                      pathType: ImplementationSpecific
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    rules:
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongupstreampolicies/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumergroups/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - nodes
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - pods
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - secrets
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - ingressclassparameterses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongconsumers/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - tcpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - udpingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - extensions
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingresses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - discovery.k8s.io
-          resources:
-            - endpointslices
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - konglicenses/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongvaults/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins
-          verbs:
-            - get
-            - list
-            - watch
-        - apiGroups:
-            - configuration.konghq.com
-          resources:
-            - kongclusterplugins/status
-          verbs:
-            - get
-            - patch
-            - update
-        - apiGroups:
-            - apiextensions.k8s.io
-          resources:
-            - customresourcedefinitions
-          verbs:
-            - list
-            - watch
-        - apiGroups:
-            - networking.k8s.io
-          resources:
-            - ingressclasses
-          verbs:
-            - get
-            - list
-            - watch
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: ClusterRole
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: Role
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    rules:
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-            - pods
-            - secrets
-            - namespaces
-          verbs:
-            - get
-        - apiGroups:
-            - \"\"
-          resourceNames:
-            - kong-ingress-controller-leader-kong-kong
-          resources:
-            - configmaps
-          verbs:
-            - get
-            - update
-        - apiGroups:
-            - \"\"
-          resources:
-            - configmaps
-          verbs:
-            - create
-        - apiGroups:
-            - \"\"
-            - coordination.k8s.io
-          resources:
-            - configmaps
-            - leases
-          verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-        - apiGroups:
-            - \"\"
-          resources:
-            - events
-          verbs:
-            - create
-            - patch
-        - apiGroups:
-            - \"\"
-          resources:
-            - services
-          verbs:
-            - get
-- object:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: RoleBinding
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-    roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: chartsnap-kong
-    subjects:
-        - kind: ServiceAccount
-          name: chartsnap-kong
-          namespace: default
-- object:
-    apiVersion: v1
-    data:
-        wait.sh: |
-            until timeout 2 bash -c \"9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}\"
-              do echo \"waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}\"
-              sleep 2
-            done
-    kind: ConfigMap
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-bash-wait-for-postgres
-        namespace: default
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-ca-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        tls.crt: '###DYNAMIC_FIELD###'
-        tls.key: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-validation-webhook-keypair
-        namespace: default
-    type: kubernetes.io/tls
-- object:
-    apiVersion: v1
-    data:
-        password: a29uZw==
-        postgres-password: '###DYNAMIC_FIELD###'
-    kind: Secret
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: postgresql
-            helm.sh/chart: postgresql-11.9.13
-        name: chartsnap-postgresql
-        namespace: default
-    type: Opaque
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-manager
-        namespace: default
-    spec:
-        ports:
-            - name: kong-manager
-              port: 8002
-              protocol: TCP
-              targetPort: 8002
-            - name: kong-manager-tls
-              port: 8445
-              protocol: TCP
-              targetPort: 8445
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: NodePort
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            enable-metrics: \"true\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong-proxy
-        namespace: default
-    spec:
-        ports:
-            - name: kong-proxy
-              port: 80
-              protocol: TCP
-              targetPort: 8000
-            - name: kong-proxy-tls
-              port: 443
-              protocol: TCP
-              targetPort: 8443
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: kong
-        type: LoadBalancer
-- object:
-    apiVersion: v1
-    kind: Service
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - bootstrap
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: kong-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
+  namespace: default
+spec:
+  rules:
+    - host: proxy.kong.example
+      http:
+        paths:
+          - backend:
+              service:
+                name: chartsnap-kong-proxy
+                port:
+                  number: 443
+            path: /
+            pathType: ImplementationSpecific
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
+  namespace: default
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
         name: chartsnap-kong-validation-webhook
         namespace: default
-    spec:
-        ports:
-            - name: webhook
-              port: 443
-              protocol: TCP
-              targetPort: webhook
-        selector:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-- object:
-    apiVersion: v1
-    kind: Service
+    failurePolicy: Ignore
+    name: validations.kong.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - configuration.konghq.com
+        apiVersions:
+          - '*'
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kongconsumers
+          - kongplugins
+          - kongclusterplugins
+          - kongingresses
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+          - services
+      - apiGroups:
+          - networking.k8s.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+      - apiGroups:
+          - gateway.networking.k8s.io
+        apiVersions:
+          - v1alpha2
+          - v1beta1
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - gateways
+          - httproutes
+    sideEffects: None
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/component: post-upgrade-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-post-upgrade-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
     metadata:
-        annotations: null
-        labels:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: postgresql
-            helm.sh/chart: postgresql-11.9.13
-        name: chartsnap-postgresql
-        namespace: default
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: post-upgrade-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+      name: kong-post-upgrade-migrations
     spec:
-        ports:
-            - name: tcp-postgresql
-              nodePort: null
-              port: 5432
-              targetPort: tcp-postgresql
-        selector:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: postgresql
-        sessionAffinity: None
-        type: ClusterIP
-- object:
-    apiVersion: v1
-    kind: Service
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - finish
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: kong-post-upgrade-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/component: pre-upgrade-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-pre-upgrade-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
     metadata:
-        labels:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: postgresql
-            helm.sh/chart: postgresql-11.9.13
-            service.alpha.kubernetes.io/tolerate-unready-endpoints: \"true\"
-        name: chartsnap-postgresql-hl
-        namespace: default
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: pre-upgrade-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: kong-2.38.0
+      name: kong-pre-upgrade-migrations
     spec:
-        clusterIP: None
-        ports:
-            - name: tcp-postgresql
-              port: 5432
-              targetPort: tcp-postgresql
-        publishNotReadyAddresses: true
-        selector:
-            app.kubernetes.io/component: primary
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/name: postgresql
-        type: ClusterIP
-- object:
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-        labels:
-            app.kubernetes.io/instance: chartsnap
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: kong
-            app.kubernetes.io/version: \"3.6\"
-            helm.sh/chart: kong-2.38.0
-        name: chartsnap-kong
-        namespace: default
-"""
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - up
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: kong-upgrade-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.6
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext: {}
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair


### PR DESCRIPTION
#### What this PR does / why we need it:

Pins version of the chartsnap helm plugin that we use for golden testing to make sure we have reproducible results on CI.

chartsnap v0.3.0 had a breaking change that made the snapshot files use plain YAML instead of TOML (because of that there are many changes to those files in the PR).

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
