### PR TITLE
feat(servicemonitor) add relabeling to ServiceMonitor

### DIFF
--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.39.2
+  version: 2.39.3
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.39.2
-digest: sha256:8315768656a2f2ea8c7288d3fd21cce81fd04c841bc9b36e71610aeea099eea6
-generated: "2024-06-17T13:19:37.766002+02:00"
+  version: 2.39.3
+digest: sha256:a96d25641b9de9ade430c5e290007cab5bff2d1e50c30e961f35ef6a631259fd
+generated: "2024-06-19T11:50:38.361756194+02:00"

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.2
+    helm.sh/chart: gateway-2.39.3
   name: chartsnap-gateway
   namespace: default
 ---
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -65,7 +65,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller-admin-api-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller-admin-api-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -94,7 +94,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller
 rules:
   - apiGroups:
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -409,7 +409,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller
   namespace: default
 rules:
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller
   namespace: default
 roleRef:
@@ -493,7 +493,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller-validation-webhook
   namespace: default
 spec:
@@ -508,7 +508,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
 ---
 apiVersion: v1
 kind: Service
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.2
+    helm.sh/chart: gateway-2.39.3
   name: chartsnap-gateway-admin
   namespace: default
 spec:
@@ -542,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.2
+    helm.sh/chart: gateway-2.39.3
   name: chartsnap-gateway-manager
   namespace: default
 spec:
@@ -570,7 +570,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: gateway-2.39.2
+    helm.sh/chart: gateway-2.39.3
   name: chartsnap-gateway-proxy
   namespace: default
 spec:
@@ -598,7 +598,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller
   namespace: default
 spec:
@@ -623,7 +623,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: controller
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: controller-2.39.2
+        helm.sh/chart: controller-2.39.3
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: gateway-2.39.2
+    helm.sh/chart: gateway-2.39.3
   name: chartsnap-gateway
   namespace: default
 spec:
@@ -778,7 +778,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: gateway
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: gateway-2.39.2
+        helm.sh/chart: gateway-2.39.3
         version: "3.6"
     spec:
       automountServiceAccountToken: false
@@ -1006,7 +1006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: controller-2.39.2
+    helm.sh/chart: controller-2.39.3
   name: chartsnap-controller-validations
   namespace: default
 webhooks:

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Nothing yet.
+* Added support for ServiceMonitor relabelings allowing labels manipulation before scraping.
 
 ## 2.39.3
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -912,6 +912,7 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | serviceMonitor.targetLabels        | ServiceMonitor targetLabels                                                           | `{}`                |
 | serviceMonitor.honorLabels         | ServiceMonitor honorLabels                                                            | `{}`                |
 | serviceMonitor.metricRelabelings   | ServiceMonitor metricRelabelings                                                      | `{}`                |
+| serviceMonitor.relabelings         | ServiceMonitor relabelings                                                            | `[]`                |
 | extraConfigMaps                    | ConfigMaps to add to mounted volumes                                                  | `[]`                |
 | extraSecrets                       | Secrets to add to mounted volumes                                                     | `[]`                |
 | nameOverride                       | Replaces "kong" in resource names, like "RELEASENAME-nameOverride" instead of "RELEASENAME-kong" | `""`                |

--- a/charts/kong/templates/servicemonitor.yaml
+++ b/charts/kong/templates/servicemonitor.yaml
@@ -24,6 +24,9 @@ spec:
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
     {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
   {{- if and .Values.ingressController.enabled (semverCompare ">= 2.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
   - targetPort: cmetrics
     scheme: http
@@ -35,6 +38,9 @@ spec:
     {{- end }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings: {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings: {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
     {{- end }}
   {{- end }}
   jobLabel: {{ .Release.Name }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -1007,6 +1007,7 @@ serviceMonitor:
 
   # honorLabels: false
   # metricRelabelings: []
+  # relabelings: []
 
 # -----------------------------------------------------------------------------
 # Kong Enterprise parameters


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

This PR adds support for ServiceMonitor relabeling option allowing for manipulation of labels before scraping.

#### Special notes for your reviewer:

relabelings is linked to the `RelabelConfigs`, which is applied to samples before scraping. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
