### PR TITLE
kgo: fix missing `renderTpl`

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.8
+
+### Features
+
+- Fix missing `renderTpl` which is used when specifying `.Values.extraLabels`
+  [#1075](https://github.com/Kong/charts/pull/1075)
+
 ## 0.1.7
 
 ### Features

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.1.7
+version: 0.1.8
 appVersion: "1.2"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/extra-labels-values.yaml
+++ b/charts/gateway-operator/ci/extra-labels-values.yaml
@@ -1,0 +1,10 @@
+extraLabels:
+  a: b
+
+livenessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1

--- a/charts/gateway-operator/templates/_helpers.tpl
+++ b/charts/gateway-operator/templates/_helpers.tpl
@@ -32,6 +32,14 @@ Create the name of the service account to use
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "kong.renderTpl" -}}
+    {{- if typeIs "string" .value }}
+{{- tpl .value .context }}
+    {{- else }}
+{{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}
+
 {{- define "kong.metaLabels" -}}
 app.kubernetes.io/name: {{ template "kong.name" . }}
 helm.sh/chart: {{ template "kong.chart" . }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fix missing `renderTpl`

#### Which issue this PR fixes

  - fixes #1074

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
