### PR TITLE
feat(kong): add revisionHistoryLimit value

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Add `revisionHistoryLimit` value to set the number of replicasets wants to keep.
+* Add `deployment.revisionHistoryLimit` to set how many old `ReplicaSet`s you want to retain.
 
 ### Changes
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add `revisionHistoryLimit` value to set the number of replicasets wants to keep.
+
 ### Changes
 
 * Added support for ServiceMonitor relabelings allowing labels manipulation before scraping.

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -614,7 +614,6 @@ directory.
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true       | `1`                 |
-| revisionHistoryLimit               | The number of replicasets will be retain                                              | `10`                |
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | customEnv                          | Custom Environment variables without `KONG_` prefix                                   |                     |
@@ -862,6 +861,7 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
+| deployment.revisionHistoryLimit    | The number of replicasets will be retain                                              | `10`                |
 | deployment.minReadySeconds         | Minimum number of seconds for which newly created pods should be ready without any of its container crashing, for it to be considered available. |                     |
 | deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |
 | deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -614,6 +614,7 @@ directory.
 | image.pullPolicy                   | Image pull policy                                                                     | `IfNotPresent`      |
 | image.pullSecrets                  | Image pull secrets                                                                    | `null`              |
 | replicaCount                       | Kong instance count. It has no effect when `autoscaling.enabled` is set to true       | `1`                 |
+| revisionHistoryLimit               | The number of replicasets will be retain                                              | `10`                |
 | plugins                            | Install custom plugins into Kong via ConfigMaps or Secrets                            | `{}`                |
 | env                                | Additional [Kong configurations](https://getkong.org/docs/latest/configuration/)      |                     |
 | customEnv                          | Custom Environment variables without `KONG_` prefix                                   |                     |

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -861,7 +861,7 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
-| deployment.revisionHistoryLimit    | The number of replicasets will be retain                                              | `10`                |
+| deployment.revisionHistoryLimit    | The number of `ReplicaSet`s to retain.                                              | `10`                |
 | deployment.minReadySeconds         | Minimum number of seconds for which newly created pods should be ready without any of its container crashing, for it to be considered available. |                     |
 | deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |
 | deployment.daemonset               | Use a DaemonSet instead of a Deployment                                               | `false`             |

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -124,6 +124,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -535,6 +535,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -547,6 +547,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -535,6 +535,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
@@ -133,6 +133,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
@@ -133,6 +133,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -544,6 +544,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -544,6 +544,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -535,6 +535,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -553,6 +553,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -519,6 +519,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -537,6 +537,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -535,6 +535,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -535,6 +535,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -79,6 +79,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -534,6 +534,7 @@ metadata:
   name: chartsnap-kong
   namespace: default
 spec:
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -666,6 +666,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -101,6 +101,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -109,6 +109,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -618,6 +618,7 @@ metadata:
   namespace: default
 spec:
   replicas: 1
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: app

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -23,7 +23,9 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   {{- end }}
-  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- if .Values.deployment.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "kong.selectorLabels" . | nindent 6 }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "kong.selectorLabels" . | nindent 6 }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -19,7 +19,6 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
-  
   # The number of old `ReplicaSet`s to retain.
   revisionHistoryLimit: 10
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -20,7 +20,7 @@ deployment:
     # controller-only release.
     enabled: true
   
-  # The number of replicasets will be retain
+  # The number of old `ReplicaSet`s to retain.
   revisionHistoryLimit: 10
 
   ## Minimum number of seconds for which a newly created pod should be ready without any of its container crashing,

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -903,6 +903,9 @@ podLabels: {}
 # It has no effect when autoscaling.enabled is set to true
 replicaCount: 1
 
+# The number of replicasets will be retain
+revisionHistoryLimit: 10
+
 # Annotations to be added to Kong deployment
 deploymentAnnotations: {}
 

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -19,6 +19,10 @@ deployment:
     # Setting this to false with ingressController.enabled=true will create a
     # controller-only release.
     enabled: true
+  
+  # The number of replicasets will be retain
+  revisionHistoryLimit: 10
+
   ## Minimum number of seconds for which a newly created pod should be ready without any of its container crashing,
   ## for it to be considered available.
   # minReadySeconds: 60
@@ -902,9 +906,6 @@ podLabels: {}
 # Kong pod count.
 # It has no effect when autoscaling.enabled is set to true
 replicaCount: 1
-
-# The number of replicasets will be retain
-revisionHistoryLimit: 10
 
 # Annotations to be added to Kong deployment
 deploymentAnnotations: {}


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

I want to set `revisionHistoryLimit` to a smaller number to reduce the replicasets stored in the history of the deployment.

#### Special notes for your reviewer:

I'm a contribute newbie. I don't know need serial modifications or not for `gateway-operator` or `ingress` charts if add this value.  
Please let me know if I'm doing anything wrong. Thanks.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
