### PR TITLE
chore(ingress): bump kong/kong and release 0.13.0

### DIFF
--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.38.0
+  version: 2.39.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.38.0
-digest: sha256:64a48e09ab03fceefc9316cfdf1bd20799fd9d065826b28dfb5f2e27ca906b2f
-generated: "2024-02-27T10:41:51.57116834-08:00"
+  version: 2.39.0
+digest: sha256:b2691f740c1442911de3e647a3f8d029e68afbcf3b4a059f756bc91e260d35d4
+generated: "2024-06-12T14:27:30.636251+02:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.12.0
+version: 0.13.0
 appVersion: "3.6"
 dependencies:
   - name: kong
-    version: ">=2.38.0"
+    version: ">=2.39.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: ">=2.38.0"
+    version: ">=2.39.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.38.0
+    helm.sh/chart: gateway-2.39.0
   name: chartsnap-gateway
   namespace: default
 ---
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -65,7 +65,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller-admin-api-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller-admin-api-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -94,9 +94,25 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -374,7 +390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -393,7 +409,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller
   namespace: default
 rules:
@@ -457,7 +473,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller
   namespace: default
 roleRef:
@@ -477,7 +493,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller-validation-webhook
   namespace: default
 spec:
@@ -492,7 +508,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -502,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.38.0
+    helm.sh/chart: gateway-2.39.0
   name: chartsnap-gateway-admin
   namespace: default
 spec:
@@ -526,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.38.0
+    helm.sh/chart: gateway-2.39.0
   name: chartsnap-gateway-manager
   namespace: default
 spec:
@@ -554,7 +570,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: gateway-2.38.0
+    helm.sh/chart: gateway-2.39.0
   name: chartsnap-gateway-proxy
   namespace: default
 spec:
@@ -582,7 +598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller
   namespace: default
 spec:
@@ -607,7 +623,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: controller
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: controller-2.38.0
+        helm.sh/chart: controller-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -642,7 +658,7 @@ spec:
               value: "true"
             - name: CONTROLLER_PUBLISH_SERVICE
               value: default/chartsnap-gateway-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -739,7 +755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.38.0
+    helm.sh/chart: gateway-2.39.0
   name: chartsnap-gateway
   namespace: default
 spec:
@@ -762,7 +778,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: gateway
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: gateway-2.38.0
+        helm.sh/chart: gateway-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -990,14 +1006,66 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.38.0
+    helm.sh/chart: controller-2.39.0
   name: chartsnap-controller-validations
   namespace: default
 webhooks:
   - admissionReviewVersions:
-      - v1beta1
+      - v1
     clientConfig:
       caBundle: '###DYNAMIC_FIELD###'
