### PR TITLE
chore(crds) update CRDs to KIC 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,6 @@ _chartsnap.ingress:
 
 .PHONY: _chartsnap
 _chartsnap: chartsnap
+	@ helm repo update
+	@ helm dependencies update charts/ingress
 	@ helm chartsnap -c ./charts/$(GOLDEN_TEST_CHART) -f $(GOLDEN_TEST_CHART_VALUES_DIR) $(CHARTSNAP_ARGS)

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -4,41 +4,85 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller
+  namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: gateway-2.39.0
+  name: chartsnap-gateway
   namespace: default
 ---
 apiVersion: v1
 data:
-  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKRENDQWd5Z0F3SUJBZ0lSQVBQYTBSOTd4d0xqMHI5d3R0L3REU2N3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUmEyOXVaeTFoWkcxcGMzTnBiMjR0WTJFd0hoY05NalF3TmpFek1UZzFOalUzV2hjTgpNelF3TmpFeE1UZzFOalUzV2pBY01Sb3dHQVlEVlFRREV4RnJiMjVuTFdGa2JXbHpjMmx2YmkxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMbi9vQ0JxdWpIN1Z6d1FnelJ1Z2xoWWhYSkQKWmpZUGd4Tm1IK0c2QzZFYmRBU0VtMkV4MktBdFVMeFJvSkwybzlrK1BVZnhzQ2JQZG80bGtvemtwNXBZRGQwSgprcHhGRFBjRlJoUUw4NTk5bkpjZEpBRkJKTUw1UkM2cEUvci9ZR1MyeFIydnJzTURlM1QzZ2V3QkkrVUovc1RTCk5Rd2VtSUNjWWhOZnRKUVRCeFBGcW41a3drMGV0ZDhOVDBXaDBBWjFwRUZwNEVVekgrdUEyMmZmb1RHR3ZWYjcKRzl2NUx4MzlFMUNhTHZZUnRZQkg1S1cvbGxVeXdFeHRmRlNFNnl0L2lpRUxxbE0yQlc2anlXU2lTdmtpajRXWApUeVRhQkNwUnNzL2M5a0t4OUQxU3J1bnhuTUtxcHBQK25ZNzlnWHJaaURkekFocE9MQzRLQkd0U25BOENBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCU2ZPR1B4U2hjTE90bEtnalp5UGZibgo5ajlXTXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUFTczBZb2Nmc1VQRjM4alBOSmxyMjJibnNIZHJQTGFCCkpaUG9UY1NMd0pHYWI1ZDIvTFJUQlJCWHltWXJWdEIrazhia1ZVdWkxWmMyMzRkaFVYNDYvQW1GT0NHN3duKzAKUTZhdmRUcFppRlY3V3dSRkM2c21aTjkrMG14WUx0aXUrY01yUE9WeHdNeVZpV09JOXNFeEpoVm9EVm5NY1ZzNQpGZmw1SURDaDZaRVpGRk1NQXpsa3haSUNIVTA1enJSNDErcFRua2dTZDh2Z21SODNxdTc0T2RqeGtOb25DdUdRCk5vSTdsTDM0RUNMT2kwLzBPajR6aHQxNTRFMTloMUJiL3krSUh1cWgwQzNMdHpzNDJoei9uYjlCbXlQMEc0d0sKaWlQQWFSNHZycWVzTWd6YWQzYWNIYmdIVDNTQkJmVzFrMWVwWWZqaUFmS2NMWU8xWjdhSG5BPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdWYrZ0lHcTZNZnRYUEJDRE5HNkNXRmlGY2tObU5nK0RFMllmNGJvTG9SdDBCSVNiCllUSFlvQzFRdkZHZ2t2YWoyVDQ5Ui9Hd0pzOTJqaVdTak9Tbm1sZ04zUW1TbkVVTTl3VkdGQXZ6bjMyY2x4MGsKQVVFa3d2bEVMcWtUK3Y5Z1pMYkZIYSt1d3dON2RQZUI3QUVqNVFuK3hOSTFEQjZZZ0p4aUUxKzBsQk1IRThXcQpmbVRDVFI2MTN3MVBSYUhRQm5Xa1FXbmdSVE1mNjREYlo5K2hNWWE5VnZzYjIva3ZIZjBUVUpvdTloRzFnRWZrCnBiK1dWVExBVEcxOFZJVHJLMytLSVF1cVV6WUZicVBKWktKSytTS1BoWmRQSk5vRUtsR3l6OXoyUXJIMFBWS3UKNmZHY3dxcW1rLzZkanYyQmV0bUlOM01DR2s0c0xnb0VhMUtjRHdJREFRQUJBb0lCQUN1eDVjZzN5bTRiZ2E3VwpvandiQ2Z2L0w3cGNJeExvS2Y3UXF3UzRWQ3NRNi94enVwem12T0ZFUkFjNWxlTndsYVZmZmIzOUJVall6QjB3CnJuRHk5bnpIMnRubWVjN0VXZnRkL2N5UDBqZlJwb3ZKaUwvU3NmUXI0dHlqVTlKUFZESFV6aEhmUjhzQWNteFUKQ08yTWh3WXpodXB1QjVCRlQ4Wkc5ck5lZEdta2Q2cGlHcVlvZG1GbmxrKyt2T09YcmVVeVlsT2syUXliM1hpTwo1ejdONjJrV2xWUVRPSzRvQjlHL0wyWk9MVjcrYlRrTStRK1JYRTRBcnl3cHM2QldYZ2VxcUhWSkEwSGVsb0hWCnpOUGJURmtNc3RpRGVxazJRQjNaNUc5dHdUZzNrZTY2b1BtTVQrQzVjTlhTbldLekRYeGdzSklNNVc4cVVjek4KdXk4UnIwRUNnWUVBeGE2ZGdrM2R1NVhaNjkrN1FXQkZranR1b3RuU1ZEWTRUendLYWFZSGZUL3BHS2VIYmZJWApLbnQraWJWNko5WTdtMFhxeEtKRERNV1pUKzFwOUM1SGlZR0hLelhVclA2b3R0a3Ixd0dwN3NSeHVYUHV4YjBnCitJdXRmdlZiTUpVWm45cWlrSkxZbVdSTjhJOGtsdnZCbTIwbUc0dEVSbDdQVTBCYkE1WWlqSWNDZ1lFQThONmsKZzlaSmZxdVl1dm9kZ0E1alZWTEZid3dXUFJZRHduSHZHU0x1UUcxSzdpSzB0dDZoZUVSMjc2emJkZWx2RXRxZQpSVUFycVpBdWVGYWVjRjhCdjV3ZjRFaUJSZW1CWlRERUg3Z3JHc0RneXM3NTA1NmxSUVJOa1VkN1QxS1lYRU1XCkJKajlEZzlDUjhHZVQrb29Ba040MEErR2VEa1Nhek5DL1cxcW5qa0NnWUI3dGxtUVVKYXhiSWhpMnpOZktKYWgKZTF3endrbWt0Z0hyWkZISDZFWExscEdVQWxQNDlJYVc2WTQ1TkQ5c2F1QUd2bXk3L2lnaitBMklQYllQUUY4NApxTDBreDUxL1hpZkx0b0YvSHVWd0xiUldNVDErdG12SjMvQUdBaHE5ZnJING5tVWFRU3dZWXZONzFyazVXL2pBCkFrRFZBQVVNWFEwMnRwRyszdGhrUlFLQmdRQ3hNZGlzOC9OVk1EOUhMY0NOK0Flek9SVHRRR01MeFNvMjNVSWIKcDhyRnNxRXcxbTlES0R4NUVVUzl4Tmdkd2dCb1NsT3NkaXlvck56Q3dsWUVMS0JJcVQzNTdOek01WjYvSmtUaApZTWExQTdkYSt6Qm1NWXM3WHBNQmtTaHhqajF2Z2hxc2Z5K0tMRWVDS2ptZ2FJM09QSHlmOHd2bFhYYmpUZTYyCktNd0tZUUtCZ0VjRlpKaUxWTmN6cVpCRG5ZQnRNNFZjdGcyVUk5TUc1d0kyamNYVW8vejFRd1IzN0Z2Mk1WUUwKeUh5aHZpcWtCOWVzNTNDTjVEb0Fqc2lJRGdZb21qdHVQVkRKV2dydEJYS2IzblFVY2NpTWRGazRMaE5FWE13bApXM0l0VkZYNm41QjZicTlHNTNpOGNLYzROVGt0azZkYktWc3VTaXhSY1JsOGRLcmRwSnZyCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
 kind: Secret
 metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong-validation-webhook-ca-keypair
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
 ---
 apiVersion: v1
 data:
