### PR TITLE
kong: Add flag to disable CRD check for mass server-side apply

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+* Added serviceMonitor.trustCRDsExist for render based deployments
 
 ### Changes
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -906,6 +906,7 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | securityContext                    | Set the securityContext for Kong Pods                                                 | `{}`                |
 | containerSecurityContext           | Set the securityContext for Containers                                                | See values.yaml     |
 | serviceMonitor.enabled             | Create ServiceMonitor for Prometheus Operator                                         | `false`             |
+| serviceMonitor.trustCRDsExist      | Do not check for the Prometheus Operator CRDs, just try to deploy                     | `false`             |
 | serviceMonitor.interval            | Scraping interval                                                                     | `30s`               |
 | serviceMonitor.namespace           | Where to create ServiceMonitor                                                        |                     |
 | serviceMonitor.labels              | ServiceMonitor labels                                                                 | `{}`                |

--- a/charts/kong/templates/servicemonitor.yaml
+++ b/charts/kong/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.serviceMonitor.enabled }}
+{{- if and .Values.serviceMonitor.enabled (or (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.serviceMonitor.trustCRDsExist) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -997,6 +997,7 @@ serviceMonitor:
   # If you wish to gather metrics from a Kong instance with the proxy disabled (such as a hybrid control plane), see:
   # https://github.com/Kong/charts/blob/main/charts/kong/README.md#prometheus-operator-integration
   enabled: false
+  trustCRDsExist: false
   # interval: 30s
   # Specifies namespace, where ServiceMonitor should be installed
   # namespace: monitoring


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
When using a mass deployment tool (like `kluctl`) helm may be rendered locally before being submitted. In this two step process the CRDs are not yet deployed and thus the chart fails to render. The ability to pre-render the templates simplifies generation of the manifests for offline review or pass through `kustomiz`. This sort of gitops workflow does all the renders in one step for review, then the apply in another step once the differences are approved.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
