### PR TITLE
fix(deploy) Increase container security

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,8 +1,4 @@
 checks:
   exclude:
-    # TODO: exclude no rule
-    # https://github.com/Kong/charts/issues/753
-    - "no-read-only-root-fs"
-    - "run-as-non-root"
     - "unset-cpu-requirements"
     - "unset-memory-requirements"

--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+## Changes
+
+- Set `readOnlyRootFilesystem: true` for kube-rbac-proxy
+  [#1057](https://github.com/Kong/charts/pull/1057)
+
 ## 0.4.9
 
 ## Changes

--- a/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
@@ -798,6 +798,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
           limits:
             cpu: 500m

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -790,6 +790,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
           limits:
             cpu: 500m

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -790,6 +790,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
           limits:
             cpu: 500m

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -792,6 +792,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
           limits:
             cpu: 500m

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -790,6 +790,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
           limits:
             cpu: 500m

--- a/charts/gateway-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -788,6 +788,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
           limits:
             cpu: 500m

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -790,6 +790,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
           limits:
             cpu: 500m

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -792,6 +792,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
           limits:
             cpu: 500m

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -90,6 +90,8 @@ spec:
         - containerPort: 8443
           name: https
           protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
         resources:
 {{ toYaml .Values.kubeRBACProxy.resources | indent 10 }}
 {{- end }}

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Run containers with read-only file system and non-root user to increase container and pod security.
+  **Note**: This change may be incompatible with user sidecar containers. In this case, change the
+  `securityContext` in your values.
+  [#1057](https://github.com/Kong/charts/pull/1057)
+
 ## 2.47.0
 
 ### Changes
@@ -346,7 +355,7 @@
 
 ## 2.26.5
 
-### Fixed 
+### Fixed
 
 * Kuma ServiceAccount Token hints and volumes are also available in migrations
   Pods.
@@ -354,19 +363,19 @@
 
 ## 2.26.4
 
-### Fixed 
+### Fixed
 
-* updated `admin_api_uri` to `admin_gui_api_url` as per [kong documentation](https://docs.konghq.com/gateway/3.4.x/reference/configuration/#admin_api_uri). 
+* updated `admin_api_uri` to `admin_gui_api_url` as per [kong documentation](https://docs.konghq.com/gateway/3.4.x/reference/configuration/#admin_api_uri).
 
 ## 2.26.3
 
-### Fixed 
+### Fixed
 
 * Enabled Service and Ingress in Kong Manager for non enterprise users.
 
 ## 2.26.2
 
-### Fixed 
+### Fixed
 
 * Add missing CRD KongConsumerGroup and extend status subresource for CRDs
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -467,7 +467,7 @@ listens if you do not provide your own. The chart can create
 configure them for you. To use this integration, install cert-manager, create
 an issuer, set `certificates.enabled: true` in values.yaml, and set your issuer
 name in `certificates.issuer` or `certificates.clusterIssuer` depending on the
-issuer type. 
+issuer type.
 
 If you do not have an issuer available, you can install the example [self-signed ClusterIssuer](https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers)
 and set `certificates.clusterIssuer: selfsigned-issuer` for testing. You
@@ -709,7 +709,7 @@ or `ingress` sections, as it is used only for stream listens.
 
 #### Admin Service mTLS
 
-On top of the common parameters listed above, the `admin` service supports parameters for mTLS client verification. 
+On top of the common parameters listed above, the `admin` service supports parameters for mTLS client verification.
 If any of `admin.tls.client.caBundle` or `admin.tls.client.secretName` are set, the admin service will be configured to
 require mTLS client verification. If both are set, `admin.tls.client.caBundle` will take precedence.
 
@@ -910,7 +910,7 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | podSecurityPolicy.spec             | Collection of [PodSecurityPolicy settings](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#what-is-a-pod-security-policy) | |
 | priorityClassName                  | Set pod scheduling priority class for Kong pods                                       | `""`                |
 | secretVolumes                      | Mount given secrets as a volume in Kong container to override default certs and keys. | `[]`                |
-| securityContext                    | Set the securityContext for Kong Pods                                                 | `{}`                |
+| securityContext                    | Set the securityContext for Kong Pods                                                 | See values.yaml     |
 | containerSecurityContext           | Set the securityContext for Containers                                                | See values.yaml     |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | `false`             |
 | serviceMonitor.trustCRDsExist      | Do not check for the Prometheus Operator CRDs, just try to deploy                     | `false`             |
@@ -938,11 +938,11 @@ containerSecurityContext: # run as root to bind to lower ports
   runAsUser: 0
 ```
 
-**Note:** The default `podAnnotations` values disable inbound proxying for Kuma 
-and Istio. This is appropriate when using Kong as a gateway for external 
+**Note:** The default `podAnnotations` values disable inbound proxying for Kuma
+and Istio. This is appropriate when using Kong as a gateway for external
 traffic inbound into the cluster.
 
-If you want to use Kong as an internal proxy within the cluster network, you 
+If you want to use Kong as an internal proxy within the cluster network, you
 should enable inbound the inbound mesh proxies:
 
 ```yaml

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -252,6 +252,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -329,6 +330,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -340,7 +342,9 @@ spec:
               name: chartsnap-kong-tmp
             - mountPath: /kong_dbless/
               name: kong-custom-dbless-config-volume
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -804,6 +804,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -913,6 +914,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -986,6 +988,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -995,7 +998,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -783,6 +783,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -894,6 +895,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -969,6 +971,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -978,7 +981,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -819,6 +819,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -930,6 +931,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1005,6 +1007,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1014,7 +1017,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -806,6 +806,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -917,6 +918,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -992,6 +994,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1001,7 +1004,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
@@ -290,6 +290,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -380,6 +381,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -389,7 +391,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
@@ -295,6 +295,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -390,6 +391,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -399,7 +401,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
@@ -290,6 +290,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -380,6 +381,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -389,7 +391,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -815,6 +815,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -926,6 +927,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1001,6 +1003,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1010,7 +1013,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -815,6 +815,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -926,6 +927,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1001,6 +1003,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1010,7 +1013,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -806,6 +806,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -917,6 +918,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -992,6 +994,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1001,7 +1004,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -824,6 +824,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -935,6 +936,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1010,6 +1012,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1019,7 +1022,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -767,6 +767,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -878,6 +879,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -953,6 +955,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -962,7 +965,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
@@ -769,6 +769,7 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsGroup: 1000
           runAsNonRoot: true
           runAsUser: 1000
           seccompProfile:
@@ -842,6 +843,7 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsGroup: 1000
           runAsNonRoot: true
           runAsUser: 1000
           seccompProfile:
@@ -921,6 +923,7 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsGroup: 1000
           runAsNonRoot: true
           runAsUser: 1000
           seccompProfile:
@@ -1021,7 +1024,9 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         resources: {}
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 30
       volumes:
       - name: chartsnap-kong-prefix-dir

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -808,6 +808,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -919,6 +920,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -994,6 +996,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1003,7 +1006,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -806,6 +806,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -917,6 +918,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -992,6 +994,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1001,7 +1004,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: my-kong-sa
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -806,6 +806,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -917,6 +918,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -992,6 +994,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1001,7 +1004,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -201,6 +201,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -274,6 +275,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -283,7 +285,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -198,6 +198,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -269,6 +270,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -278,7 +280,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -808,6 +808,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -928,6 +929,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1009,6 +1011,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1034,7 +1037,9 @@ spec:
           volumeMounts:
             - mountPath: /tmp/foo
               name: tmpdir
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -949,6 +949,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1082,6 +1083,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1173,6 +1175,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1276,6 +1279,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1285,7 +1289,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:
@@ -1323,7 +1329,8 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  annotations: null
+  annotations:
+    ignore-check.kube-linter.io/no-read-only-root-fs: writable fs is required
   labels:
     app.kubernetes.io/component: primary
     app.kubernetes.io/instance: chartsnap
@@ -1443,7 +1450,14 @@ spec:
               cpu: 250m
               memory: 256Mi
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
             runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
@@ -1454,6 +1468,9 @@ spec:
       initContainers: null
       securityContext:
         fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: default
       volumes:
         - emptyDir:
@@ -1588,6 +1605,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1691,7 +1709,9 @@ spec:
             - mountPath: /wait_postgres
               name: chartsnap-kong-bash-wait-for-postgres
       restartPolicy: OnFailure
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       volumes:
         - emptyDir:
@@ -1998,6 +2018,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -2101,7 +2122,9 @@ spec:
             - mountPath: /wait_postgres
               name: chartsnap-kong-bash-wait-for-postgres
       restartPolicy: OnFailure
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       volumes:
         - emptyDir:
@@ -2253,6 +2276,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -2356,7 +2380,9 @@ spec:
             - mountPath: /wait_postgres
               name: chartsnap-kong-bash-wait-for-postgres
       restartPolicy: OnFailure
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       volumes:
         - emptyDir:

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -226,6 +226,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -305,6 +306,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -332,7 +334,9 @@ spec:
           volumeMounts:
             - mountPath: /opt/tmp
               name: tmpdir
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -240,6 +240,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -317,6 +318,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -328,7 +330,9 @@ spec:
               name: chartsnap-kong-tmp
             - mountPath: /kong_dbless/
               name: kong-custom-dbless-config-volume
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -894,6 +894,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1020,6 +1021,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1110,6 +1112,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1199,6 +1202,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1208,7 +1212,9 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:
@@ -1246,7 +1252,8 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  annotations: null
+  annotations:
+    ignore-check.kube-linter.io/no-read-only-root-fs: writable fs is required
   labels:
     app.kubernetes.io/component: primary
     app.kubernetes.io/instance: chartsnap
@@ -1366,7 +1373,14 @@ spec:
               cpu: 250m
               memory: 256Mi
           securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
             runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm
@@ -1377,6 +1391,9 @@ spec:
       initContainers: null
       securityContext:
         fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: default
       volumes:
         - emptyDir:
@@ -1510,6 +1527,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1599,7 +1617,9 @@ spec:
             - mountPath: /wait_postgres
               name: chartsnap-kong-bash-wait-for-postgres
       restartPolicy: OnFailure
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       volumes:
         - emptyDir:
@@ -1904,6 +1924,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -1993,7 +2014,9 @@ spec:
             - mountPath: /wait_postgres
               name: chartsnap-kong-bash-wait-for-postgres
       restartPolicy: OnFailure
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       volumes:
         - emptyDir:
@@ -2144,6 +2167,7 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
             seccompProfile:
@@ -2233,7 +2257,9 @@ spec:
             - mountPath: /wait_postgres
               name: chartsnap-kong-bash-wait-for-postgres
       restartPolicy: OnFailure
-      securityContext: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: chartsnap-kong
       volumes:
         - emptyDir:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -741,6 +741,21 @@ postgresql:
   service:
     ports:
       postgresql: "5432"
+  primary:
+    annotations:
+      "ignore-check.kube-linter.io/no-read-only-root-fs": "writable fs is required"
+    podSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
 
 # -----------------------------------------------------------------------------
 # Configure cert-manager integration
@@ -985,13 +1000,16 @@ podSecurityPolicy:
 priorityClassName: ""
 
 # securityContext for Kong pods.
-securityContext: {}
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
 # securityContext for containers.
 containerSecurityContext:
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   runAsUser: 1000
+  runAsGroup: 1000
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
Change default values to run containers with read-only file system and non-root user for both kong and postgres deployments.

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes

  - Fixes https://github.com/Kong/charts/issues/753

#### Special notes for your reviewer:

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