-  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURlekNDQW1PZ0F3SUJBZ0lSQUtiQitpVTdHM21XUnVuOENoY0NBME13RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUmEyOXVaeTFoWkcxcGMzTnBiMjR0WTJFd0hoY05NalF3TmpFek1UZzFOalU0V2hjTgpNelF3TmpFeE1UZzFOalU0V2pBNE1UWXdOQVlEVlFRREV5MWphR0Z5ZEhOdVlYQXRhMjl1WnkxMllXeHBaR0YwCmFXOXVMWGRsWW1odmIyc3VaR1ZtWVhWc2RDNXpkbU13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXcKZ2dFS0FvSUJBUURUVUpxNEh6bmoyT0dIbEQxdUhTN3NEUlF2aGdyM2lWZk1xSGN5M0JNbE02YUU4K2RnMkF1dAp5cHlmMWQxNUN1MHJEYTkxN2h6cmtMeWhEYkhwSDE5ZmZodk8rTXBlNEhnUWhPRkFXaWp0NElDZW9YcWRpWFo5CkpiVHdnbyt4c1hKT0QvWnVSQ2tZUndIdldXYUtkdXUxMS9JcklUQVY2VXlMaXZXZWVGS3hLQ21qSmxFMmQ4T3UKN2dVWFdmRUFNUUNNbWExS1ArTTh2K0piTGQxekNWaWEydjFIMjZFUWJZK20zNTBLQ29oa1ViLzRlb0NFNnIzbgpnTGRlQ250VlhXYVUyODRhRzZYWW5tYVdqNml6THBTTTNhMUFDTmlFcjN3UURDeWZYdzNYMVpua1dPWGRsMEVSCm9sK2hpY3hOOW52Y1ovQlRpcXkwajZ2UEtuZGtxNXREQWdNQkFBR2pnWnN3Z1pnd0RnWURWUjBQQVFIL0JBUUQKQWdXZ01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFNQmdOVkhSTUJBZjhFQWpBQQpNQjhHQTFVZEl3UVlNQmFBRko4NFkvRktGd3M2MlVxQ05uSTk5dWYyUDFZek1EZ0dBMVVkRVFReE1DK0NMV05vCllYSjBjMjVoY0MxcmIyNW5MWFpoYkdsa1lYUnBiMjR0ZDJWaWFHOXZheTVrWldaaGRXeDBMbk4yWXpBTkJna3EKaGtpRzl3MEJBUXNGQUFPQ0FRRUFOdHgyMGxyL2dKRzNCeFNFTXNjR0xYa1d3R0VacHk5MVNPZFdIK05yeTVTcApHdUhBZHB1bnFENmtLVTJTTGRJNkhJTmhPZ2tpcVY1Vlh1SHFneFZJYWNNNUxFT0RPMVF3S2lncXNydHVFYXlZCncrbTl1N0J4RXRNRXl0K2NpNE5DSFYrTnA3NlNYRUFvNmVmbEo3aWV4SGNEeEJJeGtyMVB5eXhzalF2M3dFd0QKVCtPU0lIM09LVUdNTEJqNWRzbzVqM3ZnUXVqcHZDSGQzN3kveU84UXcvSFdEQjNSK3NRa3JsK25pWTM0TFN4dgpNRHR0N1ZqRjg3dFIybXhZOXIxcjBidnRkZG96TGxXVzM4OEFIeURwdEg4eWZVdllwdStWNytUQ0NNV3o1THl4CnNpamZ1TWp6RVBRVlNiQ2ZwczJHbXhSZHRxN1JNcUQzMVl1SnprUnB2QT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
-  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBMDFDYXVCODU0OWpoaDVROWJoMHU3QTBVTDRZSzk0bFh6S2gzTXR3VEpUT21oUFBuCllOZ0xyY3FjbjlYZGVRcnRLdzJ2ZGU0YzY1QzhvUTJ4NlI5ZlgzNGJ6dmpLWHVCNEVJVGhRRm9vN2VDQW5xRjYKbllsMmZTVzA4SUtQc2JGeVRnLzJia1FwR0VjQjcxbG1pbmJydGRmeUt5RXdGZWxNaTRyMW5uaFNzU2dwb3laUgpObmZEcnU0RkYxbnhBREVBakptdFNqL2pQTC9pV3kzZGN3bFltdHI5Ujl1aEVHMlBwdCtkQ2dxSVpGRy8rSHFBCmhPcTk1NEMzWGdwN1ZWMW1sTnZPR2h1bDJKNW1sbytvc3k2VWpOMnRRQWpZaEs5OEVBd3NuMThOMTlXWjVGamwKM1pkQkVhSmZvWW5NVGZaNzNHZndVNHFzdEkrcnp5cDNaS3ViUXdJREFRQUJBb0lCQUhOZndQbmlZck1hU1JqRApRVDhMeEFDeHEyRy9KK0c3SlNyaW1DSTJzbVZQYkEyUE5iZFVmaHZuVWRpYTVnOGVmaHRSbjRrZDlzQlBDQTVPCjhlSThkTkFvaEhwZXIrOVpVM1NCZUpLd0owU3BuTS8vam5qUkF0YVZiZE1iRmVXSTRzWG9SVDR6RE5UcWdBMzAKbTkzaHpCUSswVVBuSE4vNXZ3YzVXWjJxU0V2Y2ljVy9oY0MxMlNOU3k4YkIzTjl6MmFSZEdrd293Wjl6UGgybQo1NWlHa3hwTWxFKzJmMktqdTg4bEZFNUlRcTJ0YkhEeXE3RVJYeGN5UEU2YVdIOXZWdDI4OFRGSmNiMTljalRlCjB2K0ZLRmNOY0owZnRjZTRRNlYyeGJXUXcvRmhIVWJFcnJhblVOMjAyMUFGamIydkMyVG4vZlJYYW5JM05YTG4KU1hYOXJ5RUNnWUVBNDdXL2lYcHVrNDBFa2VYdE9GVnE2RHpWWEhMck1UVFJKUEhMcHJodHVOV0h6Q0g0OEVZcApPYXpCc0dZWjIxSnUzVXRSbzFqSXRZdWdRZXJBWmlRVEZYV2VEYzdyZnlUQTAyOTRTa2Zpa01BRzZBZTA5UzFZCk5hUUxMWFUrUmhKbHVIeXRscnVhL2NWRXdEWGhtNCtBTTZiTTQ1aVlKRTlLd3J2M3FNcjNuL2tDZ1lFQTdaRnEKTUhXZjhvWS9CZ0ZaZHRubTdRM3BmL09EQThwWFRFUFlIQ1dxYUdkTnZHWmJBWXFPUzVGMG1OM1ViR2lWUHFNSgpDVlRaTDJBSCs4TC8ydFFHdURsYk5Ob2t1YkRoZTdvUWkyQUk1SmRMOW1HYlFSVXBmY0dZdURnQkZ2aEUxYS9VClFDQ2o0V1BEUUZpYkRuck4yRHFBOGJaMWUyQ011cVJUL0pnaW5Cc0NnWUFaQTFyeDRCZ0xiejhrUTZ5R05xUFMKdFBQKy9zU2xHQmN0UnI1SEp4VXVhNDVLTnlVZ1I2UzVxQ2R5bUJTWkNmb1JwdmRseVJmckVWWmVSMG94TGg5RwppUy8rZGs5YUhSQnRhVjQrVXAwcHAxNWEySlhoSk1UK3gzRk80Z1VnTDE4ckg4NzFzcy80dGxXeUEza3YzRmlKCjAvWEh2bmhmN0xIYXFFa3hLbkovQ1FLQmdGUmRCRkdySTU2elQ2UXBUSVRwUXBsQ0RINTBrajBCV05qcmFzNHMKRGdTL1VwcXAybjJFbjUxMFRPeVFNZ1JCYTJadjdTQ1VNZ0FoNFJQbG5vZ3VMU2kwclkvcU80cDVwc2tTUFJmUgpoYmJ2aDNrNkZqRVplNzk5eFdiOTlGMGMwd3p6UUxONUk5bEJYUy8zaHpDd0tYTTA2MTlxeFBPSVNORnEwNnhxCnRqZXJBb0dBSmZPMzN2Tk9Ca1RQQnZoaDYyZlE1WmF2VUpvMDhUQ29ZSjdqNnFqT3dSSXI2SVUxbVFUNUhUTUIKZ2RpQlZmVUlVZGhGVTBxZGVraDhua25KWjRWQ2svL0tKRVRLRHpSaXZQd0dvQldpbElIWjAzRytPOHRDeWRLeApkSzNmaDVjTGk3SHFTSXRvazloZnZURVRsUDZ1N1VMOFpNOVRGTnlMK1k1M3UrSmt0Um89Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
 kind: Secret
 metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong-validation-webhook-keypair
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller-validation-webhook-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller-admin-api-keypair
+  namespace: default
+type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller-admin-api-ca-keypair
   namespace: default
 type: kubernetes.io/tls
 ---
