### PR TITLE
chore(ci): use 1 namespace for ct install tests

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -77,7 +77,10 @@ jobs:
         run: ./scripts/test-env.sh
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch main --charts charts/${{ matrix.chart-name}}
+        run: |
+          kubectl create ns kong-test
+          ct install --target-branch main --charts charts/${{ matrix.chart-name}} --namespace kong-test
+          # No need to delete the ns the cluster is scrapped after the job anyway.
 
   integration-test:
     timeout-minutes: 30


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

It seems that using a separate namespace for each test in `ct install ...` take a lot of time to delete the namespace completely:

```
Fri, 11 Oct 2024 12:38:46 GMT Deleting release "kong-qpo65402jm"...
Fri, 11 Oct 2024 12:38:46 GMT release "kong-qpo65402jm" uninstalled
Fri, 11 Oct 2024 12:38:46 GMT Deleting namespace "kong-qpo65402jm"...
Fri, 11 Oct 2024 12:38:46 GMT namespace "kong-qpo65402jm" deleted
Fri, 11 Oct 2024 12:39:12 GMT Namespace "kong-qpo65402jm" terminated.
```

Instead we can use just 1 namespace and share it which greatly decreases the time required for the test suite to run:

- before: ~~14min https://github.com/Kong/charts/actions/runs/11292449703/job/31408471139
- after: ~~7min   https://github.com/Kong/charts/actions/runs/11293815050/job/31412833958?pr=1141

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
