### PR TITLE
fix: fix KongLicense policy rule when using watch namespaces

### DIFF
--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.39.0
+  version: 2.39.1
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.39.0
-digest: sha256:b2691f740c1442911de3e647a3f8d029e68afbcf3b4a059f756bc91e260d35d4
-generated: "2024-06-12T14:27:30.636251+02:00"
+  version: 2.39.1
+digest: sha256:6a30608afa50e833a14197281ca1b7cf7280d9af6ff66a649e6258ff0ee2e7b8
+generated: "2024-06-13T14:59:35.34910922-07:00"

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.0
+    helm.sh/chart: gateway-2.39.1
   name: chartsnap-gateway
   namespace: default
 ---
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -65,7 +65,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller-admin-api-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller-admin-api-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -94,7 +94,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller
 rules:
   - apiGroups:
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -409,7 +409,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller
   namespace: default
 rules:
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller
   namespace: default
 roleRef:
@@ -493,7 +493,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller-validation-webhook
   namespace: default
 spec:
@@ -508,7 +508,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.0
+    helm.sh/chart: gateway-2.39.1
   name: chartsnap-gateway-admin
   namespace: default
 spec:
@@ -542,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.0
+    helm.sh/chart: gateway-2.39.1
   name: chartsnap-gateway-manager
   namespace: default
 spec:
@@ -570,7 +570,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: gateway-2.39.0
+    helm.sh/chart: gateway-2.39.1
   name: chartsnap-gateway-proxy
   namespace: default
 spec:
@@ -598,7 +598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller
   namespace: default
 spec:
@@ -623,7 +623,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: controller
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: controller-2.39.0
+        helm.sh/chart: controller-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.0
+    helm.sh/chart: gateway-2.39.1
   name: chartsnap-gateway
   namespace: default
 spec:
@@ -778,7 +778,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: gateway
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: gateway-2.39.0
+        helm.sh/chart: gateway-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -1006,7 +1006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: controller-2.39.1
   name: chartsnap-controller-validations
   namespace: default
 webhooks:

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-### Changes
+Nothing yet.
+
+## 2.39.2
+
+### Fixed
 
 * Fixes `KongLicense` policy rules for Ingress controller when using `watchNamespaces`
   [#1084](https://github.com/Kong/charts/pull/1084)

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+* Fixes `KongLicense` policy rules for Ingress controller when using `watchNamespaces`
+  [#1084](https://github.com/Kong/charts/pull/1084)
+
 ## 2.39.1
 
 ### Fixed

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.39.1
+version: 2.39.2
 appVersion: "3.6"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-admin
   namespace: default
 spec:
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -119,7 +119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -143,7 +143,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -858,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -371,7 +371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -436,7 +436,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -484,7 +484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -513,7 +513,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -542,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -566,7 +566,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -866,7 +866,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -858,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -511,7 +511,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -539,7 +539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -562,7 +562,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -861,7 +861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -887,7 +887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -511,7 +511,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -539,7 +539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -562,7 +562,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -861,7 +861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -889,7 +889,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -852,7 +852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -876,7 +876,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -364,7 +364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -447,7 +447,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -467,7 +467,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -482,7 +482,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -492,7 +492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -520,7 +520,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -548,7 +548,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -571,7 +571,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -870,7 +870,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -929,7 +929,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +433,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +448,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +486,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -514,7 +514,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -537,7 +537,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -842,7 +842,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -555,7 +555,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -854,7 +854,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: my-kong-sa
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -852,7 +852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -858,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -97,7 +97,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
         environment: test
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -895,7 +895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -921,7 +921,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -945,7 +945,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -78,7 +78,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -90,7 +90,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -248,7 +248,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-default
   namespace: default
 rules:
@@ -482,7 +482,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-default
   namespace: default
 roleRef:
@@ -572,7 +572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -587,7 +587,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -625,7 +625,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -661,7 +661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -689,7 +689,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1318,7 +1318,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1551,7 +1551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1575,7 +1575,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1704,7 +1704,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1720,7 +1720,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1959,7 +1959,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -1975,7 +1975,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -96,6 +96,22 @@ rules:
   - apiGroups:
       - configuration.konghq.com
     resources:
+      - konglicenses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - konglicenses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
       - kongvaults
     verbs:
       - get
@@ -457,22 +473,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - configuration.konghq.com
-    resources:
-      - konglicenses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - configuration.konghq.com
-    resources:
-      - konglicenses/status
-    verbs:
-      - get
-      - patch
-      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -120,7 +120,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -128,7 +128,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -366,7 +366,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -71,7 +71,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -83,7 +83,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -379,7 +379,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 rules:
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -547,7 +547,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
 ---
 apiVersion: v1
 kind: Service
@@ -557,7 +557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -613,7 +613,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong
   namespace: default
 spec:
@@ -641,7 +641,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1241,7 +1241,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1459,7 +1459,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1483,7 +1483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1611,7 +1611,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1627,7 +1627,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1851,7 +1851,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.1
+    helm.sh/chart: kong-2.39.2
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -1867,7 +1867,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.1
+        helm.sh/chart: kong-2.39.2
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1671,6 +1671,14 @@ resource roles into their separate templates.
   - get
   - list
   - watch
+{{- end -}}
+
+{{/*
+kong.kubernetesRBACClusterRoles outputs a static list of RBAC rules (the "rules" block
+of a Role or ClusterRole) that provide the ingress controller access to the
+Kubernetes Cluster-scoped resources it uses to build Kong configuration.
+*/}}
+{{- define "kong.kubernetesRBACClusterRules" -}}
 {{- if (semverCompare ">= 3.1.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
 - apiGroups:
   - configuration.konghq.com
@@ -1689,14 +1697,6 @@ resource roles into their separate templates.
   - patch
   - update
 {{- end -}}
-{{- end -}}
-
-{{/*
-kong.kubernetesRBACClusterRoles outputs a static list of RBAC rules (the "rules" block
-of a Role or ClusterRole) that provide the ingress controller access to the
-Kubernetes Cluster-scoped resources it uses to build Kong configuration.
-*/}}
-{{- define "kong.kubernetesRBACClusterRules" -}}
 {{- if (semverCompare ">= 3.1.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
 - apiGroups:
   - configuration.konghq.com


### PR DESCRIPTION
#### What this PR does / why we need it:

The `KongLicense` policy rule was incorrectly put into `Role` instead of the `ClusterRole` which causes KIC versions which have `KongLicense` controller enabled (3.1+) to issue errors:

```
2024-06-11 12:34:02.215	W0611 10:34:02.215528       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229: failed to list *v1alpha1.KongLicense: konglicenses.configuration.konghq.com is forbidden: User "system:serviceaccount:my-company:my-company-kong-kong" cannot list resource "konglicenses" in API group "configuration.konghq.com" at the cluster scope
2024-06-11 12:34:02.215	E0611 10:34:02.215585       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229: Failed to watch *v1alpha1.KongLicense: failed to list *v1alpha1.KongLicense: konglicenses.configuration.konghq.com is forbidden: User "system:serviceaccount:my-company:my-company-kong-kong" cannot list resource "konglicenses" in API group "configuration.konghq.com" at the cluster scope
2024-06-11 12:34:25.289	W0611 10:34:25.288829       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229: failed to list *v1alpha1.KongLicense: konglicenses.configuration.konghq.com is forbidden: User "system:serviceaccount:my-company:my-company-kong-kong" cannot list resource "konglicenses" in API group "configuration.konghq.com" at the cluster scope
2024-06-11 12:34:25.289	E0611 10:34:25.289209       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229: Failed to watch *v1alpha1.KongLicense: failed to list *v1alpha1.KongLicense: konglicenses.configuration.konghq.com is forbidden: User "system:serviceaccount:my-company:my-company-kong-kong" cannot list resource "konglicenses" in API group "configuration.konghq.com" at the cluster scope
2024-06-11 12:35:07.165	W0611 10:35:07.165101       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229: failed to list *v1alpha1.KongLicense: konglicenses.configuration.konghq.com is forbidden: User "system:serviceaccount:my-company:my-company-kong-kong" cannot list resource "konglicenses" in API group "configuration.konghq.com" at the cluster scope
2024-06-11 12:35:07.165	E0611 10:35:07.165594       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229: Failed to watch *v1alpha1.KongLicense: failed to list *v1alpha1.KongLicense: konglicenses.configuration.konghq.com is forbidden: User "system:serviceaccount:my-company:my-company-kong-kong" cannot list resource "konglicenses" in API group "configuration.konghq.com" at the cluster scope
```

This only came out when used with `watchNamespaces` because without it the [`ClusterRole` contains both sets of policy rules](https://github.com/Kong/charts/blob/72650f5768dde1867812fab42e863de7db60f80f/charts/kong/templates/controller-rbac-resources.yaml#L99-L100).

And also given the fact that [`KongLicense` is cluster scoped](https://github.com/Kong/kubernetes-ingress-controller/blob/ce7b47bd29a5e1af3a24c07017431ce234200f18/config/crd/bases/configuration.konghq.com_konglicenses.yaml#L19).

#### Which issue this PR fixes

Fixes #1083

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