@@ -48,11 +92,27 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller
 rules:
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - configuration.konghq.com
+    resources:
+      - kongcustomentities/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -328,17 +388,17 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-kong
+  name: chartsnap-controller
 subjects:
   - kind: ServiceAccount
-    name: chartsnap-kong
+    name: chartsnap-controller
     namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -347,10 +407,10 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller
   namespace: default
 rules:
   - apiGroups:
@@ -411,18 +471,18 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: chartsnap-kong
+  name: chartsnap-controller
 subjects:
   - kind: ServiceAccount
-    name: chartsnap-kong
+    name: chartsnap-controller
     namespace: default
 ---
 apiVersion: v1
@@ -431,10 +491,10 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong-validation-webhook
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller-validation-webhook
   namespace: default
 spec:
   ports:
@@ -446,9 +506,9 @@ spec:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
+    helm.sh/chart: controller-2.39.0
 ---
 apiVersion: v1
 kind: Service
@@ -456,10 +516,34 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong-manager
+    helm.sh/chart: gateway-2.39.0
+  name: chartsnap-gateway-admin
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+    - name: kong-admin-tls
+      port: 8444
+      protocol: TCP
+      targetPort: 8444
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: gateway
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: gateway-2.39.0
+  name: chartsnap-gateway-manager
   namespace: default
 spec:
   ports:
@@ -474,7 +558,7 @@ spec:
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: gateway
   type: NodePort
 ---
 apiVersion: v1
@@ -483,11 +567,11 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong-proxy
+    helm.sh/chart: gateway-2.39.0
+  name: chartsnap-gateway-proxy
   namespace: default
 spec:
   ports:
@@ -502,7 +586,7 @@ spec:
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: gateway
   type: LoadBalancer
 ---
 apiVersion: apps/v1
@@ -512,10 +596,10 @@ metadata:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller
   namespace: default
 spec:
   replicas: 1
@@ -523,21 +607,23 @@ spec:
     matchLabels:
       app.kubernetes.io/component: app
       app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/name: kong
+      app.kubernetes.io/name: controller
   template:
     metadata:
       annotations:
         kuma.io/gateway: enabled
-        kuma.io/service-account-token-volume: chartsnap-kong-token
+        kuma.io/service-account-token-volume: chartsnap-controller-token
+        traffic.kuma.io/exclude-outbound-ports: "8444"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "8444"
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
-        app: chartsnap-kong
+        app: chartsnap-controller
         app.kubernetes.io/component: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: kong
+        app.kubernetes.io/name: controller
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.38.0
+        helm.sh/chart: controller-2.39.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -556,17 +642,23 @@ spec:
                   fieldPath: metadata.namespace
             - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
               value: 0.0.0.0:8080
+            - name: CONTROLLER_ANONYMOUS_REPORTS
+              value: "false"
             - name: CONTROLLER_ELECTION_ID
               value: kong-ingress-controller-leader-kong
             - name: CONTROLLER_INGRESS_CLASS
               value: kong
+            - name: CONTROLLER_KONG_ADMIN_SVC
+              value: default/chartsnap-gateway-admin
+            - name: CONTROLLER_KONG_ADMIN_TLS_CLIENT_CERT_FILE
+              value: /etc/secrets/admin-api-cert/tls.crt
+            - name: CONTROLLER_KONG_ADMIN_TLS_CLIENT_KEY_FILE
+              value: /etc/secrets/admin-api-cert/tls.key
             - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
               value: "true"
-            - name: CONTROLLER_KONG_ADMIN_URL
-              value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
-              value: default/chartsnap-kong-proxy
-          image: kong/kubernetes-ingress-controller:3.1
+              value: default/chartsnap-gateway-proxy
+          image: kong/kubernetes-ingress-controller:3.2
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -615,8 +707,82 @@ spec:
               name: webhook-cert
               readOnly: true
             - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-              name: chartsnap-kong-token
+              name: chartsnap-controller-token
               readOnly: true
+            - mountPath: /etc/secrets/admin-api-cert
+              name: admin-api-cert
+              readOnly: true
+      securityContext: {}
+      serviceAccountName: chartsnap-controller
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-controller-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-controller-tmp
+        - name: chartsnap-controller-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-controller-validation-webhook-keypair
+        - name: admin-api-cert
+          secret:
+            secretName: chartsnap-controller-admin-api-keypair
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/version: "3.6"
+    helm.sh/chart: gateway-2.39.0
+  name: chartsnap-gateway
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: gateway
+  template:
+    metadata:
+      annotations:
+        kuma.io/gateway: enabled
+        kuma.io/service-account-token-volume: chartsnap-gateway-token
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app: chartsnap-gateway
+        app.kubernetes.io/component: app
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: gateway
+        app.kubernetes.io/version: "3.6"
+        helm.sh/chart: gateway-2.39.0
+        version: "3.6"
+    spec:
+      automountServiceAccountToken: false
+      containers:
         - env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout
@@ -627,13 +793,13 @@ spec:
             - name: KONG_ADMIN_GUI_ERROR_LOG
               value: /dev/stderr
             - name: KONG_ADMIN_LISTEN
-              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+              value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
             - name: KONG_CLUSTER_LISTEN
               value: "off"
             - name: KONG_DATABASE
               value: "off"
-            - name: KONG_KIC
-              value: "on"
             - name: KONG_LUA_PACKAGE_PATH
               value: /opt/?.lua;/opt/?/init.lua;;
             - name: KONG_NGINX_WORKER_PROCESSES
@@ -656,6 +822,8 @@ spec:
               value: /dev/stdout basic
             - name: KONG_PROXY_STREAM_ERROR_LOG
               value: /dev/stderr
+            - name: KONG_ROLE
+              value: traditional
             - name: KONG_ROUTER_FLAVOR
               value: traditional
             - name: KONG_STATUS_ACCESS_LOG
@@ -689,6 +857,9 @@ spec:
             timeoutSeconds: 5
           name: proxy
           ports:
+            - containerPort: 8444
+              name: admin-tls
+              protocol: TCP
             - containerPort: 8000
               name: proxy
               protocol: TCP
@@ -721,9 +892,9 @@ spec:
               type: RuntimeDefault
           volumeMounts:
             - mountPath: /kong_prefix/
-              name: chartsnap-kong-prefix-dir
+              name: chartsnap-gateway-prefix-dir
             - mountPath: /tmp
-              name: chartsnap-kong-tmp
+              name: chartsnap-gateway-tmp
       initContainers:
         - command:
             - rm
@@ -739,13 +910,13 @@ spec:
             - name: KONG_ADMIN_GUI_ERROR_LOG
               value: /dev/stderr
             - name: KONG_ADMIN_LISTEN
-              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+              value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
             - name: KONG_CLUSTER_LISTEN
               value: "off"
             - name: KONG_DATABASE
               value: "off"
-            - name: KONG_KIC
-              value: "on"
             - name: KONG_LUA_PACKAGE_PATH
               value: /opt/?.lua;/opt/?/init.lua;;
             - name: KONG_NGINX_WORKER_PROCESSES
@@ -768,6 +939,8 @@ spec:
               value: /dev/stdout basic
             - name: KONG_PROXY_STREAM_ERROR_LOG
               value: /dev/stderr
+            - name: KONG_ROLE
+              value: traditional
             - name: KONG_ROUTER_FLAVOR
               value: traditional
             - name: KONG_STATUS_ACCESS_LOG
@@ -794,20 +967,20 @@ spec:
               type: RuntimeDefault
           volumeMounts:
             - mountPath: /kong_prefix/
-              name: chartsnap-kong-prefix-dir
+              name: chartsnap-gateway-prefix-dir
             - mountPath: /tmp
-              name: chartsnap-kong-tmp
+              name: chartsnap-gateway-tmp
       securityContext: {}
-      serviceAccountName: chartsnap-kong
+      serviceAccountName: chartsnap-gateway
       terminationGracePeriodSeconds: 30
       volumes:
         - emptyDir:
             sizeLimit: 256Mi
-          name: chartsnap-kong-prefix-dir
+          name: chartsnap-gateway-prefix-dir
         - emptyDir:
             sizeLimit: 1Gi
-          name: chartsnap-kong-tmp
-        - name: chartsnap-kong-token
+          name: chartsnap-gateway-tmp
+        - name: chartsnap-gateway-token
           projected:
             sources:
               - serviceAccountToken:
@@ -824,9 +997,6 @@ spec:
                         apiVersion: v1
                         fieldPath: metadata.namespace
                       path: namespace