+      service:
+        name: chartsnap-controller-validation-webhook
+        namespace: default
+    failurePolicy: Ignore
+    matchPolicy: Equivalent
+    name: secrets.credentials.validation.ingress-controller.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: konghq.com/credential
+          operator: Exists
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJekNDQWd1Z0F3SUJBZ0lRQjBiZlduMGVtTnl4K1lCOTZHWGdTakFOQmdrcWhraUc5dzBCQVFzRkFEQWMKTVJvd0dBWURWUVFERXhGcmIyNW5MV0ZrYldsemMybHZiaTFqWVRBZUZ3MHlOREEyTVRJeE1qSTNOREZhRncwegpOREEyTVRBeE1qSTNOREZhTUJ3eEdqQVlCZ05WQkFNVEVXdHZibWN0WVdSdGFYTnphVzl1TFdOaE1JSUJJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNYSGk3YStrK1RlNzB1K3FMRnVoNHd5OW0rN1AKUmdMaUpUekptbmw3ZWhUN29EMHplelM0S0hsYW9rSC9rM0R1M3VYekk2RkNWUTdYUWFCbjFFN2dQcTdoOTJvVgpaT0FVWDBoYWRabDBrUGM0Q0VZajVYblBFWWFGMUI2ODI0NVVUK3psM29TNDdrSWd2VEUra0hteU9HYndNUnd1Cnp2RzJCU3dTMHdPM1FjMzQ1MlNXNytEN1c1WHVjUncwNWhnWnhmbmM5U2Y1RDNJK0JUYUdMTlFGVjM4RTVHa24KWk81VzZxMm9PWExoVTVXaXE5bGdINFdvOVJib3NIRm9yU29JVXdnNjd0RDhvdGFzKzNpS0s5R2VWcmtSNlhvOQpIVjFhMjc5YXgwb0ZRNXk4Z2t0YStvbjZ5MWN0UUhQVGRFaWJvOGNqRUFMck9UNzBIZGxURlFOTGt3SURBUUFCCm8yRXdYekFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0VHQ0NzR0FRVUYKQndNQ01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZGSGFJdElzbjF4UFdINFg0VGRGc284VAovWjBLTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBK1puTkZzR04xZFNpZXdlK2doWmJscDZzZmJxck82WXdtCjNDVnIyUEEwd0VPemtXUlRyTnlVVkJUdVBoNXNZcG9IQitKVXdVVHVDd3lZM3ZWZTZaTTNKbU1WcFpuUHhTbDcKUGZVYkJlb0dxK3loSDlZWjhqdXBiSU9OUzZja01aTElrWjIzWDNYd0gzR3JrVHZCakloQ3YwWkpmQWQvZDdPbApHQlEzZ2ZYaVd4eFdqcFlIT3BmdTF4NERBd0NiWmZZZEJjcHpSOXNyV0V0SG1Jc3M4Sk9XRGV1YUMvTzFKdWExClY0RGZDL0xDTmNVTFY5b21ZTEZRbkFsbVlwMWtBRzVwRVN3aDAwKzhWK2UzN0wxby9KMzI3RlE0ajVLMFlVS1YKL2FJeHRyWXBGT255UFZDN0R5SXFuQVZKYmw0TFNkY1Iyc0pFdm1vbldnNENlZHdYUFFaSAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      service:
+        name: chartsnap-controller-validation-webhook
+        namespace: default
+    failurePolicy: Ignore
+    matchPolicy: Equivalent
+    name: secrets.plugins.validation.ingress-controller.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURJekNDQWd1Z0F3SUJBZ0lRQjBiZlduMGVtTnl4K1lCOTZHWGdTakFOQmdrcWhraUc5dzBCQVFzRkFEQWMKTVJvd0dBWURWUVFERXhGcmIyNW5MV0ZrYldsemMybHZiaTFqWVRBZUZ3MHlOREEyTVRJeE1qSTNOREZhRncwegpOREEyTVRBeE1qSTNOREZhTUJ3eEdqQVlCZ05WQkFNVEVXdHZibWN0WVdSdGFYTnphVzl1TFdOaE1JSUJJakFOCkJna3Foa2lHOXcwQkFRRUZBQU9DQVE4QU1JSUJDZ0tDQVFFQXNYSGk3YStrK1RlNzB1K3FMRnVoNHd5OW0rN1AKUmdMaUpUekptbmw3ZWhUN29EMHplelM0S0hsYW9rSC9rM0R1M3VYekk2RkNWUTdYUWFCbjFFN2dQcTdoOTJvVgpaT0FVWDBoYWRabDBrUGM0Q0VZajVYblBFWWFGMUI2ODI0NVVUK3psM29TNDdrSWd2VEUra0hteU9HYndNUnd1Cnp2RzJCU3dTMHdPM1FjMzQ1MlNXNytEN1c1WHVjUncwNWhnWnhmbmM5U2Y1RDNJK0JUYUdMTlFGVjM4RTVHa24KWk81VzZxMm9PWExoVTVXaXE5bGdINFdvOVJib3NIRm9yU29JVXdnNjd0RDhvdGFzKzNpS0s5R2VWcmtSNlhvOQpIVjFhMjc5YXgwb0ZRNXk4Z2t0YStvbjZ5MWN0UUhQVGRFaWJvOGNqRUFMck9UNzBIZGxURlFOTGt3SURBUUFCCm8yRXdYekFPQmdOVkhROEJBZjhFQkFNQ0FxUXdIUVlEVlIwbEJCWXdGQVlJS3dZQkJRVUhBd0VHQ0NzR0FRVUYKQndNQ01BOEdBMVVkRXdFQi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZGSGFJdElzbjF4UFdINFg0VGRGc284VAovWjBLTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFBK1puTkZzR04xZFNpZXdlK2doWmJscDZzZmJxck82WXdtCjNDVnIyUEEwd0VPemtXUlRyTnlVVkJUdVBoNXNZcG9IQitKVXdVVHVDd3lZM3ZWZTZaTTNKbU1WcFpuUHhTbDcKUGZVYkJlb0dxK3loSDlZWjhqdXBiSU9OUzZja01aTElrWjIzWDNYd0gzR3JrVHZCakloQ3YwWkpmQWQvZDdPbApHQlEzZ2ZYaVd4eFdqcFlIT3BmdTF4NERBd0NiWmZZZEJjcHpSOXNyV0V0SG1Jc3M4Sk9XRGV1YUMvTzFKdWExClY0RGZDL0xDTmNVTFY5b21ZTEZRbkFsbVlwMWtBRzVwRVN3aDAwKzhWK2UzN0wxby9KMzI3RlE0ajVLMFlVS1YKL2FJeHRyWXBGT255UFZDN0R5SXFuQVZKYmw0TFNkY1Iyc0pFdm1vbldnNENlZHdYUFFaSAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
       service:
         name: chartsnap-controller-validation-webhook
         namespace: default
@@ -1030,7 +1098,6 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
-          - secrets
           - services
       - apiGroups:
           - networking.k8s.io


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump `kong/kong` dependency in `kong/ingress` and release `kong/ingress` 0.13.0.

#### Which issue this PR fixes
Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6135.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
