### PR TITLE
objects that uses the "kong.no_daemon_env" function to fetch env uses the old default values

### DIFF
--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -967,12 +967,6 @@ Use the Pod security context defined in Values or set the UID by default
 {{ .Values.securityContext | toYaml }}
 {{- end -}}
 
-{{- define "kong.no_daemon_env" -}}
-{{- template "kong.env" . }}
-- name: KONG_NGINX_DAEMON
-  value: "off"
-{{- end -}}
-
 {{/*
 The environment values passed to Kong; this should come after all
 the template that it itself is using form the above sections.
@@ -1841,4 +1835,10 @@ envFrom:
 {{- toYaml . | nindent 2 -}}
   {{- else -}}
   {{- end -}}
+{{- end -}}
+
+{{- define "kong.no_daemon_env" -}}
+{{- template "kong.env" . }}
+- name: KONG_NGINX_DAEMON
+  value: "off"
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

#### Which issue this PR fixes
migration-pre-upgrade, migration-post-upgrade and other objects that uses the "kong.no_daemon_env" function to fetch env uses the old default values before they get overwritten, causing wrong host url that points to the default namespace "kong" even if other namespace is used.

This is caused because the "kong.no_daemon_env" function is defined early, to fix it, I had to move it's define at the end of the file.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