-        - name: webhook-cert
-          secret:
-            secretName: chartsnap-kong-validation-webhook-keypair
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -834,18 +1004,70 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: kong
+    app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.38.0
-  name: chartsnap-kong-validations
+    helm.sh/chart: controller-2.39.0
+  name: chartsnap-controller-validations
   namespace: default
 webhooks:
   - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
+        name: chartsnap-controller-validation-webhook
+        namespace: default
+    failurePolicy: Ignore
+    matchPolicy: Equivalent
+    name: secrets.credentials.validation.ingress-controller.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: konghq.com/credential
+          operator: Exists
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      caBundle: '###DYNAMIC_FIELD###'
+      service:
+        name: chartsnap-controller-validation-webhook
+        namespace: default
+    failurePolicy: Ignore
+    matchPolicy: Equivalent
+    name: secrets.plugins.validation.ingress-controller.konghq.com
+    objectSelector:
+      matchExpressions:
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - secrets
+    sideEffects: None
+  - admissionReviewVersions:
       - v1beta1
     clientConfig:
-      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKRENDQWd5Z0F3SUJBZ0lSQVBQYTBSOTd4d0xqMHI5d3R0L3REU2N3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUmEyOXVaeTFoWkcxcGMzTnBiMjR0WTJFd0hoY05NalF3TmpFek1UZzFOalUzV2hjTgpNelF3TmpFeE1UZzFOalUzV2pBY01Sb3dHQVlEVlFRREV4RnJiMjVuTFdGa2JXbHpjMmx2YmkxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMbi9vQ0JxdWpIN1Z6d1FnelJ1Z2xoWWhYSkQKWmpZUGd4Tm1IK0c2QzZFYmRBU0VtMkV4MktBdFVMeFJvSkwybzlrK1BVZnhzQ2JQZG80bGtvemtwNXBZRGQwSgprcHhGRFBjRlJoUUw4NTk5bkpjZEpBRkJKTUw1UkM2cEUvci9ZR1MyeFIydnJzTURlM1QzZ2V3QkkrVUovc1RTCk5Rd2VtSUNjWWhOZnRKUVRCeFBGcW41a3drMGV0ZDhOVDBXaDBBWjFwRUZwNEVVekgrdUEyMmZmb1RHR3ZWYjcKRzl2NUx4MzlFMUNhTHZZUnRZQkg1S1cvbGxVeXdFeHRmRlNFNnl0L2lpRUxxbE0yQlc2anlXU2lTdmtpajRXWApUeVRhQkNwUnNzL2M5a0t4OUQxU3J1bnhuTUtxcHBQK25ZNzlnWHJaaURkekFocE9MQzRLQkd0U25BOENBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCU2ZPR1B4U2hjTE90bEtnalp5UGZibgo5ajlXTXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUFTczBZb2Nmc1VQRjM4alBOSmxyMjJibnNIZHJQTGFCCkpaUG9UY1NMd0pHYWI1ZDIvTFJUQlJCWHltWXJWdEIrazhia1ZVdWkxWmMyMzRkaFVYNDYvQW1GT0NHN3duKzAKUTZhdmRUcFppRlY3V3dSRkM2c21aTjkrMG14WUx0aXUrY01yUE9WeHdNeVZpV09JOXNFeEpoVm9EVm5NY1ZzNQpGZmw1SURDaDZaRVpGRk1NQXpsa3haSUNIVTA1enJSNDErcFRua2dTZDh2Z21SODNxdTc0T2RqeGtOb25DdUdRCk5vSTdsTDM0RUNMT2kwLzBPajR6aHQxNTRFMTloMUJiL3krSUh1cWgwQzNMdHpzNDJoei9uYjlCbXlQMEc0d0sKaWlQQWFSNHZycWVzTWd6YWQzYWNIYmdIVDNTQkJmVzFrMWVwWWZqaUFmS2NMWU8xWjdhSG5BPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      caBundle: '###DYNAMIC_FIELD###'
       service:
-        name: chartsnap-kong-validation-webhook
+        name: chartsnap-controller-validation-webhook
         namespace: default
     failurePolicy: Ignore
     name: validations.kong.konghq.com
@@ -876,7 +1098,6 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
-          - secrets
           - services
       - apiGroups:
           - networking.k8s.io

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -4,85 +4,41 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller
-  namespace: default
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.0
-  name: chartsnap-gateway
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
   namespace: default
 ---
 apiVersion: v1
 data:
-  tls.crt: '###DYNAMIC_FIELD###'
-  tls.key: '###DYNAMIC_FIELD###'
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKRENDQWd5Z0F3SUJBZ0lSQVBQYTBSOTd4d0xqMHI5d3R0L3REU2N3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUmEyOXVaeTFoWkcxcGMzTnBiMjR0WTJFd0hoY05NalF3TmpFek1UZzFOalUzV2hjTgpNelF3TmpFeE1UZzFOalUzV2pBY01Sb3dHQVlEVlFRREV4RnJiMjVuTFdGa2JXbHpjMmx2YmkxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMbi9vQ0JxdWpIN1Z6d1FnelJ1Z2xoWWhYSkQKWmpZUGd4Tm1IK0c2QzZFYmRBU0VtMkV4MktBdFVMeFJvSkwybzlrK1BVZnhzQ2JQZG80bGtvemtwNXBZRGQwSgprcHhGRFBjRlJoUUw4NTk5bkpjZEpBRkJKTUw1UkM2cEUvci9ZR1MyeFIydnJzTURlM1QzZ2V3QkkrVUovc1RTCk5Rd2VtSUNjWWhOZnRKUVRCeFBGcW41a3drMGV0ZDhOVDBXaDBBWjFwRUZwNEVVekgrdUEyMmZmb1RHR3ZWYjcKRzl2NUx4MzlFMUNhTHZZUnRZQkg1S1cvbGxVeXdFeHRmRlNFNnl0L2lpRUxxbE0yQlc2anlXU2lTdmtpajRXWApUeVRhQkNwUnNzL2M5a0t4OUQxU3J1bnhuTUtxcHBQK25ZNzlnWHJaaURkekFocE9MQzRLQkd0U25BOENBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCU2ZPR1B4U2hjTE90bEtnalp5UGZibgo5ajlXTXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUFTczBZb2Nmc1VQRjM4alBOSmxyMjJibnNIZHJQTGFCCkpaUG9UY1NMd0pHYWI1ZDIvTFJUQlJCWHltWXJWdEIrazhia1ZVdWkxWmMyMzRkaFVYNDYvQW1GT0NHN3duKzAKUTZhdmRUcFppRlY3V3dSRkM2c21aTjkrMG14WUx0aXUrY01yUE9WeHdNeVZpV09JOXNFeEpoVm9EVm5NY1ZzNQpGZmw1SURDaDZaRVpGRk1NQXpsa3haSUNIVTA1enJSNDErcFRua2dTZDh2Z21SODNxdTc0T2RqeGtOb25DdUdRCk5vSTdsTDM0RUNMT2kwLzBPajR6aHQxNTRFMTloMUJiL3krSUh1cWgwQzNMdHpzNDJoei9uYjlCbXlQMEc0d0sKaWlQQWFSNHZycWVzTWd6YWQzYWNIYmdIVDNTQkJmVzFrMWVwWWZqaUFmS2NMWU8xWjdhSG5BPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBdWYrZ0lHcTZNZnRYUEJDRE5HNkNXRmlGY2tObU5nK0RFMllmNGJvTG9SdDBCSVNiCllUSFlvQzFRdkZHZ2t2YWoyVDQ5Ui9Hd0pzOTJqaVdTak9Tbm1sZ04zUW1TbkVVTTl3VkdGQXZ6bjMyY2x4MGsKQVVFa3d2bEVMcWtUK3Y5Z1pMYkZIYSt1d3dON2RQZUI3QUVqNVFuK3hOSTFEQjZZZ0p4aUUxKzBsQk1IRThXcQpmbVRDVFI2MTN3MVBSYUhRQm5Xa1FXbmdSVE1mNjREYlo5K2hNWWE5VnZzYjIva3ZIZjBUVUpvdTloRzFnRWZrCnBiK1dWVExBVEcxOFZJVHJLMytLSVF1cVV6WUZicVBKWktKSytTS1BoWmRQSk5vRUtsR3l6OXoyUXJIMFBWS3UKNmZHY3dxcW1rLzZkanYyQmV0bUlOM01DR2s0c0xnb0VhMUtjRHdJREFRQUJBb0lCQUN1eDVjZzN5bTRiZ2E3VwpvandiQ2Z2L0w3cGNJeExvS2Y3UXF3UzRWQ3NRNi94enVwem12T0ZFUkFjNWxlTndsYVZmZmIzOUJVall6QjB3CnJuRHk5bnpIMnRubWVjN0VXZnRkL2N5UDBqZlJwb3ZKaUwvU3NmUXI0dHlqVTlKUFZESFV6aEhmUjhzQWNteFUKQ08yTWh3WXpodXB1QjVCRlQ4Wkc5ck5lZEdta2Q2cGlHcVlvZG1GbmxrKyt2T09YcmVVeVlsT2syUXliM1hpTwo1ejdONjJrV2xWUVRPSzRvQjlHL0wyWk9MVjcrYlRrTStRK1JYRTRBcnl3cHM2QldYZ2VxcUhWSkEwSGVsb0hWCnpOUGJURmtNc3RpRGVxazJRQjNaNUc5dHdUZzNrZTY2b1BtTVQrQzVjTlhTbldLekRYeGdzSklNNVc4cVVjek4KdXk4UnIwRUNnWUVBeGE2ZGdrM2R1NVhaNjkrN1FXQkZranR1b3RuU1ZEWTRUendLYWFZSGZUL3BHS2VIYmZJWApLbnQraWJWNko5WTdtMFhxeEtKRERNV1pUKzFwOUM1SGlZR0hLelhVclA2b3R0a3Ixd0dwN3NSeHVYUHV4YjBnCitJdXRmdlZiTUpVWm45cWlrSkxZbVdSTjhJOGtsdnZCbTIwbUc0dEVSbDdQVTBCYkE1WWlqSWNDZ1lFQThONmsKZzlaSmZxdVl1dm9kZ0E1alZWTEZid3dXUFJZRHduSHZHU0x1UUcxSzdpSzB0dDZoZUVSMjc2emJkZWx2RXRxZQpSVUFycVpBdWVGYWVjRjhCdjV3ZjRFaUJSZW1CWlRERUg3Z3JHc0RneXM3NTA1NmxSUVJOa1VkN1QxS1lYRU1XCkJKajlEZzlDUjhHZVQrb29Ba040MEErR2VEa1Nhek5DL1cxcW5qa0NnWUI3dGxtUVVKYXhiSWhpMnpOZktKYWgKZTF3endrbWt0Z0hyWkZISDZFWExscEdVQWxQNDlJYVc2WTQ1TkQ5c2F1QUd2bXk3L2lnaitBMklQYllQUUY4NApxTDBreDUxL1hpZkx0b0YvSHVWd0xiUldNVDErdG12SjMvQUdBaHE5ZnJING5tVWFRU3dZWXZONzFyazVXL2pBCkFrRFZBQVVNWFEwMnRwRyszdGhrUlFLQmdRQ3hNZGlzOC9OVk1EOUhMY0NOK0Flek9SVHRRR01MeFNvMjNVSWIKcDhyRnNxRXcxbTlES0R4NUVVUzl4Tmdkd2dCb1NsT3NkaXlvck56Q3dsWUVMS0JJcVQzNTdOek01WjYvSmtUaApZTWExQTdkYSt6Qm1NWXM3WHBNQmtTaHhqajF2Z2hxc2Z5K0tMRWVDS2ptZ2FJM09QSHlmOHd2bFhYYmpUZTYyCktNd0tZUUtCZ0VjRlpKaUxWTmN6cVpCRG5ZQnRNNFZjdGcyVUk5TUc1d0kyamNYVW8vejFRd1IzN0Z2Mk1WUUwKeUh5aHZpcWtCOWVzNTNDTjVEb0Fqc2lJRGdZb21qdHVQVkRKV2dydEJYS2IzblFVY2NpTWRGazRMaE5FWE13bApXM0l0VkZYNm41QjZicTlHNTNpOGNLYzROVGt0azZkYktWc3VTaXhSY1JsOGRLcmRwSnZyCi0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
 kind: Secret
 metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller-validation-webhook-ca-keypair
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
 ---
 apiVersion: v1
 data:
