### PR TITLE
chore(ci) add kong-3.x and dispatch triggers for the test workflows

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -11,7 +11,9 @@ on:
     branches:
       - main
       - release/kong-2.x
+      - release/kong-3.x
       - prepare-kgo-chart
+    workflow_dispatch: {}
 
 env:
   # Specify this here because these tests rely on ktf to run kind for cluster creation.


### PR DESCRIPTION
#### What this PR does / why we need it:

Add kong-3.x release branch to the PR checks conditions. Want to run them for https://github.com/Kong/charts/pull/976 and following to the 3.x branch.

Add dispatch option to the PR checks because ey why not. Having the ability to run tests on things that aren't normally in the trigger pipeline is useful.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- ~Changes are documented under the "Unreleased" header in CHANGELOG.md~
- ~New or modified sections of values.yaml are documented in the README.md~
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
