### PR TITLE
fix(probes) allows overriding the default liveness/readiness probe with custom commands

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-* Allows overriding the liveness/readiness probes to use a command, default behavior is not changed
-
 ### Changes
 
 * Updated handling of `session_conf_secret` to accommodate Kong 3.6.

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Allows overriding the liveness/readiness probes to use a command, default behavior is not changed
+
 ### Changes
 
 * Updated handling of `session_conf_secret` to accommodate Kong 3.6.
@@ -209,7 +211,7 @@
 
 ## 2.26.5
 
-### Fixed 
+### Fixed
 
 * Kuma ServiceAccount Token hints and volumes are also available in migrations
   Pods.
@@ -217,19 +219,19 @@
 
 ## 2.26.4
 
-### Fixed 
+### Fixed
 
-* updated `admin_api_uri` to `admin_gui_api_url` as per [kong documentation](https://docs.konghq.com/gateway/3.4.x/reference/configuration/#admin_api_uri). 
+* updated `admin_api_uri` to `admin_gui_api_url` as per [kong documentation](https://docs.konghq.com/gateway/3.4.x/reference/configuration/#admin_api_uri).
 
 ## 2.26.3
 
-### Fixed 
+### Fixed
 
 * Enabled Service and Ingress in Kong Manager for non enterprise users.
 
 ## 2.26.2
 
-### Fixed 
+### Fixed
 
 * Add missing CRD KongConsumerGroup and extend status subresource for CRDs
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -24,6 +24,10 @@
   with non-KIC labels. Requires KIC 3.0+.
   [#1061](https://github.com/Kong/charts/pull/1061)
 
+* Allows overriding the liveness/readiness probes to use a command, default behavior is not changed
+  [#1070](https://github.com/Kong/charts/pull/1070)
+
+
 ## 2.38.0
 
 ### Changes

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -19,6 +19,9 @@ helm install kong/kong --generate-name
 
 ## Table of contents
 
+- [Kong for Kubernetes](#kong-for-kubernetes)
+- [TL;DR;](#tldr)
+- [Table of contents](#table-of-contents)
 - [Prerequisites](#prerequisites)
 - [Install](#install)
 - [Uninstall](#uninstall)
@@ -57,6 +60,8 @@ helm install kong/kong --generate-name
   - [Ingress Controller Parameters](#ingress-controller-parameters)
     - [The `env` section](#the-env-section)
     - [The `customEnv` section](#the-customenv-section)
+    - [The `gatewayDiscovery` section](#the-gatewaydiscovery-section)
+      - [Configuration](#configuration-1)
   - [General Parameters](#general-parameters)
     - [The `env` section](#the-env-section-1)
     - [The `customEnv` section](#the-customenv-section-1)
@@ -71,9 +76,7 @@ helm install kong/kong --generate-name
   - [Sessions](#sessions)
   - [Email/SMTP](#emailsmtp)
 - [Prometheus Operator integration](#prometheus-operator-integration)
-- [Argo CD considerations](#argo-cd-considerations)
-- [Changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md)
-- [Upgrading](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md)
+- [Argo CD Considerations](#argo-cd-considerations)
 - [Seeking help](#seeking-help)
 
 ## Prerequisites
@@ -464,7 +467,7 @@ listens if you do not provide your own. The chart can create
 configure them for you. To use this integration, install cert-manager, create
 an issuer, set `certificates.enabled: true` in values.yaml, and set your issuer
 name in `certificates.issuer` or `certificates.clusterIssuer` depending on the
-issuer type. 
+issuer type.
 
 If you do not have an issuer available, you can install the example [self-signed ClusterIssuer](https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers)
 and set `certificates.clusterIssuer: selfsigned-issuer` for testing. You
@@ -705,7 +708,7 @@ or `ingress` sections, as it is used only for stream listens.
 
 #### Admin Service mTLS
 
-On top of the common parameters listed above, the `admin` service supports parameters for mTLS client verification. 
+On top of the common parameters listed above, the `admin` service supports parameters for mTLS client verification.
 If any of `admin.tls.client.caBundle` or `admin.tls.client.secretName` are set, the admin service will be configured to
 require mTLS client verification. If both are set, `admin.tls.client.caBundle` will take precedence.
 
@@ -879,8 +882,8 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | autoscaling.targetCPUUtilizationPercentage | Target Percentage for when autoscaling takes affect. Only used if cluster does not support `autoscaling/v2` or `autoscaling/v2beta2` | `80`  |
 | autoscaling.metrics                | metrics used for autoscaling for clusters that supports `autoscaling/v2` or `autoscaling/v2beta2`           | See [values.yaml](values.yaml) |
 | updateStrategy                     | update strategy for deployment                                                        | `{}`                |
-| readinessProbe                     | Kong readiness probe                                                                  |                     |
-| livenessProbe                      | Kong liveness probe                                                                   |                     |
+| readinessProbe                     | Kong readiness probe                                                                  | See [values.yaml](values.yaml#L826) |
+| livenessProbe                      | Kong liveness probe                                                                   | See [values.yaml](values.yaml#L838) |
 | startupProbe                       | Kong startup probe                                                                    |                     |
 | lifecycle                          | Proxy container lifecycle hooks                                                       | see `values.yaml`   |
 | terminationGracePeriodSeconds      | Sets the [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for Deployment pods | 30                  |
@@ -929,11 +932,11 @@ containerSecurityContext: # run as root to bind to lower ports
   runAsUser: 0
 ```
 
-**Note:** The default `podAnnotations` values disable inbound proxying for Kuma 
-and Istio. This is appropriate when using Kong as a gateway for external 
+**Note:** The default `podAnnotations` values disable inbound proxying for Kuma
+and Istio. This is appropriate when using Kong as a gateway for external
 traffic inbound into the cluster.
 
-If you want to use Kong as an internal proxy within the cluster network, you 
+If you want to use Kong as an internal proxy within the cluster network, you
 should enable inbound the inbound mesh proxies:
 
 ```yaml

--- a/charts/kong/ci/probe-test-values.yaml
+++ b/charts/kong/ci/probe-test-values.yaml
@@ -2,7 +2,7 @@
 # - enable the probes with execGet
 
 livenessProbe:
-  execGet:
+  exec:
     command:
       - python3.10
       - /home/kong/scripts/liveness_probe.py
@@ -13,7 +13,7 @@ livenessProbe:
   failureThreshold: 3
 
 readinessProbe:
-  execGet:
+  exec:
     command:
       - python3.10
       - /home/kong/scripts/readiness_probe.py

--- a/charts/kong/ci/probe-test-values.yaml
+++ b/charts/kong/ci/probe-test-values.yaml
@@ -1,0 +1,24 @@
+# CI test for testing the probe with an exec command instead of the default httpGet
+# - enable the probes with execGet
+
+livenessProbe:
+  execGet:
+    command:
+      - python3.10
+      - /home/kong/scripts/liveness_probe.py
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  execGet:
+    command:
+      - python3.10
+      - /home/kong/scripts/readiness_probe.py
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -275,9 +275,30 @@ spec:
         {{- include "kong.volumeMounts" . | nindent 10 }}
         {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 10 }}
         readinessProbe:
+        {{- if .Values.readinessProbe.exec }}
+          exec:
+{{ toYaml .Values.readinessProbe.exec | indent 10 }}
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- else }}
 {{ include "kong.proxy.compatibleReadiness" . | indent 10 }}
+          {{- end }}
         livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 10 }}
+          {{- if .Values.livenessProbe.exec }}
+          exec:
+{{ toYaml .Values.livenessProbe.exec | indent 10 }}
+          {{- else }}
+          httpGet:
+{{ toYaml .Values.livenessProbe.httpGet | indent 10 }}
+          {{- end }}
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
         {{- if .Values.startupProbe }}
         startupProbe:
 {{ toYaml .Values.startupProbe | indent 10 }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -823,6 +823,7 @@ resources: {}
   #  memory: 2G
 
 # readinessProbe for Kong pods
+# replace httpGet with exec if you want to use a custom command
 readinessProbe:
   httpGet:
     path: "/status/ready"
@@ -835,6 +836,7 @@ readinessProbe:
   failureThreshold: 3
 
 # livenessProbe for Kong pods
+# replace httpGet with exec if you want to use a custom command
 livenessProbe:
   httpGet:
     path: "/status"


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
This allows folks to override the liveness/readiness probe with a custom exec/command instead of defaulting to the httpGet. Keeps the existing behavior as default so no breaking changes. 

#### Which issue this PR fixes
  - fixes [Duplicate handler when overriding readiness/liveness probes #1065](https://github.com/Kong/charts/issues/1065)

#### Special notes for your reviewer:

example values with execGet 

`helm template . --values values.yaml`

values.yaml
```
# readinessProbe for Kong pods
# replace httpGet with exec if you want to use a custom command
readinessProbe:
  exec:
    command:
      - python3.10
      - /home/kong/scripts/readiness_probe.py
  initialDelaySeconds: 5
  timeoutSeconds: 5
  periodSeconds: 10
  successThreshold: 1
  failureThreshold: 3

# livenessProbe for Kong pods
# replace httpGet with exec if you want to use a custom command
livenessProbe:
  exec:
    command:
      - python3.10
      - /home/kong/scripts/readiness_probe.py
  initialDelaySeconds: 5
  timeoutSeconds: 5
  periodSeconds: 10
  successThreshold: 1
  failureThreshold: 3
```

rendered out manifest 

```
        readinessProbe:
          exec:
          command:
          - python3.10
          - /home/kong/scripts/readiness_probe.py
          initialDelaySeconds: 5
          timeoutSeconds: 5
          periodSeconds: 10
          successThreshold: 1
          failureThreshold: 3
        livenessProbe:
          exec:
          command:
          - python3.10
          - /home/kong/scripts/readiness_probe.py
          initialDelaySeconds: 5
          timeoutSeconds: 5
          periodSeconds: 10
          successThreshold: 1
          failureThreshold: 3
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