-  tls.crt: '###DYNAMIC_FIELD###'
-  tls.key: '###DYNAMIC_FIELD###'
+  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURlekNDQW1PZ0F3SUJBZ0lSQUtiQitpVTdHM21XUnVuOENoY0NBME13RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUmEyOXVaeTFoWkcxcGMzTnBiMjR0WTJFd0hoY05NalF3TmpFek1UZzFOalU0V2hjTgpNelF3TmpFeE1UZzFOalU0V2pBNE1UWXdOQVlEVlFRREV5MWphR0Z5ZEhOdVlYQXRhMjl1WnkxMllXeHBaR0YwCmFXOXVMWGRsWW1odmIyc3VaR1ZtWVhWc2RDNXpkbU13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXcKZ2dFS0FvSUJBUURUVUpxNEh6bmoyT0dIbEQxdUhTN3NEUlF2aGdyM2lWZk1xSGN5M0JNbE02YUU4K2RnMkF1dAp5cHlmMWQxNUN1MHJEYTkxN2h6cmtMeWhEYkhwSDE5ZmZodk8rTXBlNEhnUWhPRkFXaWp0NElDZW9YcWRpWFo5CkpiVHdnbyt4c1hKT0QvWnVSQ2tZUndIdldXYUtkdXUxMS9JcklUQVY2VXlMaXZXZWVGS3hLQ21qSmxFMmQ4T3UKN2dVWFdmRUFNUUNNbWExS1ArTTh2K0piTGQxekNWaWEydjFIMjZFUWJZK20zNTBLQ29oa1ViLzRlb0NFNnIzbgpnTGRlQ250VlhXYVUyODRhRzZYWW5tYVdqNml6THBTTTNhMUFDTmlFcjN3UURDeWZYdzNYMVpua1dPWGRsMEVSCm9sK2hpY3hOOW52Y1ovQlRpcXkwajZ2UEtuZGtxNXREQWdNQkFBR2pnWnN3Z1pnd0RnWURWUjBQQVFIL0JBUUQKQWdXZ01CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFNQmdOVkhSTUJBZjhFQWpBQQpNQjhHQTFVZEl3UVlNQmFBRko4NFkvRktGd3M2MlVxQ05uSTk5dWYyUDFZek1EZ0dBMVVkRVFReE1DK0NMV05vCllYSjBjMjVoY0MxcmIyNW5MWFpoYkdsa1lYUnBiMjR0ZDJWaWFHOXZheTVrWldaaGRXeDBMbk4yWXpBTkJna3EKaGtpRzl3MEJBUXNGQUFPQ0FRRUFOdHgyMGxyL2dKRzNCeFNFTXNjR0xYa1d3R0VacHk5MVNPZFdIK05yeTVTcApHdUhBZHB1bnFENmtLVTJTTGRJNkhJTmhPZ2tpcVY1Vlh1SHFneFZJYWNNNUxFT0RPMVF3S2lncXNydHVFYXlZCncrbTl1N0J4RXRNRXl0K2NpNE5DSFYrTnA3NlNYRUFvNmVmbEo3aWV4SGNEeEJJeGtyMVB5eXhzalF2M3dFd0QKVCtPU0lIM09LVUdNTEJqNWRzbzVqM3ZnUXVqcHZDSGQzN3kveU84UXcvSFdEQjNSK3NRa3JsK25pWTM0TFN4dgpNRHR0N1ZqRjg3dFIybXhZOXIxcjBidnRkZG96TGxXVzM4OEFIeURwdEg4eWZVdllwdStWNytUQ0NNV3o1THl4CnNpamZ1TWp6RVBRVlNiQ2ZwczJHbXhSZHRxN1JNcUQzMVl1SnprUnB2QT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
+  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBMDFDYXVCODU0OWpoaDVROWJoMHU3QTBVTDRZSzk0bFh6S2gzTXR3VEpUT21oUFBuCllOZ0xyY3FjbjlYZGVRcnRLdzJ2ZGU0YzY1QzhvUTJ4NlI5ZlgzNGJ6dmpLWHVCNEVJVGhRRm9vN2VDQW5xRjYKbllsMmZTVzA4SUtQc2JGeVRnLzJia1FwR0VjQjcxbG1pbmJydGRmeUt5RXdGZWxNaTRyMW5uaFNzU2dwb3laUgpObmZEcnU0RkYxbnhBREVBakptdFNqL2pQTC9pV3kzZGN3bFltdHI5Ujl1aEVHMlBwdCtkQ2dxSVpGRy8rSHFBCmhPcTk1NEMzWGdwN1ZWMW1sTnZPR2h1bDJKNW1sbytvc3k2VWpOMnRRQWpZaEs5OEVBd3NuMThOMTlXWjVGamwKM1pkQkVhSmZvWW5NVGZaNzNHZndVNHFzdEkrcnp5cDNaS3ViUXdJREFRQUJBb0lCQUhOZndQbmlZck1hU1JqRApRVDhMeEFDeHEyRy9KK0c3SlNyaW1DSTJzbVZQYkEyUE5iZFVmaHZuVWRpYTVnOGVmaHRSbjRrZDlzQlBDQTVPCjhlSThkTkFvaEhwZXIrOVpVM1NCZUpLd0owU3BuTS8vam5qUkF0YVZiZE1iRmVXSTRzWG9SVDR6RE5UcWdBMzAKbTkzaHpCUSswVVBuSE4vNXZ3YzVXWjJxU0V2Y2ljVy9oY0MxMlNOU3k4YkIzTjl6MmFSZEdrd293Wjl6UGgybQo1NWlHa3hwTWxFKzJmMktqdTg4bEZFNUlRcTJ0YkhEeXE3RVJYeGN5UEU2YVdIOXZWdDI4OFRGSmNiMTljalRlCjB2K0ZLRmNOY0owZnRjZTRRNlYyeGJXUXcvRmhIVWJFcnJhblVOMjAyMUFGamIydkMyVG4vZlJYYW5JM05YTG4KU1hYOXJ5RUNnWUVBNDdXL2lYcHVrNDBFa2VYdE9GVnE2RHpWWEhMck1UVFJKUEhMcHJodHVOV0h6Q0g0OEVZcApPYXpCc0dZWjIxSnUzVXRSbzFqSXRZdWdRZXJBWmlRVEZYV2VEYzdyZnlUQTAyOTRTa2Zpa01BRzZBZTA5UzFZCk5hUUxMWFUrUmhKbHVIeXRscnVhL2NWRXdEWGhtNCtBTTZiTTQ1aVlKRTlLd3J2M3FNcjNuL2tDZ1lFQTdaRnEKTUhXZjhvWS9CZ0ZaZHRubTdRM3BmL09EQThwWFRFUFlIQ1dxYUdkTnZHWmJBWXFPUzVGMG1OM1ViR2lWUHFNSgpDVlRaTDJBSCs4TC8ydFFHdURsYk5Ob2t1YkRoZTdvUWkyQUk1SmRMOW1HYlFSVXBmY0dZdURnQkZ2aEUxYS9VClFDQ2o0V1BEUUZpYkRuck4yRHFBOGJaMWUyQ011cVJUL0pnaW5Cc0NnWUFaQTFyeDRCZ0xiejhrUTZ5R05xUFMKdFBQKy9zU2xHQmN0UnI1SEp4VXVhNDVLTnlVZ1I2UzVxQ2R5bUJTWkNmb1JwdmRseVJmckVWWmVSMG94TGg5RwppUy8rZGs5YUhSQnRhVjQrVXAwcHAxNWEySlhoSk1UK3gzRk80Z1VnTDE4ckg4NzFzcy80dGxXeUEza3YzRmlKCjAvWEh2bmhmN0xIYXFFa3hLbkovQ1FLQmdGUmRCRkdySTU2elQ2UXBUSVRwUXBsQ0RINTBrajBCV05qcmFzNHMKRGdTL1VwcXAybjJFbjUxMFRPeVFNZ1JCYTJadjdTQ1VNZ0FoNFJQbG5vZ3VMU2kwclkvcU80cDVwc2tTUFJmUgpoYmJ2aDNrNkZqRVplNzk5eFdiOTlGMGMwd3p6UUxONUk5bEJYUy8zaHpDd0tYTTA2MTlxeFBPSVNORnEwNnhxCnRqZXJBb0dBSmZPMzN2Tk9Ca1RQQnZoaDYyZlE1WmF2VUpvMDhUQ29ZSjdqNnFqT3dSSXI2SVUxbVFUNUhUTUIKZ2RpQlZmVUlVZGhGVTBxZGVraDhua25KWjRWQ2svL0tKRVRLRHpSaXZQd0dvQldpbElIWjAzRytPOHRDeWRLeApkSzNmaDVjTGk3SHFTSXRvazloZnZURVRsUDZ1N1VMOFpNOVRGTnlMK1k1M3UrSmt0Um89Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
 kind: Secret
 metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller-validation-webhook-keypair
