### PR TITLE
fix(helpers) KONG_PORT_MAPS value for tls overrideServiceTarget port

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -337,7 +337,11 @@ Parameters: takes a service (e.g. .Values.proxy) as its argument and returns KON
   {{- end -}}
 
   {{- if .tls.enabled -}}
+  {{- if .tls.overrideServiceTargetPort -}}
+        {{- $portMaps = append $portMaps (printf "%d:%d" (int64 .tls.servicePort) (int64 .tls.overrideServiceTargetPort)) -}}
+  {{- else -}}
         {{- $portMaps = append $portMaps (printf "%d:%d" (int64 .tls.servicePort) (int64 .tls.containerPort)) -}}
+  {{- end -}}
   {{- end -}}
 
   {{- $portMapsString := ($portMaps | join ", ") -}}


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:
Currently KONG_PORT_MAPS uses the acutal tls serviceTargetPort even if overrideServiceTarget port is specified. This PR addresses the same, it uses tls overrideServiceTarget value when overrideServiceTarget is given.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [X] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
