### PR TITLE
feat(kong): support configurable kgo deployment selector labels

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.2.1
+
+### Changes
 
 - Added the ability to define deployment selector labels
   [#1118](https://github.com/Kong/charts/pull/1118)

--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added the ability to define deployment selector labels
+  [#1118](https://github.com/Kong/charts/pull/1118)
+
 ## 0.2.0
 
 ### Changes

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -10,7 +10,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
+      {{- if .Values.selectorLabels }}
+      {{- toYaml .Values.selectorLabels | nindent 6}}
+      {{- else }}
       {{- include "kong.selectorLabels" . | nindent 6 }}
+      {{- end }}
   strategy:
     type: Recreate
   template:

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -109,3 +109,7 @@ args: []
 # Use this section to change the certs-dir emptyDir size
 certsDir:
   sizeLimit: 256Mi
+
+# Override the default deployment selector labels. This is useful if you don't want
+# to use the defaults or are migrating to this chart and want to use existing labels.
+# selectorLabels: []


### PR DESCRIPTION
#### What this PR does / why we need it:

We are currently deploying KGO through kustomize and are trying to migrate to helm with zero downtime. One issue I've seen is that the deployment selector labels have changed. Since that is an immutable field it causes issues with the helm deploy of the gateway operator. This PR adds the ability to override the default selector labels.


#### Special notes for your reviewer:

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