-  namespace: default
-type: kubernetes.io/tls
----
-apiVersion: v1
-data:
-  tls.crt: '###DYNAMIC_FIELD###'
-  tls.key: '###DYNAMIC_FIELD###'
-kind: Secret
-metadata:
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller-admin-api-keypair
-  namespace: default
-type: kubernetes.io/tls
----
-apiVersion: v1
-data:
-  tls.crt: '###DYNAMIC_FIELD###'
-  tls.key: '###DYNAMIC_FIELD###'
-kind: Secret
-metadata:
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller-admin-api-ca-keypair
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
 ---
@@ -92,27 +48,11 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
 rules:
-  - apiGroups:
-      - configuration.konghq.com
-    resources:
-      - kongcustomentities
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - configuration.konghq.com
-    resources:
-      - kongcustomentities/status
-    verbs:
-      - get
-      - patch
-      - update
   - apiGroups:
       - configuration.konghq.com
     resources:
@@ -388,17 +328,17 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: chartsnap-controller
+  name: chartsnap-kong
 subjects:
   - kind: ServiceAccount
-    name: chartsnap-controller
+    name: chartsnap-kong
     namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -407,10 +347,10 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
   namespace: default
 rules:
   - apiGroups:
@@ -471,18 +411,18 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: chartsnap-controller
+  name: chartsnap-kong
 subjects:
   - kind: ServiceAccount
-    name: chartsnap-controller
+    name: chartsnap-kong
     namespace: default
 ---
 apiVersion: v1
@@ -491,10 +431,10 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller-validation-webhook
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
   ports:
@@ -506,9 +446,9 @@ spec:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
+    helm.sh/chart: kong-2.38.0
 ---
 apiVersion: v1
 kind: Service
@@ -516,34 +456,10 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: gateway
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.0
-  name: chartsnap-gateway-admin
-  namespace: default
-spec:
-  clusterIP: None
-  ports:
-    - name: kong-admin-tls
-      port: 8444
-      protocol: TCP
-      targetPort: 8444
-  selector:
-    app.kubernetes.io/component: app
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: gateway
-  type: ClusterIP
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.0
-  name: chartsnap-gateway-manager
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-manager
   namespace: default
 spec:
   ports:
@@ -558,7 +474,7 @@ spec:
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: gateway
+    app.kubernetes.io/name: kong
   type: NodePort
 ---
 apiVersion: v1
@@ -567,11 +483,11 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: gateway
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: gateway-2.39.0
-  name: chartsnap-gateway-proxy
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-proxy
   namespace: default
 spec:
   ports:
@@ -586,7 +502,7 @@ spec:
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/name: gateway
+    app.kubernetes.io/name: kong
   type: LoadBalancer
 ---
 apiVersion: apps/v1
@@ -596,10 +512,10 @@ metadata:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong
   namespace: default
 spec:
   replicas: 1
@@ -607,23 +523,21 @@ spec:
     matchLabels:
       app.kubernetes.io/component: app
       app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/name: controller
+      app.kubernetes.io/name: kong
   template:
     metadata:
       annotations:
         kuma.io/gateway: enabled
-        kuma.io/service-account-token-volume: chartsnap-controller-token
-        traffic.kuma.io/exclude-outbound-ports: "8444"
-        traffic.sidecar.istio.io/excludeOutboundPorts: "8444"
+        kuma.io/service-account-token-volume: chartsnap-kong-token
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
-        app: chartsnap-controller
+        app: chartsnap-kong
         app.kubernetes.io/component: app
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: controller
+        app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: controller-2.39.0
+        helm.sh/chart: kong-2.38.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -642,23 +556,17 @@ spec:
                   fieldPath: metadata.namespace
             - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
               value: 0.0.0.0:8080
-            - name: CONTROLLER_ANONYMOUS_REPORTS
-              value: "false"
             - name: CONTROLLER_ELECTION_ID
               value: kong-ingress-controller-leader-kong
             - name: CONTROLLER_INGRESS_CLASS
               value: kong
-            - name: CONTROLLER_KONG_ADMIN_SVC
-              value: default/chartsnap-gateway-admin
-            - name: CONTROLLER_KONG_ADMIN_TLS_CLIENT_CERT_FILE
-              value: /etc/secrets/admin-api-cert/tls.crt
-            - name: CONTROLLER_KONG_ADMIN_TLS_CLIENT_KEY_FILE
-              value: /etc/secrets/admin-api-cert/tls.key
             - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
               value: "true"
+            - name: CONTROLLER_KONG_ADMIN_URL
+              value: https://localhost:8444
             - name: CONTROLLER_PUBLISH_SERVICE
