### PR TITLE
chore(kong): bump kic tag and release 2.39.0

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.39.0
 
 ### Changes
 
@@ -23,6 +23,8 @@
   [#1061](https://github.com/Kong/charts/pull/1061)
 * Add RBAC policy rules for Custom Entities
   [#1081](https://github.com/Kong/charts/pull/1081)
+* Bumped default `kong/kubernetes-ingress-controller` image tag to 3.2.
+  [#1085](https://github.com/Kong/charts/pull/1085)
 
 ## 2.38.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.38.0
+version: 2.39.0
 appVersion: "3.6"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-admin
   namespace: default
 spec:
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -119,7 +119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -143,7 +143,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -858,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -54,9 +54,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -335,7 +351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -355,7 +371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -420,7 +436,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -441,7 +457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -457,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -468,7 +484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -497,7 +513,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -526,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -550,7 +566,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -579,7 +595,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -850,7 +866,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,9 +50,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -330,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -514,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -537,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -568,7 +584,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -842,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,9 +59,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -339,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -358,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -422,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -442,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -457,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -467,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -495,7 +511,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -523,7 +539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -546,7 +562,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -575,7 +591,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -845,7 +861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -871,7 +887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,9 +59,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -339,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -358,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -422,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -442,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -457,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -467,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -495,7 +511,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -523,7 +539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -546,7 +562,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -575,7 +591,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -845,7 +861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -873,7 +889,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,9 +50,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -330,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -514,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -537,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -566,7 +582,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -836,7 +852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -860,7 +876,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -68,9 +68,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -348,7 +364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -367,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -431,7 +447,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -451,7 +467,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -466,7 +482,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -476,7 +492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -504,7 +520,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -532,7 +548,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -555,7 +571,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -584,7 +600,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -854,7 +870,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -913,7 +929,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +433,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +448,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +486,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -514,7 +514,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -537,7 +537,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -842,7 +842,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,9 +50,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -330,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -516,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -539,7 +555,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -568,7 +584,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -838,7 +854,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: my-kong-sa
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,9 +50,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -330,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -514,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -537,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -566,7 +582,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -836,7 +852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,9 +50,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -330,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -514,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -537,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -842,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -97,7 +97,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,9 +50,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -330,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -514,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -537,7 +553,7 @@ spec:
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
         environment: test
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -570,7 +586,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -879,7 +895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -905,7 +921,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -929,7 +945,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -78,7 +78,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -90,7 +90,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -232,10 +232,26 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-default
   namespace: default
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -466,7 +482,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -486,7 +502,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-default
   namespace: default
 roleRef:
@@ -556,7 +572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -571,7 +587,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -581,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -609,7 +625,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -645,7 +661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -673,7 +689,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -711,7 +727,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: env-config
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -1286,7 +1302,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1302,7 +1318,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1535,7 +1551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1559,7 +1575,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1688,7 +1704,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1704,7 +1720,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1943,7 +1959,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -1959,7 +1975,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -120,7 +120,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -128,7 +128,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -366,7 +366,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -71,7 +71,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -83,9 +83,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -363,7 +379,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -382,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -446,7 +462,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -516,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -531,7 +547,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -541,7 +557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -569,7 +585,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -597,7 +613,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -625,7 +641,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -656,7 +672,7 @@ spec:
               value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -1209,7 +1225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1225,7 +1241,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1443,7 +1459,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1467,7 +1483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1595,7 +1611,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1611,7 +1627,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1835,7 +1851,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: kong-2.39.0
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -1851,7 +1867,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: kong-2.39.0
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -532,7 +532,7 @@ ingressController:
   enabled: true
   image:
     repository: kong/kubernetes-ingress-controller
-    tag: "3.1"
+    tag: "3.2"
     # Optionally set a semantic version for version-gated features. This can normally
     # be left unset. You only need to set this if your tag is not a semver string,
     # such as when you are using a "next" tag. Set this to the effective semantic


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump default KIC image to 3.2 and release `kong/kong` 2.39.0.

#### Which issue this PR fixes
Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6135.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
