### PR TITLE
fix(kong): fix handling version labels so that they are not based on Chart.yaml's version

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+* Fixed handling version labels `app.kubernetes.io/version` and `version` so that
+  they are not based on `Chart.yaml`'s version but on the version set in `values.yaml`.
+  [#1132](https://github.com/Kong/charts/pull/1132)
+
 ## 2.41.1
 
 ### Changes

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.5"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong
   namespace: default
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.5"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong-manager
   namespace: default
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.5"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong-portalapi
   namespace: default
@@ -71,7 +71,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.5"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong-portal
   namespace: default
@@ -98,7 +98,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.5"
     enable-metrics: "true"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong-proxy
@@ -127,7 +127,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.5"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong
   namespace: default
@@ -151,9 +151,9 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
-        app.kubernetes.io/version: "3.6"
+        app.kubernetes.io/version: "3.5"
         helm.sh/chart: kong-2.41.1
-        version: "3.6"
+        version: "3.5"
     spec:
       automountServiceAccountToken: false
       containers:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.4"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong
   namespace: default
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.4"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong-manager
   namespace: default
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.4"
     enable-metrics: "true"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong-proxy
@@ -73,7 +73,7 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
-    app.kubernetes.io/version: "3.6"
+    app.kubernetes.io/version: "3.4"
     helm.sh/chart: kong-2.41.1
   name: chartsnap-kong
   namespace: default
@@ -97,9 +97,9 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
-        app.kubernetes.io/version: "3.6"
+        app.kubernetes.io/version: "3.4"
         helm.sh/chart: kong-2.41.1
-        version: "3.6"
+        version: "3.4"
     spec:
       automountServiceAccountToken: false
       containers:

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -30,7 +30,8 @@ app.kubernetes.io/name: {{ template "kong.name" . }}
 helm.sh/chart: {{ template "kong.chart" . }}
 app.kubernetes.io/instance: "{{ .Release.Name }}"
 app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{ $version := semver (include "kong.effectiveVersion" .Values.image) }}
+app.kubernetes.io/version: {{ printf "%d.%d" $version.Major $version.Minor | quote }}
 {{- range $key, $value := .Values.extraLabels }}
 {{ $key }}: {{ include "kong.renderTpl" (dict "value" $value "context" $) | quote }}
 {{- end }}

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -61,7 +61,8 @@ spec:
         {{- include "kong.metaLabels" . | nindent 8 }}
         app.kubernetes.io/component: app
         app: {{ template "kong.fullname" . }}
-        version: {{ .Chart.AppVersion | quote }}
+        {{ $version := semver (include "kong.effectiveVersion" .Values.image) }}
+        version: {{ printf "%d.%d" $version.Major $version.Minor | quote }}
         {{- if .Values.podLabels }}
         {{ include "kong.renderTpl" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes version label handling so that it's not based on `Chart.yaml`'s version but on `"kong.effectiveVersion"` template like all other places in chart templates.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