-              value: default/chartsnap-gateway-proxy
-          image: kong/kubernetes-ingress-controller:3.2
+              value: default/chartsnap-kong-proxy
+          image: kong/kubernetes-ingress-controller:3.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -707,82 +615,8 @@ spec:
               name: webhook-cert
               readOnly: true
             - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-              name: chartsnap-controller-token
+              name: chartsnap-kong-token
               readOnly: true
-            - mountPath: /etc/secrets/admin-api-cert
-              name: admin-api-cert
-              readOnly: true
-      securityContext: {}
-      serviceAccountName: chartsnap-controller
-      terminationGracePeriodSeconds: 30
-      volumes:
-        - emptyDir:
-            sizeLimit: 256Mi
-          name: chartsnap-controller-prefix-dir
-        - emptyDir:
-            sizeLimit: 1Gi
-          name: chartsnap-controller-tmp
-        - name: chartsnap-controller-token
-          projected:
-            sources:
-              - serviceAccountToken:
-                  expirationSeconds: 3607
-                  path: token
-              - configMap:
-                  items:
-                    - key: ca.crt
-                      path: ca.crt
-                  name: kube-root-ca.crt
-              - downwardAPI:
-                  items:
-                    - fieldRef:
-                        apiVersion: v1
-                        fieldPath: metadata.namespace
-                      path: namespace
-        - name: webhook-cert
-          secret:
-            secretName: chartsnap-controller-validation-webhook-keypair
-        - name: admin-api-cert
-          secret:
-            secretName: chartsnap-controller-admin-api-keypair
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app.kubernetes.io/component: app
-    app.kubernetes.io/instance: chartsnap
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.0
-  name: chartsnap-gateway
-  namespace: default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: app
-      app.kubernetes.io/instance: chartsnap
-      app.kubernetes.io/name: gateway
-  template:
-    metadata:
-      annotations:
-        kuma.io/gateway: enabled
-        kuma.io/service-account-token-volume: chartsnap-gateway-token
-        traffic.sidecar.istio.io/includeInboundPorts: ""
-      labels:
-        app: chartsnap-gateway
-        app.kubernetes.io/component: app
-        app.kubernetes.io/instance: chartsnap
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: gateway
-        app.kubernetes.io/version: "3.6"
-        helm.sh/chart: gateway-2.39.0
-        version: "3.6"
-    spec:
-      automountServiceAccountToken: false
-      containers:
         - env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout
@@ -793,13 +627,13 @@ spec:
             - name: KONG_ADMIN_GUI_ERROR_LOG
               value: /dev/stderr
             - name: KONG_ADMIN_LISTEN
-              value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
-            - name: KONG_ANONYMOUS_REPORTS
-              value: "off"
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
             - name: KONG_CLUSTER_LISTEN
               value: "off"
             - name: KONG_DATABASE
               value: "off"
+            - name: KONG_KIC
+              value: "on"
             - name: KONG_LUA_PACKAGE_PATH
               value: /opt/?.lua;/opt/?/init.lua;;
             - name: KONG_NGINX_WORKER_PROCESSES
@@ -822,8 +656,6 @@ spec:
               value: /dev/stdout basic
             - name: KONG_PROXY_STREAM_ERROR_LOG
               value: /dev/stderr
-            - name: KONG_ROLE
-              value: traditional
             - name: KONG_ROUTER_FLAVOR
               value: traditional
             - name: KONG_STATUS_ACCESS_LOG
@@ -857,9 +689,6 @@ spec:
             timeoutSeconds: 5
           name: proxy
           ports:
-            - containerPort: 8444
-              name: admin-tls
-              protocol: TCP
             - containerPort: 8000
               name: proxy
               protocol: TCP
@@ -892,9 +721,9 @@ spec:
               type: RuntimeDefault
           volumeMounts:
             - mountPath: /kong_prefix/
-              name: chartsnap-gateway-prefix-dir
+              name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
-              name: chartsnap-gateway-tmp
+              name: chartsnap-kong-tmp
       initContainers:
         - command:
             - rm
@@ -910,13 +739,13 @@ spec:
             - name: KONG_ADMIN_GUI_ERROR_LOG
               value: /dev/stderr
             - name: KONG_ADMIN_LISTEN
-              value: 0.0.0.0:8444 http2 ssl, [::]:8444 http2 ssl
-            - name: KONG_ANONYMOUS_REPORTS
-              value: "off"
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
             - name: KONG_CLUSTER_LISTEN
               value: "off"
             - name: KONG_DATABASE
               value: "off"
+            - name: KONG_KIC
+              value: "on"
             - name: KONG_LUA_PACKAGE_PATH
               value: /opt/?.lua;/opt/?/init.lua;;
             - name: KONG_NGINX_WORKER_PROCESSES
@@ -939,8 +768,6 @@ spec:
               value: /dev/stdout basic
             - name: KONG_PROXY_STREAM_ERROR_LOG
               value: /dev/stderr
-            - name: KONG_ROLE
-              value: traditional
             - name: KONG_ROUTER_FLAVOR
               value: traditional
             - name: KONG_STATUS_ACCESS_LOG
@@ -967,20 +794,20 @@ spec:
               type: RuntimeDefault
           volumeMounts:
             - mountPath: /kong_prefix/
-              name: chartsnap-gateway-prefix-dir
+              name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
-              name: chartsnap-gateway-tmp
+              name: chartsnap-kong-tmp
       securityContext: {}
-      serviceAccountName: chartsnap-gateway
+      serviceAccountName: chartsnap-kong
       terminationGracePeriodSeconds: 30
       volumes:
         - emptyDir:
             sizeLimit: 256Mi
-          name: chartsnap-gateway-prefix-dir
+          name: chartsnap-kong-prefix-dir
         - emptyDir:
             sizeLimit: 1Gi
-          name: chartsnap-gateway-tmp
-        - name: chartsnap-gateway-token
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
           projected:
             sources:
               - serviceAccountToken:
@@ -997,6 +824,9 @@ spec:
                         apiVersion: v1
                         fieldPath: metadata.namespace
                       path: namespace
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -1004,70 +834,18 @@ metadata:
   labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: controller
+    app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.0
-  name: chartsnap-controller-validations
+    helm.sh/chart: kong-2.38.0
+  name: chartsnap-kong-validations
   namespace: default
 webhooks:
   - admissionReviewVersions:
-      - v1
-    clientConfig:
-      caBundle: '###DYNAMIC_FIELD###'
-      service:
-        name: chartsnap-controller-validation-webhook
-        namespace: default
-    failurePolicy: Ignore
-    matchPolicy: Equivalent
-    name: secrets.credentials.validation.ingress-controller.konghq.com
-    objectSelector:
-      matchExpressions:
-        - key: konghq.com/credential
-          operator: Exists
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - secrets
-    sideEffects: None
-  - admissionReviewVersions:
-      - v1
-    clientConfig:
-      caBundle: '###DYNAMIC_FIELD###'
-      service:
-        name: chartsnap-controller-validation-webhook
-        namespace: default
-    failurePolicy: Ignore
-    matchPolicy: Equivalent
-    name: secrets.plugins.validation.ingress-controller.konghq.com
-    objectSelector:
-      matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
-    rules:
-      - apiGroups:
-          - ""
-        apiVersions:
-          - v1
-        operations:
-          - CREATE
-          - UPDATE
-        resources:
-          - secrets
-    sideEffects: None
-  - admissionReviewVersions:
       - v1beta1
     clientConfig:
