### PR TITLE
feat: add `allowAnyOrigin` to kong/`manager.ingress` KM-122

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -22,6 +22,9 @@
   with non-KIC labels. Requires KIC 3.0+.
   [#1061](https://github.com/Kong/charts/pull/1061)
 
+* Added an optional property `allowAnyOrigin` under `manager.ingress` to enable users to allow access to Kong Manager from any origin.
+  [#1078](https://github.com/Kong/charts/pull/1078)
+
 ## 2.38.0
 
 ### Changes

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -57,6 +57,8 @@ helm install kong/kong --generate-name
   - [Ingress Controller Parameters](#ingress-controller-parameters)
     - [The `env` section](#the-env-section)
     - [The `customEnv` section](#the-customenv-section)
+    - [The `gatewayDiscovery` section](#the-gatewaydiscovery-section)
+      - [Configuration](#configuration-1)
   - [General Parameters](#general-parameters)
     - [The `env` section](#the-env-section-1)
     - [The `customEnv` section](#the-customenv-section-1)
@@ -67,11 +69,12 @@ helm install kong/kong --generate-name
     - [Kong Enterprise License](#kong-enterprise-license)
     - [Kong Enterprise Docker registry access](#kong-enterprise-docker-registry-access)
   - [Service location hints](#service-location-hints)
+  - [Accessing Kong Manager from multiple URLs](#accessing-kong-manager-from-multiple-urls)
   - [RBAC](#rbac)
   - [Sessions](#sessions)
   - [Email/SMTP](#emailsmtp)
 - [Prometheus Operator integration](#prometheus-operator-integration)
-- [Argo CD considerations](#argo-cd-considerations)
+- [Argo CD Considerations](#argo-cd-considerations)
 - [Changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md)
 - [Upgrading](https://github.com/Kong/charts/blob/main/charts/kong/UPGRADE.md)
 - [Seeking help](#seeking-help)
@@ -1081,6 +1084,17 @@ each of their respective services can be accessed to ensure that Kong services
 can locate one another and properly set CORS headers. See the
 [Property Reference documentation](https://docs.konghq.com/enterprise/latest/property-reference/)
 for more details on these settings.
+
+### Accessing Kong Manager from multiple URLs
+
+By default, Kong Gateway will be configured with `KONG_ADMIN_GUI_URL` set to the URL (from `hostname` and `path`) provided under `manager.ingress` in `values.yaml`. This enforces the CORS headers in the Admin API responses to match the URL of the Kong Manager.
+
+If you are configuring Kong Manager to be accessed from multiple URLs, to allow accessing the Admin API from different origins, you will need to set `manager.ingress.allowAnyOrigin` to `true`. This will skip injecting `KONG_ADMIN_GUI_URL` in the final rendered configuration, and allow access to the Admin API from any origin.
+
+Learn more:
+
+* Configuration reference for `admin_gui_url`: https://docs.konghq.com/gateway/latest/reference/configuration/#admin_gui_url
+* CORS in the context of Kong Gateway: https://docs.konghq.com/gateway/latest/production/networking/dns-considerations/#cors-in-the-context-of-kong-gateway
 
 ### RBAC
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1082,7 +1082,7 @@ the template that it itself is using form the above sections.
   {{- $_ := set $autoEnv "KONG_ADMIN_GUI_ERROR_LOG" "/dev/stderr" -}}
 
   {{- $_ := set $autoEnv "KONG_ADMIN_GUI_LISTEN" (include "kong.listen" .Values.manager) -}}
-  {{- if .Values.manager.ingress.enabled }}
+  {{- if and .Values.manager.ingress.enabled (not .Values.manager.ingress.allowAnyOrigin) }}
     {{- $_ := set $autoEnv "KONG_ADMIN_GUI_URL" (include "kong.ingress.serviceUrl" .Values.manager.ingress) -}}
   {{- end -}}
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -1096,6 +1096,12 @@ manager:
   ingress:
     # Enable/disable exposure using ingress.
     enabled: false
+    # Control to allow any origin to access the Kong Manager.
+    # When enabled, ADMIN_GUI_URL in the rendered configuration will be skipped.
+    # Learn more about ADMIN_GUI_URL: https://docs.konghq.com/gateway/latest/reference/configuration/#admin_gui_url
+    # Learn more about CORS in Kong Gateway: https://docs.konghq.com/gateway/latest/production/networking/dns-considerations/#cors-in-the-context-of-kong-gateway
+    # Default: false
+    allowAnyOrigin: false
     ingressClassName:
     # TLS secret name.
     # tls: kong-manager.example.com-tls

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -1097,8 +1097,8 @@ manager:
     # Enable/disable exposure using ingress.
     enabled: false
     # Control to allow any origin to access the Kong Manager.
-    # When enabled, ADMIN_GUI_URL in the rendered configuration will be skipped.
-    # Learn more about ADMIN_GUI_URL: https://docs.konghq.com/gateway/latest/reference/configuration/#admin_gui_url
+    # When enabled, KONG_ADMIN_GUI_URL will NOT be injected in the rendered configuration.
+    # Learn more about KONG_ADMIN_GUI_URL: https://docs.konghq.com/gateway/latest/reference/configuration/#admin_gui_url
     # Learn more about CORS in Kong Gateway: https://docs.konghq.com/gateway/latest/production/networking/dns-considerations/#cors-in-the-context-of-kong-gateway
     # Default: false
     allowAnyOrigin: false


### PR DESCRIPTION
#### What this PR does / why we need it:

This pull request adds an optional property `allowAnyOrigin` under `manager.ingress` in `kong` Charts.

#### Which issue this PR fixes

KM-122

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
