### PR TITLE
feat(kgo): add ability to specify probes

### DIFF
--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.1.6
+version: 0.1.7
 appVersion: "1.2"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/probes-and-args.yaml
+++ b/charts/gateway-operator/ci/probes-and-args.yaml
@@ -1,0 +1,13 @@
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+args:
+  - --zap-log-level=debug

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -43,19 +43,11 @@ spec:
               fieldPath: metadata.namespace
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
+          {{- toYaml .Values.livenessProbe | nindent 10 }}
         readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          {{- toYaml .Values.readinessProbe | nindent 10 }}
         resources:
-{{ toYaml .Values.resources | indent 10 }}
+          {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -48,6 +48,21 @@ gwapi-standard-crds:
 gwapi-experimental-crds:
   enabled: false
 
+# Customize gateway-operator livenessProbe.
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 15
+  periodSeconds: 20
+# Customize gateway-operator readinessProbe.
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8081
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
 # Use this section to customize the requests and limits of gateway-operator
 resources:
   limits:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Add ability to specify `readinessProbe` and `livenessProbe` for KGO Pods.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
