### PR TITLE
feat(kong): add metrics Service for ingress controller exposed metrics

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -6,10 +6,7 @@
 
 * Explicitly cert-manager group on Certificate. [#1128](https://github.com/Kong/charts/pull/1128)
 * Add missing load balancer service values. [#1116](https://github.com/Kong/charts/pull/1116)
-
-### Fixes
-
-* Enables KIC metrics to be scraped by adding in a service to correctly work with the defined ServiceMonitor.
+* Enables KIC metrics to be scraped by adding in a service to correctly work with the defined ServiceMonitor. [#1134](https://github.com/Kong/charts/pull/1134)
 
 ## 2.42.0
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-* Fixes KIC webhook service config to correctly work with ServiceMonitor (by adding in the correct ports to match ServiceMonitor config)
+* Enables KIC metrics to be scraped by adding in a service to correctly work with the defined ServiceMonitor.
 
 ## 2.42.0
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Explicitly cert-manager group on Certificate. [#1128](https://github.com/Kong/charts/pull/1128)
 * Add missing load balancer service values. [#1116](https://github.com/Kong/charts/pull/1116)
 
+### Fixes
+
+* Fixes KIC webhook service config to correctly work with ServiceMonitor (by adding in the correct ports to match ServiceMonitor config)
+
 ## 2.42.0
 
 ### Fixes

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -458,6 +458,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -458,6 +458,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -458,6 +458,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -458,6 +458,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -466,6 +466,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     acme.com/some-key: some-value
     app.kubernetes.io/component: app

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -466,6 +466,29 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    acme.com/some-key: some-value
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    acme.com/some-key: some-value
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -458,6 +458,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -458,6 +458,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -467,6 +467,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -467,6 +467,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -467,6 +467,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -467,6 +467,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -458,6 +458,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -458,6 +458,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -476,6 +476,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -476,6 +476,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -442,6 +442,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -442,6 +442,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -458,6 +458,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -458,6 +458,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -458,6 +458,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -458,6 +458,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -458,6 +458,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -458,6 +458,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -458,6 +458,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -458,6 +458,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -581,6 +581,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -581,6 +581,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -541,6 +541,27 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+  selector:
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.7"
+    helm.sh/chart: kong-2.42.0
+  name: chartsnap-kong-metrics
+  namespace: default
+spec:
+  ports:
     - name: cmetrics
       port: 10255
       protocol: TCP

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -541,6 +541,14 @@ spec:
       port: 443
       protocol: TCP
       targetPort: webhook
+    - name: cmetrics
+      port: 10255
+      protocol: TCP
+      targetPort: cmetrics
+    - name: status
+      port: 10254
+      protocol: TCP
+      targetPort: cstatus
   selector:
     app.kubernetes.io/component: app
     app.kubernetes.io/instance: chartsnap

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -227,6 +227,16 @@ spec:
     port: 443
     protocol: TCP
     targetPort: webhook
+  {{- if and .Values.ingressController.enabled (semverCompare ">= 2.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+  - name: cmetrics
+    port: 10255
+    protocol: TCP
+    targetPort: cmetrics
+  - name: status
+    port: 10254
+    protocol: TCP
+    targetPort: cstatus
+  {{- end }}
   selector:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: app

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -227,16 +227,6 @@ spec:
     port: 443
     protocol: TCP
     targetPort: webhook
-  {{- if and .Values.ingressController.enabled (semverCompare ">= 2.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
-  - name: cmetrics
-    port: 10255
-    protocol: TCP
-    targetPort: cmetrics
-  - name: status
-    port: 10254
-    protocol: TCP
-    targetPort: cstatus
-  {{- end }}
   selector:
     {{- include "kong.metaLabels" . | nindent 4 }}
     app.kubernetes.io/component: app

--- a/charts/kong/templates/controller-service-metrics.yaml
+++ b/charts/kong/templates/controller-service-metrics.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.ingressController.enabled (semverCompare ">= 2.0.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "kong.fullname" . }}-metrics
+  namespace: {{ template "kong.namespace" . }}
+  labels:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+    {{- if .Values.ingressController.labels }}
+      {{- toYaml .Values.ingressController.labels | nindent 4 }}
+    {{- end }}
+spec:
+  ports:
+  - name: cmetrics
+    port: 10255
+    protocol: TCP
+    targetPort: cmetrics
+  - name: status
+    port: 10254
+    protocol: TCP
+    targetPort: cstatus
+  selector:
+    {{- include "kong.metaLabels" . | nindent 4 }}
+    app.kubernetes.io/component: app
+{{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:
Correctly adds in ports to the KIC webhook service so that the servicemonitor can correctly match 


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