-      caBundle: '###DYNAMIC_FIELD###'
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURKRENDQWd5Z0F3SUJBZ0lSQVBQYTBSOTd4d0xqMHI5d3R0L3REU2N3RFFZSktvWklodmNOQVFFTEJRQXcKSERFYU1CZ0dBMVVFQXhNUmEyOXVaeTFoWkcxcGMzTnBiMjR0WTJFd0hoY05NalF3TmpFek1UZzFOalUzV2hjTgpNelF3TmpFeE1UZzFOalUzV2pBY01Sb3dHQVlEVlFRREV4RnJiMjVuTFdGa2JXbHpjMmx2YmkxallUQ0NBU0l3CkRRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFMbi9vQ0JxdWpIN1Z6d1FnelJ1Z2xoWWhYSkQKWmpZUGd4Tm1IK0c2QzZFYmRBU0VtMkV4MktBdFVMeFJvSkwybzlrK1BVZnhzQ2JQZG80bGtvemtwNXBZRGQwSgprcHhGRFBjRlJoUUw4NTk5bkpjZEpBRkJKTUw1UkM2cEUvci9ZR1MyeFIydnJzTURlM1QzZ2V3QkkrVUovc1RTCk5Rd2VtSUNjWWhOZnRKUVRCeFBGcW41a3drMGV0ZDhOVDBXaDBBWjFwRUZwNEVVekgrdUEyMmZmb1RHR3ZWYjcKRzl2NUx4MzlFMUNhTHZZUnRZQkg1S1cvbGxVeXdFeHRmRlNFNnl0L2lpRUxxbE0yQlc2anlXU2lTdmtpajRXWApUeVRhQkNwUnNzL2M5a0t4OUQxU3J1bnhuTUtxcHBQK25ZNzlnWHJaaURkekFocE9MQzRLQkd0U25BOENBd0VBCkFhTmhNRjh3RGdZRFZSMFBBUUgvQkFRREFnS2tNQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUYKQlFjREFqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCU2ZPR1B4U2hjTE90bEtnalp5UGZibgo5ajlXTXpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQUFTczBZb2Nmc1VQRjM4alBOSmxyMjJibnNIZHJQTGFCCkpaUG9UY1NMd0pHYWI1ZDIvTFJUQlJCWHltWXJWdEIrazhia1ZVdWkxWmMyMzRkaFVYNDYvQW1GT0NHN3duKzAKUTZhdmRUcFppRlY3V3dSRkM2c21aTjkrMG14WUx0aXUrY01yUE9WeHdNeVZpV09JOXNFeEpoVm9EVm5NY1ZzNQpGZmw1SURDaDZaRVpGRk1NQXpsa3haSUNIVTA1enJSNDErcFRua2dTZDh2Z21SODNxdTc0T2RqeGtOb25DdUdRCk5vSTdsTDM0RUNMT2kwLzBPajR6aHQxNTRFMTloMUJiL3krSUh1cWgwQzNMdHpzNDJoei9uYjlCbXlQMEc0d0sKaWlQQWFSNHZycWVzTWd6YWQzYWNIYmdIVDNTQkJmVzFrMWVwWWZqaUFmS2NMWU8xWjdhSG5BPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
       service:
-        name: chartsnap-controller-validation-webhook
+        name: chartsnap-kong-validation-webhook
         namespace: default
     failurePolicy: Ignore
     name: validations.kong.konghq.com
@@ -1098,6 +876,7 @@ webhooks:
           - CREATE
           - UPDATE
         resources:
+          - secrets
           - services
       - apiGroups:
           - networking.k8s.io

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.39.1
+
+### Fixed
+
+* Added missing `KongCustomEntity` CRD for KIC 3.2.
+
 ## 2.39.0
 
 ### Changes

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.39.0
+version: 2.39.1
 appVersion: "3.6"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-admin
   namespace: default
 spec:
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -119,7 +119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -143,7 +143,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -858,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -371,7 +371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -436,7 +436,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -484,7 +484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -513,7 +513,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -542,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -566,7 +566,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -866,7 +866,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -858,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -511,7 +511,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -539,7 +539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -562,7 +562,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -861,7 +861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -887,7 +887,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -511,7 +511,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -539,7 +539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -562,7 +562,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -861,7 +861,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -889,7 +889,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -852,7 +852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -876,7 +876,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -364,7 +364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -447,7 +447,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -467,7 +467,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -482,7 +482,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -492,7 +492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -520,7 +520,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -548,7 +548,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -571,7 +571,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -870,7 +870,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -929,7 +929,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +433,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +448,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -486,7 +486,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -514,7 +514,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -537,7 +537,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -842,7 +842,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -555,7 +555,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -854,7 +854,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: my-kong-sa
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -852,7 +852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -858,7 +858,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4.0.0-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -97,7 +97,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -553,7 +553,7 @@ spec:
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
         environment: test
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -895,7 +895,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -921,7 +921,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -945,7 +945,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -78,7 +78,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -90,7 +90,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -149,7 +149,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -232,7 +232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-default
   namespace: default
 rules:
@@ -482,7 +482,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-default
   namespace: default
 roleRef:
@@ -572,7 +572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -587,7 +587,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -625,7 +625,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -661,7 +661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -689,7 +689,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1318,7 +1318,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1551,7 +1551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1575,7 +1575,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1704,7 +1704,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1720,7 +1720,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1959,7 +1959,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -1975,7 +1975,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -120,7 +120,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -128,7 +128,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -366,7 +366,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -71,7 +71,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -83,7 +83,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -379,7 +379,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -547,7 +547,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
 ---
 apiVersion: v1
 kind: Service
@@ -557,7 +557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -613,7 +613,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -641,7 +641,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1241,7 +1241,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1459,7 +1459,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1483,7 +1483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1611,7 +1611,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1627,7 +1627,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1851,7 +1851,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.39.0
+    helm.sh/chart: kong-2.39.1
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -1867,7 +1867,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.39.0
+        helm.sh/chart: kong-2.39.1
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/crds/custom-resource-definitions.yaml
+++ b/charts/kong/crds/custom-resource-definitions.yaml
@@ -1,9 +1,8 @@
-# generated using: kubectl kustomize 'github.com/kong/kubernetes-ingress-controller/config/crd?ref=v3.1.0'
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: ingressclassparameterses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -60,7 +59,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -381,7 +380,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -528,7 +527,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -574,6 +573,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           credentials:
             description: |-
               Credentials are references to secrets containing a credential to be
@@ -581,6 +581,7 @@ spec:
             items:
               type: string
             type: array
+            x-kubernetes-list-type: set
           custom_id:
             description: |-
               CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping
@@ -704,7 +705,204 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: kongcustomentities.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongCustomEntity
+    listKind: KongCustomEntityList
+    plural: kongcustomentities
+    shortNames:
+    - kce
+    singular: kongcustomentity
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: type of the Kong entity
+      jsonPath: .spec.type
+      name: Entity Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCustomEntity defines a "custom" Kong entity that KIC cannot
+          support the entity type directly.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              controllerName:
+                description: ControllerName specifies the controller that should reconcile
+                  it, like ingress class.
+                type: string
+              fields:
+                description: Fields defines the fields of the Kong entity itself.
+                x-kubernetes-preserve-unknown-fields: true
+              parentRef:
+                description: |-
+                  ParentRef references the kubernetes resource it attached to when its scope is "attached".
+                  Currently only KongPlugin/KongClusterPlugin allowed. This will make the custom entity to be attached
+                  to the entity(service/route/consumer) where the plugin is attached.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    description: Empty namespace means the same namespace of the owning
+                      object.
+                    type: string
+                required:
+                - name
+                type: object
+              type:
+                description: EntityType is the type of the Kong entity. The type is
+                  used in generating declarative configuration.
+                type: string
+            required:
+            - controllerName
+            - fields
+            - type
+            type: object
+          status:
+            description: Status stores the reconciling status of the resource.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the KongCustomEntityStatus.
+
+
+                  Known condition types are:
+
+
+                  * "Programmed"
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            required:
+            - conditions
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: The spec.type field is immutable
+          rule: self.spec.type == oldSelf.spec.type
+        - message: The spec.type field cannot be known Kong entity types
+          rule: '!(self.spec.type in [''services'',''routes'',''upstreams'',''targets'',''plugins'',''consumers'',''consumer_groups''])'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1095,7 +1293,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1308,7 +1506,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1623,7 +1821,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   labels:
     gateway.networking.k8s.io/policy: direct
   name: kongupstreampolicies.configuration.konghq.com
@@ -2070,7 +2268,7 @@ spec:
 
 
                             * Gateway (Gateway conformance profile)
-                            * Service (Mesh conformance profile, experimental, ClusterIP Services only)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
 
 
                             Support for other resources is Implementation-Specific.
@@ -2156,9 +2354,6 @@ spec:
 
 
                             Support: Extended
-
-
-                            <gateway:experimental>
                           format: int32
                           maximum: 65535
                           minimum: 1
@@ -2169,14 +2364,12 @@ spec:
                             following resources, SectionName is interpreted as the following:
 
 
-                            * Gateway: Listener Name. When both Port (experimental) and SectionName
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
                             both specified values.
-                            * Service: Port Name. When both Port (experimental) and SectionName
+                            * Service: Port name. When both Port (experimental) and SectionName
                             are specified, the name and port of the selected listener must match
-                            both specified values. Note that attaching Routes to Services as Parents
-                            is part of experimental Mesh support and is not supported for any other
-                            purpose.
+                            both specified values.
 
 
                             Implementations MAY choose to support attaching Routes to other resources.
@@ -2366,7 +2559,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2563,7 +2756,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: tcpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2759,6 +2952,7 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
             type: object
         type: object
@@ -2771,7 +2965,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: udpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2931,6 +3125,7 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     type: array
+                    x-kubernetes-list-type: atomic
                 type: object
             type: object
         type: object


### PR DESCRIPTION
Adds the 3.2 CRDs, including `KongCustomEntity`.

Releases kong chart 2.39.1.