### PR TITLE
kgo: add args and provide current defaults via env

### DIFF
--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.1.5
+version: 0.1.6
 appVersion: "1.2"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/env-and-args-values.yaml
+++ b/charts/gateway-operator/ci/env-and-args-values.yaml
@@ -1,0 +1,6 @@
+env:
+  # gateway controller
+  enable_controller_gateway: false
+
+args:
+  - --zap-log-level=debug

--- a/charts/gateway-operator/ci/env-and-customenv-values.yaml
+++ b/charts/gateway-operator/ci/env-and-customenv-values.yaml
@@ -1,0 +1,6 @@
+env:
+  # gateway controller
+  enable_controller_gateway: false
+
+customEnv:
+  TZ: "Europe/Berlin"

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -28,11 +28,15 @@ spec:
         {{- end }}
     spec:
       containers:
-      - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+      - name: manager
+        {{ with .Values.args -}}
+        args:
+        {{ range $val := . -}}
+        - {{ $val }}
+        {{ end }}
+        {{- end -}}
         env:
-        {{- include "kong.env" . | nindent 8 }}
+        {{- include "kong.env" . | indent 8 }}
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -44,7 +48,6 @@ spec:
             port: 8081
           initialDelaySeconds: 15
           periodSeconds: 20
-        name: manager
         readinessProbe:
           httpGet:
             path: /readyz

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -58,6 +58,8 @@ resources:
     memory: 128Mi
 
 # Use this section to add environment variables to operator's container
+# NOTE: This is mutually exclusive with the args sections.
+# When both an env and a corresponding arg are provided, the arg will take precedence.
 env: {}
   # # gateway controller
   # enable_controller_gateway: true
@@ -78,6 +80,12 @@ env: {}
 # Example as below, uncomment if required and add additional attributes as required.
 # customEnv:
 #   TZ: "Europe/Berlin"
+
+# Use this section to add extra args to the operator's container.
+# NOTE: This is a list of strings, so each arg should be a separate item in the list.
+# NOTE: This is mutually exclusive with the env and customEnv sections.
+# When both an env and a corresponding arg are provided, the arg will take precedence.
+args: []
 
 # Use this section to change the certs-dir emptyDir size
 certsDir:


### PR DESCRIPTION
#### What this PR does / why we need it:

Provide `args` section KGO chart.

This will help users to migrate from pre 1.2 versions which didn't have the ability to use the env vars (implemented in https://github.com/Kong/gateway-operator-archive/pull/1616).

The reason for this is that pre 1.2 had `ControlPlane` and `GatewayConfiguration` in `v1alpha1` and 1.2+ have those CRDs only defined in `v1beta1` which makes it impossible to easily migrate using this chart which didn't provide users a way to disable `Gateway` and `ControlPlane` controllers to prevent errors like these:

```
manager {"level":"error","ts":"2024-04-18T12:33:54Z","msg":"failed to run manager","error":"no matches for kind \"ControlPlane\" in version \"gateway-operator.konghq.com/v1beta1\"","stacktrace":"main.main\n\t/workspace/main.go:17\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:271"}
Stream closed EOF for kong-system/kgo-gateway-operator-controller-manager-7549bd865b-vvzkt (manager)
```

Using the `args` provided in this PR users will be able to disable the controllers that require manual upgrade path (`ControlPlane` and `Gateway`), migrate to a newer KGO version, install new CRDs, and if they'd like enable those disabled controllers.
