### PR TITLE
chore(kgo): add `PodDisruptionBudget` to manager rbac

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.11
+
+### Changes
+
+- Added `poddisruptionbudgets` to RBAC policy rules in operator's manager-role.
+  [#1114](https://github.com/Kong/charts/pull/1114)
+
 ## 0.1.10
 
 ### Changes

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.1.10
+version: 0.1.11
 appVersion: "1.2"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/templates/rbac-resources.yaml
+++ b/charts/gateway-operator/templates/rbac-resources.yaml
@@ -719,6 +719,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `poddisruptionbudgets` rule to the cluster role used by KGO.

#### Which issue this PR fixes
Part of https://github.com/Kong/gateway-operator/issues/142.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
