### PR TITLE
fix: specifically set issuer ref group name

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Explicitly cert-manager group on Certificate
+
 ## 2.41.1
 
 ### Changes

--- a/charts/kong/templates/certificate.yaml
+++ b/charts/kong/templates/certificate.yaml
@@ -71,18 +71,22 @@ spec:
   {{- end }}
   {{ if .clusterIssuer -}}
   issuerRef:
+    group: cert-manager.io
     name: {{ .clusterIssuer }}
     kind: ClusterIssuer
   {{ else if .issuer -}}
   issuerRef:
+    group: cert-manager.io
     name: {{ .issuer }}
     kind: Issuer
   {{ else if .globalClusterIssuer -}}
   issuerRef:
+    group: cert-manager.io
     name: {{ .globalClusterIssuer}}
     kind: ClusterIssuer
   {{ else if .globalIssuer -}}
   issuerRef:
+    group: cert-manager.io
     name: {{ .globalIssuer }}
     kind: Issuer
   {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

This is the explicit group for cert-manager Issuer/ClusterIssuer.
On my use case is we set default issuer group to something different than default cert-manager.io

#### Special notes for your reviewer:

#### Checklist

- [X] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [X] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
