### PR TITLE
chore: update dep versions used in CI

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Specify this here because these tests rely on ktf to run kind for cluster creation.
-      KIND_VERSION: v0.20.0
+      KIND_VERSION: v0.22.0
     strategy:
       matrix:
         chart-name:
@@ -65,7 +65,7 @@ jobs:
         uses: helm/chart-testing-action@v2.6.1
 
       - name: Run chart-testing (lint)
-        run: ct lint --check-version-increment=false
+        run: ct lint --target-branch main --check-version-increment=false
 
       - name: setup testing environment (kind-cluster)
         env:
@@ -74,23 +74,25 @@ jobs:
         run: ./scripts/test-env.sh
 
       - name: Run chart-testing (install)
-        run: ct install --charts charts/${{ matrix.chart-name}}
+        run: ct install --target-branch main --charts charts/${{ matrix.chart-name}}
 
   integration-test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
       # Specify this here because these tests rely on ktf to run kind for cluster creation.
-      KIND_VERSION: v0.20.0
-      GATEWAY_API_VERSION: v0.8.1
+      KIND_VERSION: v0.22.0
+      GATEWAY_API_VERSION: v1.0.0
     strategy:
       matrix:
         kubernetes-version:
-          - "1.23.13"
-          - "1.24.7"
-          - "1.25.9"
-          - "1.26.4"
-          - "1.27.1"
+          - "1.23.17"
+          - "1.24.17"
+          - "1.25.16"
+          - "1.26.13"
+          - "1.27.11"
+          - "1.28.7"
+          - "1.29.2"
         chart-name:
           - kong
           - ingress
@@ -98,8 +100,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup helm
         uses: azure/setup-helm@v4.2.0
@@ -143,8 +143,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: setup helm
         uses: azure/setup-helm@v4.2.0

--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -38,7 +38,7 @@ jobs:
           helm repo add kong https://charts.konghq.com
 
       - name: Run chart-testing (lint)
-        run: ct lint --charts ${{ matrix.chart-name }}
+        run: ct lint --target-branch main --charts ${{ matrix.chart-name }}
         working-directory: charts
 
       - name: setup testing environment (kind-cluster)
@@ -47,7 +47,7 @@ jobs:
         run: ./scripts/test-env.sh
 
       - name: run chart-testing (install)
-        run: ct install --charts ${{ matrix.chart-name }}
+        run: ct install --target-branch main --charts ${{ matrix.chart-name }}
         working-directory: charts
         if: matrix.chart-name == 'kong'
 
@@ -65,9 +65,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Fetch history
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -30,9 +30,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}/.."
-KIND_VERSION="${KIND_VERSION:-v0.19.0}"
-KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.27.1}"
-GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v0.8.1}"
+KIND_VERSION="${KIND_VERSION:-v0.22.0}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.29.2}"
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.0.0}"
 CHART_NAME="${CHART_NAME:-ingress}"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"


### PR DESCRIPTION
#### What this PR does / why we need it:

- Update dep versions used in CI
  - kind
  - k8s
 
- Do not check out with `fetch-depth` where not necessary to make CI checkout faster.

- Use `main` target branch in `ct install` and `ct lint` calls so that we no longer rely on branch that synced in https://github.com/Kong/charts/blob/6269907dc8c8af41edbb3f43b6f446deba09a30f/.github/workflows/master-mirrors-main.yaml but rather on the actual default branch which is as of now `main`.