### PR TITLE
feat(kgo): add kubernetes-configuration crds subchart

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+### Changes
+
+- Added a `kubernetes-configuration-crds` subchart to install Kong's Kubernetes Configuration CRDs.
+  It's off by default.
+  [#1151](https://github.com/Kong/charts/pull/1151)
+
 ## 0.2.3
 
 ### Fixes

--- a/charts/gateway-operator/Chart.lock
+++ b/charts/gateway-operator/Chart.lock
@@ -8,5 +8,8 @@ dependencies:
 - name: gwapi-experimental-crds
   repository: ""
   version: 1.1.0
-digest: sha256:1eecbe3e6242f1a62b9c1a3c024f6983c0f5053d7147307b796bcc116fd664c2
-generated: "2024-08-09T09:58:05.387848+02:00"
+- name: kubernetes-configuration-crds
+  repository: ""
+  version: 0.0.35
+digest: sha256:ce87c26c263258a5258892fef8266f4e6d5760663de1ae36e1846e74f8481918
+generated: "2024-10-24T17:00:35.905215+02:00"

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.2.3
+version: 0.3.0
 appVersion: "1.3"
 annotations:
   artifacthub.io/prerelease: "false"
@@ -23,3 +23,6 @@ dependencies:
   - name: gwapi-experimental-crds
     version: 1.1.0
     condition: gwapi-experimental-crds.enabled
+  - name: kubernetes-configuration-crds
+    version: 0.0.35
+    condition: kubernetes-configuration-crds.enabled

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: kubernetes-configuration-crds
+version: 0.0.35
+appVersion: "0.0.35"
+description: A Helm chart for Kong's Kubernetes Configuration CRDs

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/README.md
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/README.md
@@ -1,0 +1,15 @@
+# kubernetes-configuration subchart
+
+This sub-chart contains Kong's [Kubernetes Configuration][kconf] CRDs, allowing users to control whether to install them.
+
+[kconf]: https://github.com/Kong/kubernetes-configuration
+
+### Contributing
+
+#### Syncing CRDs with `kong/kubernetes-configuration` repository
+
+To update the CRDs, you can run the following command:
+
+```bash
+kustomize build github.com/kong/kubernetes-configuration/config/crd > ./charts/gateway-operator/charts/kubernetes-configuration/crds/kubernetes-configuration-crds.yaml
+```

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
@@ -1,0 +1,7880 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: ingressclassparameterses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: IngressClassParameters
+    listKind: IngressClassParametersList
+    plural: ingressclassparameterses
+    singular: ingressclassparameters
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IngressClassParameters is the Schema for the IngressClassParameters
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the IngressClassParameters specification.
+            properties:
+              enableLegacyRegexDetection:
+                default: false
+                description: |-
+                  EnableLegacyRegexDetection automatically detects if ImplementationSpecific Ingress paths are regular expression
+                  paths using the legacy 2.x heuristic. The controller adds the "~" prefix to those paths if the Kong version is
+                  3.0 or higher.
+                type: boolean
+              serviceUpstream:
+                default: false
+                description: Offload load-balancing to kube-proxy or sidecar.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongcacertificates.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongCACertificate
+    listKind: KongCACertificateList
+    plural: kongcacertificates
+    singular: kongcacertificate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCACertificate is the schema for CACertificate API which defines
+          a Kong CA Certificate.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongCACertificateSpec contains the specification for the
+              KongCACertificate.
+            properties:
+              cert:
+                description: Cert is the PEM-encoded CA certificate.
+                type: string
+              controlPlaneRef:
+                description: ControlPlaneRef references the Konnect Control Plane
+                  that this KongCACertificate should be created in.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              tags:
+                description: Tags is an optional set of tags applied to the certificate.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - cert
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongCACertificateStatus defines the observed state of KongCACertificate.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongcertificates.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongCertificate
+    listKind: KongCertificateList
+    plural: kongcertificates
+    singular: kongcertificate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCertificate is the schema for Certificate API which defines
+          a Kong Certificate.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongCertificateSpec contains the specification for the KongCertificate.
+            properties:
+              cert:
+                description: Cert is the PEM-encoded certificate.
+                type: string
+              cert_alt:
+                description: |-
+                  CertAlt is the PEM-encoded certificate.
+                  This should only be set if you have both RSA and ECDSA types of
+                  certificate available and would like Kong to prefer serving using ECDSA certs
+                  when client advertises support for it.
+                type: string
+              controlPlaneRef:
+                description: ControlPlaneRef references the Konnect Control Plane
+                  that this KongCertificate should be created in.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              key:
+                description: Key is the PEM-encoded private key.
+                type: string
+              key_alt:
+                description: |-
+                  KeyAlt is the PEM-encoded private key.
+                  This should only be set if you have both RSA and ECDSA types of
+                  certificate available and would like Kong to prefer serving using ECDSA certs
+                  when client advertises support for it.
+                type: string
+              tags:
+                description: Tags is an optional set of tags applied to the certificate.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - cert
+            - key
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongCertificateStatus defines the observed state of KongCertificate.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongclusterplugins.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongClusterPlugin
+    listKind: KongClusterPluginList
+    plural: kongclusterplugins
+    shortNames:
+    - kcp
+    singular: kongclusterplugin
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongClusterPlugin is the Schema for the kongclusterplugins API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          config:
+            description: |-
+              Config contains the plugin configuration. It's a list of keys and values
+              required to configure the plugin.
+              Please read the documentation of the plugin being configured to set values
+              in here. For any plugin in Kong, anything that goes in the `config` JSON
+              key in the Admin API request, goes into this property.
+              Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: |-
+              ConfigFrom references a secret containing the plugin configuration.
+              This should be used when the plugin configuration contains sensitive information,
+              such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin.
+              Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once.
+            properties:
+              secretKeyRef:
+                description: Specifies a name, a namespace, and a key of a secret
+                  to refer to.
+                properties:
+                  key:
+                    description: The key containing the value.
+                    type: string
+                  name:
+                    description: The secret containing the key.
+                    type: string
+                  namespace:
+                    description: The namespace containing the secret.
+                    type: string
+                required:
+                - key
+                - name
+                - namespace
+                type: object
+            required:
+            - secretKeyRef
+            type: object
+          configPatches:
+            description: |-
+              ConfigPatches represents JSON patches to the configuration of the plugin.
+              Each item means a JSON patch to add something in the configuration,
+              where path is specified in `path` and value is in `valueFrom` referencing
+              a key in a secret.
+              When Config is specified, patches will be applied to the configuration in Config.
+              Otherwise, patches will be applied to an empty object.
+            items:
+              description: |-
+                NamespacedConfigPatch is a JSON patch to add values from secrets to KongClusterPlugin
+                to the generated configuration of plugin in Kong.
+              properties:
+                path:
+                  description: Path is the JSON path to add the patch.
+                  type: string
+                valueFrom:
+                  description: ValueFrom is the reference to a key of a secret where
+                    the patched value comes from.
+                  properties:
+                    secretKeyRef:
+                      description: Specifies a name, a namespace, and a key of a secret
+                        to refer to.
+                      properties:
+                        key:
+                          description: The key containing the value.
+                          type: string
+                        name:
+                          description: The secret containing the key.
+                          type: string
+                        namespace:
+                          description: The namespace containing the secret.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      - namespace
+                      type: object
+                  required:
+                  - secretKeyRef
+                  type: object
+              required:
+              - path
+              - valueFrom
+              type: object
+            type: array
+          consumerRef:
+            description: ConsumerRef is a reference to a particular consumer.
+            type: string
+          disabled:
+            description: Disabled set if the plugin is disabled or not.
+            type: boolean
+          instance_name:
+            description: |-
+              InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the
+              same plugin in multiple contexts, for example, on multiple services.
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          ordering:
+            description: |-
+              Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise.
+              `<phase>` is a request processing phase (for example, `access` or `body_filter`) and
+              `<plugin>` is the name of the plugin that will run before or after the KongPlugin.
+              For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]`
+              will create a rate limiting plugin that limits requests _before_ they are authenticated.
+            properties:
+              after:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: PluginOrderingPhase indicates which plugins in a phase
+                  should affect the target plugin's order
+                type: object
+              before:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: PluginOrderingPhase indicates which plugins in a phase
+                  should affect the target plugin's order
+                type: object
+            type: object
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config.
+            type: string
+          protocols:
+            description: |-
+              Protocols configures plugin to run on requests received on specific
+              protocols.
+            items:
+              description: |-
+                KongProtocol is a valid Kong protocol.
+                This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
+              type: string
+            type: array
+          run_on:
+            description: |-
+              RunOn configures the plugin to run on the first or the second or both
+              nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+          status:
+            description: Status represents the current status of the KongClusterPlugin
+              resource.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the KongClusterPluginStatus.
+
+                  Known condition types are:
+
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - plugin
+        type: object
+        x-kubernetes-validations:
+        - message: Using both config and configFrom fields is not allowed.
+          rule: '!(has(self.config) && has(self.configFrom))'
+        - message: Using both configFrom and configPatches fields is not allowed.
+          rule: '!(has(self.configFrom) && has(self.configPatches))'
+        - message: The plugin field is immutable
+          rule: self.plugin == oldSelf.plugin
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongconsumergroups.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongConsumerGroup
+    listKind: KongConsumerGroupList
+    plural: kongconsumergroups
+    shortNames:
+    - kcg
+    singular: kongconsumergroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KongConsumerGroup is the Schema for the kongconsumergroups API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongConsumerGroupSpec defines the desired state of KongConsumerGroup.
+            properties:
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a ControlPlane this
+                  ConsumerGroup is associated with.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              name:
+                description: Name is the name of the ConsumerGroup in Kong.
+                type: string
+              tags:
+                description: Tags is an optional set of tags applied to the ConsumerGroup.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status represents the current status of the KongConsumerGroup
+              resource.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describe the current conditions of the KongConsumerGroup.
+
+                  Known condition types are:
+
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: controlPlaneRef is required once set
+          rule: (!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) || has(self.spec.controlPlaneRef)
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) ? true
+            : (!has(self.status) || !self.status.conditions.exists(c, c.type == ''Programmed''
+            && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongconsumers.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongConsumer
+    listKind: KongConsumerList
+    plural: kongconsumers
+    shortNames:
+    - kc
+    singular: kongconsumer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Username of a Kong Consumer
+      jsonPath: .username
+      name: Username
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongConsumer is the Schema for the kongconsumers API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          consumerGroups:
+            description: |-
+              ConsumerGroups are references to consumer groups (that consumer wants to be part of)
+              provisioned in Kong.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: set
+          credentials:
+            description: |-
+              Credentials are references to secrets containing a credential to be
+              provisioned in Kong.
+            items:
+              type: string
+            type: array
+            x-kubernetes-list-type: set
+          custom_id:
+            description: |-
+              CustomID is a Kong cluster-unique existing ID for the consumer - useful for mapping
+              Kong with users in your existing database.
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongConsumerSpec defines the specification of the KongConsumer.
+            properties:
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a ControlPlane this
+                  Consumer is associated with.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              tags:
+                description: Tags is an optional set of tags applied to the consumer.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status represents the current status of the KongConsumer
+              resource.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describe the current conditions of the KongConsumer.
+
+                  Known condition types are:
+
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+          username:
+            description: Username is a Kong cluster-unique username of the consumer.
+            type: string
+        type: object
+        x-kubernetes-validations:
+        - message: Need to provide either username or custom_id
+          rule: has(self.username) || has(self.custom_id)
+        - message: controlPlaneRef is required once set
+          rule: (!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) || has(self.spec.controlPlaneRef)
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef)) ? true : (!has(self.status)
+            || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongcredentialacls.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongCredentialACL
+    listKind: KongCredentialACLList
+    plural: kongcredentialacls
+    singular: kongcredentialacl
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCredentialACL is the schema for ACL credentials API which
+          defines a ACL credential for consumers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the ACL credential specification.
+            properties:
+              consumerRef:
+                description: ConsumerRef is a reference to a Consumer this KongCredentialACL
+                  is associated with.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              group:
+                description: Group is the name for the ACL credential.
+                type: string
+              tags:
+                description: Tags is a list of tags for the ACL credential.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - consumerRef
+            - group
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status contains the ACL credential status.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  consumerID:
+                    description: ConsumerID is the Konnect ID of the Consumer this
+                      entity is associated with.
+                    type: string
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.consumerRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongcredentialapikeys.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongCredentialAPIKey
+    listKind: KongCredentialAPIKeyList
+    plural: kongcredentialapikeys
+    singular: kongcredentialapikey
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCredentialAPIKey is the schema for API key credentials API
+          which defines a API key credential for consumers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the API Key credential specification.
+            properties:
+              consumerRef:
+                description: ConsumerRef is a reference to a Consumer this KongCredentialAPIKey
+                  is associated with.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              key:
+                description: Key is the key for the API Key credential.
+                type: string
+              tags:
+                description: Tags is a list of tags for the API Key credential.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - consumerRef
+            - key
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status contains the API Key credential status.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  consumerID:
+                    description: ConsumerID is the Konnect ID of the Consumer this
+                      entity is associated with.
+                    type: string
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.consumerRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongcredentialbasicauths.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongCredentialBasicAuth
+    listKind: KongCredentialBasicAuthList
+    plural: kongcredentialbasicauths
+    singular: kongcredentialbasicauth
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCredentialBasicAuth is the schema for BasicAuth credentials
+          API which defines a BasicAuth credential for consumers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the BasicAuth credential specification.
+            properties:
+              consumerRef:
+                description: ConsumerRef is a reference to a Consumer this CredentialBasicAuth
+                  is associated with.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              password:
+                description: Password is the password for the BasicAuth credential.
+                type: string
+              tags:
+                description: Tags is a list of tags for the BasicAuth credential.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+              username:
+                description: Username is the username for the BasicAuth credential.
+                type: string
+            required:
+            - consumerRef
+            - password
+            - username
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status contains the BasicAuth credential status.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  consumerID:
+                    description: ConsumerID is the Konnect ID of the Consumer this
+                      entity is associated with.
+                    type: string
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.consumerRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongcredentialhmacs.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongCredentialHMAC
+    listKind: KongCredentialHMACList
+    plural: kongcredentialhmacs
+    singular: kongcredentialhmac
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCredentialHMAC is the schema for HMAC credentials API which
+          defines a HMAC credential for consumers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the HMAC credential specification.
+            properties:
+              consumerRef:
+                description: ConsumerRef is a reference to a Consumer this KongCredentialHMAC
+                  is associated with.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              id:
+                description: ID is the unique identifier for the HMAC credential.
+                type: string
+              secret:
+                description: Secret is the secret for the HMAC credential.
+                type: string
+              tags:
+                description: Tags is a list of tags for the HMAC credential.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+              username:
+                description: Username is the username for the HMAC credential.
+                type: string
+            required:
+            - consumerRef
+            - username
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status contains the HMAC credential status.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  consumerID:
+                    description: ConsumerID is the Konnect ID of the Consumer this
+                      entity is associated with.
+                    type: string
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.consumerRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongcredentialjwts.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongCredentialJWT
+    listKind: KongCredentialJWTList
+    plural: kongcredentialjwts
+    singular: kongcredentialjwt
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCredentialJWT is the schema for JWT credentials API which
+          defines a JWT credential for consumers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the JWT credential specification.
+            properties:
+              algorithm:
+                default: HS256
+                description: Algorithm is the algorithm used to sign the JWT token.
+                enum:
+                - HS256
+                - HS384
+                - HS512
+                - RS256
+                - RS384
+                - RS512
+                - ES256
+                - ES384
+                - ES512
+                - PS256
+                - PS384
+                - PS512
+                - EdDSA
+                type: string
+              consumerRef:
+                description: ConsumerRef is a reference to a Consumer this KongCredentialJWT
+                  is associated with.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              id:
+                description: ID is the unique identifier for the JWT credential.
+                type: string
+              key:
+                description: Key is the key for the JWT credential.
+                type: string
+              rsa_public_key:
+                description: RSA PublicKey is the RSA public key for the JWT credential.
+                type: string
+              secret:
+                description: Secret is the secret for the JWT credential.
+                type: string
+              tags:
+                description: Tags is a list of tags for the JWT credential.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - consumerRef
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: Status contains the JWT credential status.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  consumerID:
+                    description: ConsumerID is the Konnect ID of the Consumer this
+                      entity is associated with.
+                    type: string
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.consumerRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef'
+        - message: spec.rsa_public_key is required when algorithm is RS*, ES*, PS*
+            or EdDSA*
+          rule: 'self.spec.algorithm in [ ''RS256'',''RS384'',''RS512'',''ES256'',''ES384'',''ES512'',''PS256'',''PS384'',''PS512'',''EdDSA'',
+            ] ? has(self.spec.rsa_public_key) : true'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongcustomentities.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongCustomEntity
+    listKind: KongCustomEntityList
+    plural: kongcustomentities
+    shortNames:
+    - kce
+    singular: kongcustomentity
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: type of the Kong entity
+      jsonPath: .spec.type
+      name: Entity Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongCustomEntity defines a "custom" Kong entity that KIC cannot
+          support the entity type directly.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongCustomEntitySpec defines the specification of the KongCustomEntity.
+            properties:
+              controllerName:
+                description: ControllerName specifies the controller that should reconcile
+                  it, like ingress class.
+                type: string
+              fields:
+                description: Fields defines the fields of the Kong entity itself.
+                x-kubernetes-preserve-unknown-fields: true
+              parentRef:
+                description: |-
+                  ParentRef references the kubernetes resource it attached to when its scope is "attached".
+                  Currently only KongPlugin/KongClusterPlugin allowed. This will make the custom entity to be attached
+                  to the entity(service/route/consumer) where the plugin is attached.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    description: Empty namespace means the same namespace of the owning
+                      object.
+                    type: string
+                required:
+                - name
+                type: object
+              type:
+                description: EntityType is the type of the Kong entity. The type is
+                  used in generating declarative configuration.
+                type: string
+            required:
+            - controllerName
+            - fields
+            - type
+            type: object
+          status:
+            description: Status stores the reconciling status of the resource.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the KongCustomEntityStatus.
+
+                  Known condition types are:
+
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            required:
+            - conditions
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: The spec.type field is immutable
+          rule: self.spec.type == oldSelf.spec.type
+        - message: The spec.type field cannot be known Kong entity types
+          rule: '!(self.spec.type in [''services'',''routes'',''upstreams'',''targets'',''plugins'',''consumers'',''consumer_groups''])'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongdataplaneclientcertificates.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongDataPlaneClientCertificate
+    listKind: KongDataPlaneClientCertificateList
+    plural: kongdataplaneclientcertificates
+    singular: kongdataplaneclientcertificate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongDataPlaneClientCertificate is the schema for KongDataPlaneClientCertificate
+          API which defines a KongDataPlaneClientCertificate entity.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongDataPlaneClientCertificateSpec defines the spec for a
+              KongDataPlaneClientCertificate.
+            properties:
+              cert:
+                description: Cert is the certificate in PEM format. Once the certificate
+                  gets programmed this field becomes immutable.
+                minLength: 1
+                type: string
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a Konnect ControlPlane
+                  this KongDataPlaneClientCertificate is associated with.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+            required:
+            - cert
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongDataPlaneClientCertificateStatus defines the status for
+              a KongDataPlaneClientCertificate.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '!has(self.spec.controlPlaneRef) ? true : (!self.status.conditions.exists(c,
+            c.type == ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
+            == self.spec.controlPlaneRef'
+        - message: spec.cert is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.cert == self.spec.cert'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+            - it's not supported yet
+          rule: '!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef)
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongIngress
+    listKind: KongIngressList
+    plural: kongingresses
+    shortNames:
+    - ki
+    singular: kongingress
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongIngress is the Schema for the kongingresses API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          proxy:
+            description: |-
+              Proxy defines additional connection options for the routes to be configured in the
+              Kong Gateway, e.g. `connection_timeout`, `retries`, etc.
+            properties:
+              connect_timeout:
+                description: "The timeout in milliseconds for\testablishing a connection
+                  to the upstream server.\nDeprecated: use Service's \"konghq.com/connect-timeout\"
+                  annotation instead."
+                minimum: 0
+                type: integer
+              path:
+                description: |-
+                  (optional) The path to be used in requests to the upstream server.
+                  Deprecated: use Service's "konghq.com/path" annotation instead.
+                pattern: ^/.*$
+                type: string
+              protocol:
+                description: |-
+                  The protocol used to communicate with the upstream.
+                  Deprecated: use Service's "konghq.com/protocol" annotation instead.
+                enum:
+                - http
+                - https
+                - grpc
+                - grpcs
+                - tcp
+                - tls
+                - udp
+                type: string
+              read_timeout:
+                description: |-
+                  The timeout in milliseconds between two successive read operations
+                  for transmitting a request to the upstream server.
+                  Deprecated: use Service's "konghq.com/read-timeout" annotation instead.
+                minimum: 0
+                type: integer
+              retries:
+                description: |-
+                  The number of retries to execute upon failure to proxy.
+                  Deprecated: use Service's "konghq.com/retries" annotation instead.
+                minimum: 0
+                type: integer
+              write_timeout:
+                description: |-
+                  The timeout in milliseconds between two successive write operations
+                  for transmitting a request to the upstream server.
+                  Deprecated: use Service's "konghq.com/write-timeout" annotation instead.
+                minimum: 0
+                type: integer
+            type: object
+          route:
+            description: |-
+              Route define rules to match client requests.
+              Each Route is associated with a Service,
+              and a Service may have multiple Routes associated to it.
+            properties:
+              headers:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: |-
+                  Headers contains one or more lists of values indexed by header name
+                  that will cause this Route to match if present in the request.
+                  The Host header cannot be used with this attribute.
+                  Deprecated: use Ingress' "konghq.com/headers" annotation instead.
+                type: object
+              https_redirect_status_code:
+                description: |-
+                  HTTPSRedirectStatusCode is the status code Kong responds with
+                  when all properties of a Route match except the protocol.
+                  Deprecated: use Ingress' "ingress.kubernetes.io/force-ssl-redirect" or
+                  "konghq.com/https-redirect-status-code" annotations instead.
+                type: integer
+              methods:
+                description: |-
+                  Methods is a list of HTTP methods that match this Route.
+                  Deprecated: use Ingress' "konghq.com/methods" annotation instead.
+                items:
+                  type: string
+                type: array
+              path_handling:
+                description: |-
+                  PathHandling controls how the Service path, Route path and requested path
+                  are combined when sending a request to the upstream.
+                  Deprecated: use Ingress' "konghq.com/path-handling" annotation instead.
+                enum:
+                - v0
+                - v1
+                type: string
+              preserve_host:
+                description: |-
+                  PreserveHost sets When matching a Route via one of the hosts domain names,
+                  use the request Host header in the upstream request headers.
+                  If set to false, the upstream Host header will be that of the Service’s host.
+                  Deprecated: use Ingress' "konghq.com/preserve-host" annotation instead.
+                type: boolean
+              protocols:
+                description: |-
+                  Protocols is an array of the protocols this Route should allow.
+                  Deprecated: use Ingress' "konghq.com/protocols" annotation instead.
+                items:
+                  description: |-
+                    KongProtocol is a valid Kong protocol.
+                    This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+                  enum:
+                  - http
+                  - https
+                  - grpc
+                  - grpcs
+                  - tcp
+                  - tls
+                  - udp
+                  type: string
+                type: array
+              regex_priority:
+                description: |-
+                  RegexPriority is a number used to choose which route resolves a given request
+                  when several routes match it using regexes simultaneously.
+                  Deprecated: use Ingress' "konghq.com/regex-priority" annotation instead.
+                type: integer
+              request_buffering:
+                description: |-
+                  RequestBuffering sets whether to enable request body buffering or not.
+                  Deprecated: use Ingress' "konghq.com/request-buffering" annotation instead.
+                type: boolean
+              response_buffering:
+                description: |-
+                  ResponseBuffering sets whether to enable response body buffering or not.
+                  Deprecated: use Ingress' "konghq.com/response-buffering" annotation instead.
+                type: boolean
+              snis:
+                description: |-
+                  SNIs is a list of SNIs that match this Route when using stream routing.
+                  Deprecated: use Ingress' "konghq.com/snis" annotation instead.
+                items:
+                  type: string
+                type: array
+              strip_path:
+                description: |-
+                  StripPath sets When matching a Route via one of the paths
+                  strip the matching prefix from the upstream request URL.
+                  Deprecated: use Ingress' "konghq.com/strip-path" annotation instead.
+                type: boolean
+            type: object
+          upstream:
+            description: |-
+              Upstream represents a virtual hostname and can be used to loadbalance
+              incoming requests over multiple targets (e.g. Kubernetes `Services` can
+              be a target, OR `Endpoints` can be targets).
+            properties:
+              algorithm:
+                description: |-
+                  Algorithm is the load balancing algorithm to use.
+                  Accepted values are: "round-robin", "consistent-hashing", "least-connections", "latency".
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
+                - latency
+                type: string
+              hash_fallback:
+                description: |-
+                  HashFallback defines What to use as hashing input
+                  if the primary hash_on does not return a hash.
+                  Accepted values are: "none", "consumer", "ip", "header", "cookie".
+                type: string
+              hash_fallback_header:
+                description: |-
+                  HashFallbackHeader is the header name to take the value from as hash input.
+                  Only required when "hash_fallback" is set to "header".
+                type: string
+              hash_fallback_query_arg:
+                description: HashFallbackQueryArg is the "hash_fallback" version of
+                  HashOnQueryArg.
+                type: string
+              hash_fallback_uri_capture:
+                description: HashFallbackURICapture is the "hash_fallback" version
+                  of HashOnURICapture.
+                type: string
+              hash_on:
+                description: |-
+                  HashOn defines what to use as hashing input.
+                  Accepted values are: "none", "consumer", "ip", "header", "cookie", "path", "query_arg", "uri_capture".
+                type: string
+              hash_on_cookie:
+                description: |-
+                  The cookie name to take the value from as hash input.
+                  Only required when "hash_on" or "hash_fallback" is set to "cookie".
+                type: string
+              hash_on_cookie_path:
+                description: |-
+                  The cookie path to set in the response headers.
+                  Only required when "hash_on" or "hash_fallback" is set to "cookie".
+                type: string
+              hash_on_header:
+                description: |-
+                  HashOnHeader defines the header name to take the value from as hash input.
+                  Only required when "hash_on" is set to "header".
+                type: string
+              hash_on_query_arg:
+                description: HashOnQueryArg is the query string parameter whose value
+                  is the hash input when "hash_on" is set to "query_arg".
+                type: string
+              hash_on_uri_capture:
+                description: |-
+                  HashOnURICapture is the name of the capture group whose value is the hash input when "hash_on" is set to
+                  "uri_capture".
+                type: string
+              healthchecks:
+                description: Healthchecks defines the health check configurations
+                  in Kong.
+                properties:
+                  active:
+                    description: ActiveHealthcheck configures active health check
+                      probing.
+                    properties:
+                      concurrency:
+                        minimum: 1
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        type: object
+                      healthy:
+                        description: |-
+                          Healthy configures thresholds and HTTP status codes
+                          to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          successes:
+                            minimum: 0
+                            type: integer
+                        type: object
+                      http_path:
+                        pattern: ^/.*$
+                        type: string
+                      https_sni:
+                        type: string
+                      https_verify_certificate:
+                        type: boolean
+                      timeout:
+                        minimum: 0
+                        type: integer
+                      type:
+                        type: string
+                      unhealthy:
+                        description: |-
+                          Unhealthy configures thresholds and HTTP status codes
+                          to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeouts:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: |-
+                      PassiveHealthcheck configures passive checks around
+                      passive health checks.
+                    properties:
+                      healthy:
+                        description: |-
+                          Healthy configures thresholds and HTTP status codes
+                          to mark targets healthy for an upstream.
+                        properties:
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          successes:
+                            minimum: 0
+                            type: integer
+                        type: object
+                      type:
+                        type: string
+                      unhealthy:
+                        description: |-
+                          Unhealthy configures thresholds and HTTP status codes
+                          to mark targets unhealthy.
+                        properties:
+                          http_failures:
+                            minimum: 0
+                            type: integer
+                          http_statuses:
+                            items:
+                              type: integer
+                            type: array
+                          interval:
+                            minimum: 0
+                            type: integer
+                          tcp_failures:
+                            minimum: 0
+                            type: integer
+                          timeouts:
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    type: number
+                type: object
+              host_header:
+                description: |-
+                  HostHeader is The hostname to be used as Host header
+                  when proxying requests through Kong.
+                type: string
+              slots:
+                description: Slots is the number of slots in the load balancer algorithm.
+                minimum: 10
+                type: integer
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: '''proxy'' field is no longer supported, use Service''s annotations
+            instead'
+          rule: '!has(self.proxy)'
+        - message: '''route'' field is no longer supported, use Ingress'' annotations
+            instead'
+          rule: '!has(self.route)'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongkeys.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongKey
+    listKind: KongKeyList
+    plural: kongkeys
+    singular: kongkey
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongKey is the schema for KongKey API which defines a KongKey
+          entity.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongKeySpec defines the spec for a KongKey.
+            properties:
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a Konnect ControlPlane
+                  this KongKey is associated with.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              jwk:
+                description: |-
+                  JWK is a JSON Web Key represented as a string.
+                  The JWK must contain a KID field that matches the KID in the KongKey.
+                  Either JWK or PEM must be set.
+                type: string
+              keySetRef:
+                description: |-
+                  KeySetRef is a reference to a KongKeySet this KongKey is attached to.
+                  ControlPlane referenced by a KongKeySet must be the same as the ControlPlane referenced by the KongKey.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  namespacedRef:
+                    description: |-
+                      NamespacedRef is a reference to a KeySet entity inside the cluster.
+                      This field is required when the Type is namespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the KeySet object.
+                        minLength: 1
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type defines type of the KeySet object reference. It can be one of:
+                      - konnectID
+                      - namespacedRef
+                    enum:
+                    - konnectID
+                    - namespacedRef
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is namespacedRef, namespacedRef must be set
+                  rule: 'self.type == ''namespacedRef'' ? has(self.namespacedRef)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+              kid:
+                description: |-
+                  KID is a unique identifier for a key.
+                  When JWK is provided, KID has to match the KID in the JWK.
+                minLength: 1
+                type: string
+              name:
+                description: Name is an optional name to associate with the given
+                  key.
+                type: string
+              pem:
+                description: |-
+                  PEM is a keypair in PEM format.
+                  Either JWK or PEM must be set.
+                properties:
+                  private_key:
+                    description: The private key in PEM format.
+                    minLength: 1
+                    type: string
+                  public_key:
+                    description: The public key in PEM format.
+                    minLength: 1
+                    type: string
+                required:
+                - private_key
+                - public_key
+                type: object
+              tags:
+                description: Tags is an optional set of strings associated with the
+                  Key for grouping and filtering.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - kid
+            type: object
+            x-kubernetes-validations:
+            - message: Either 'jwk' or 'pem' must be set
+              rule: has(self.jwk) || has(self.pem)
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongKeyStatus defines the status for a KongKey.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this entity is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  keySetID:
+                    description: KeySetID is the Konnect ID of the KeySet this entity
+                      is associated with.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+            - it's not supported yet
+          rule: '!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef)
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongkeysets.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongKeySet
+    listKind: KongKeySetList
+    plural: kongkeysets
+    singular: kongkeyset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongKeySet is the schema for KongKeySet API which defines a KongKeySet
+          entity.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongKeySetSpec defines the spec for a KongKeySet.
+            properties:
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a Konnect ControlPlane
+                  with which KongKeySet is associated.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              name:
+                description: Name is a name of the KeySet.
+                minLength: 1
+                type: string
+              tags:
+                description: Tags is an optional set of strings associated with the
+                  KeySet for grouping and filtering.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - name
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongKeySetStatus defines the status for a KongKeySet.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+            - it's not supported yet
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: konglicenses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongLicense
+    listKind: KongLicenseList
+    plural: konglicenses
+    shortNames:
+    - kl
+    singular: konglicense
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Enabled to configure on Kong gateway instances
+      jsonPath: .enabled
+      name: Enabled
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongLicense stores a Kong enterprise license to apply to managed
+          Kong gateway instances.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          enabled:
+            default: true
+            description: |-
+              Enabled is set to true to let controllers (like KIC or KGO) to reconcile it.
+              Default value is true to apply the license by default.
+            type: boolean
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          rawLicenseString:
+            description: RawLicenseString is a string with the raw content of the
+              license.
+            type: string
+          status:
+            description: Status is the status of the KongLicense being processed by
+              controllers.
+            properties:
+              controllers:
+                items:
+                  description: |-
+                    KongLicenseControllerStatus is the status of owning KongLicense being processed
+                    identified by the controllerName field.
+                  properties:
+                    conditions:
+                      default:
+                      - lastTransitionTime: "1970-01-01T00:00:00Z"
+                        message: Waiting for controller
+                        reason: Pending
+                        status: Unknown
+                        type: Programmed
+                      description: Conditions describe the current conditions of the
+                        KongLicense on the controller.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is an identifier of the controller to reconcile this KongLicense.
+                        Should be unique in the list of controller statuses.
+                      type: string
+                    controllerRef:
+                      description: |-
+                        ControllerRef is the reference of the controller to reconcile this KongLicense.
+                        It is usually the name of (KIC/KGO) pod that reconciles it.
+                      properties:
+                        group:
+                          description: |-
+                            Group is the group of referent.
+                            It should be empty if the referent is in "core" group (like pod).
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          description: |-
+                            Kind is the kind of the referent.
+                            By default the nil kind means kind Pod.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent.
+                            It should be empty if the referent is cluster scoped.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - controllerName
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - controllerName
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - enabled
+        - rawLicenseString
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongpluginbindings.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongPluginBinding
+    listKind: KongPluginBindingList
+    plural: kongpluginbindings
+    singular: kongpluginbinding
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Kind of the plugin
+      jsonPath: .spec.pluginRef.kind
+      name: Plugin-kind
+      type: string
+    - description: Name of the plugin
+      jsonPath: .spec.pluginRef.name
+      name: Plugin-name
+      type: string
+    - description: The Resource is Programmed
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongPluginBinding is the schema for Plugin Bindings API which
+          defines a Kong Plugin Binding.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongPluginBindingSpec defines specification of a KongPluginBinding.
+            properties:
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a ControlPlane this
+                  KongPluginBinding is associated with.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              pluginRef:
+                description: PluginReference is a reference to the KongPlugin or KongClusterPlugin
+                  resource.
+                properties:
+                  kind:
+                    default: KongPlugin
+                    description: Kind can be KongPlugin or KongClusterPlugin. If not
+                      set, it is assumed to be KongPlugin.
+                    enum:
+                    - KongPlugin
+                    - KongClusterPlugin
+                    type: string
+                  name:
+                    description: Name is the name of the KongPlugin or KongClusterPlugin
+                      resource.
+                    type: string
+                required:
+                - name
+                type: object
+                x-kubernetes-validations:
+                - message: pluginRef name must be set
+                  rule: self.name != ''
+              targets:
+                description: |-
+                  Targets contains the targets references. It is possible to set multiple combinations
+                  of references, as described in https://docs.konghq.com/gateway/latest/key-concepts/plugins/#precedence
+                  The complete set of allowed combinations and their order of precedence for plugins
+                  configured to multiple entities is:
+
+                  1. Consumer + route + service
+                  2. Consumer group + service + route
+                  3. Consumer + route
+                  4. Consumer + service
+                  5. Consumer group + route
+                  6. Consumer group + service
+                  7. Route + service
+                  8. Consumer
+                  9. Consumer group
+                  10. Route
+                  11. Service
+                properties:
+                  consumerGroupRef:
+                    description: |-
+                      ConsumerGroupReference is used to reference a configuration.konghq.com/ConsumerGroup resource.
+                      The group/kind is fixed, therefore the reference is performed only by name.
+                    properties:
+                      name:
+                        description: Name is the name of the entity.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  consumerRef:
+                    description: |-
+                      ConsumerReference is used to reference a configuration.konghq.com/Consumer resource.
+                      The group/kind is fixed, therefore the reference is performed only by name.
+                    properties:
+                      name:
+                        description: Name is the name of the entity.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  routeRef:
+                    description: |-
+                      RouteReference can be used to reference one of the following resouces:
+                      - networking.k8s.io/Ingress
+                      - gateway.networking.k8s.io/HTTPRoute
+                      - gateway.networking.k8s.io/GRPCRoute
+                      - configuration.konghq.com/KongRoute
+                    properties:
+                      group:
+                        enum:
+                        - ""
+                        - core
+                        - networking.k8s.io
+                        - gateway.networking.k8s.io
+                        - configuration.konghq.com
+                        type: string
+                      kind:
+                        enum:
+                        - Service
+                        - Ingress
+                        - HTTPRoute
+                        - GRPCRoute
+                        - KongService
+                        - KongRoute
+                        type: string
+                      name:
+                        description: Name is the name of the entity.
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-validations:
+                    - message: group/kind not allowed for the routeRef
+                      rule: (self.kind == 'KongRoute' && self.group == 'configuration.konghq.com')
+                        || (self.kind == 'Ingress' && self.group == 'networking.k8s.io')
+                        || (self.kind == 'HTTPRoute' && self.group == 'gateway.networking.k8s.io')
+                        || (self.kind == 'GRPCRoute' && self.group == 'gateway.networking.k8s.io')
+                  serviceRef:
+                    description: |-
+                      ServiceReference can be used to reference one of the following resouces:
+                      - core/Service or /Service
+                      - configuration.konghq.com/KongService
+                    properties:
+                      group:
+                        enum:
+                        - ""
+                        - core
+                        - networking.k8s.io
+                        - gateway.networking.k8s.io
+                        - configuration.konghq.com
+                        type: string
+                      kind:
+                        enum:
+                        - Service
+                        - Ingress
+                        - HTTPRoute
+                        - GRPCRoute
+                        - KongService
+                        - KongRoute
+                        type: string
+                      name:
+                        description: Name is the name of the entity.
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-validations:
+                    - message: group/kind not allowed for the serviceRef
+                      rule: (self.kind == 'KongService' && self.group == 'configuration.konghq.com')
+                        || (self.kind == 'Service' && (self.group == '' || self.group
+                        == 'core'))
+                type: object
+                x-kubernetes-validations:
+                - message: Cannot set Consumer and ConsumerGroup at the same time
+                  rule: '(has(self.consumerRef) ? !has(self.consumerGroupRef) : true)'
+                - message: At least one entity reference must be set
+                  rule: has(self.routeRef) || has(self.serviceRef) || has(self.consumerRef)
+                    || has(self.consumerGroupRef)
+                - message: KongRoute can be used only when serviceRef is unset or
+                    set to KongService
+                  rule: '(has(self.routeRef) && self.routeRef.kind == ''KongRoute'')
+                    ? (!has(self.serviceRef) || self.serviceRef.kind == ''KongService'')
+                    : true'
+                - message: KongService can be used only when routeRef is unset or
+                    set to KongRoute
+                  rule: '(has(self.serviceRef) && self.serviceRef.kind == ''KongService'')
+                    ? (!has(self.routeRef) || self.routeRef.kind == ''KongRoute'')
+                    : true'
+            required:
+            - pluginRef
+            - targets
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongPluginBindingStatus represents the current status of
+              the KongBinding resource.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongplugins.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongPlugin
+    listKind: KongPluginList
+    plural: kongplugins
+    shortNames:
+    - kp
+    singular: kongplugin
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the plugin
+      jsonPath: .plugin
+      name: Plugin-Type
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Indicates if the plugin is disabled
+      jsonPath: .disabled
+      name: Disabled
+      priority: 1
+      type: boolean
+    - description: Configuration of the plugin
+      jsonPath: .config
+      name: Config
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: KongPlugin is the Schema for the kongplugins API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          config:
+            description: |-
+              Config contains the plugin configuration. It's a list of keys and values
+              required to configure the plugin.
+              Please read the documentation of the plugin being configured to set values
+              in here. For any plugin in Kong, anything that goes in the `config` JSON
+              key in the Admin API request, goes into this property.
+              Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          configFrom:
+            description: |-
+              ConfigFrom references a secret containing the plugin configuration.
+              This should be used when the plugin configuration contains sensitive information,
+              such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin.
+              Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once.
+            properties:
+              secretKeyRef:
+                description: Specifies a name and a key of a secret to refer to. The
+                  namespace is implicitly set to the one of referring object.
+                properties:
+                  key:
+                    description: The key containing the value.
+                    type: string
+                  name:
+                    description: The secret containing the key.
+                    type: string
+                required:
+                - key
+                - name
+                type: object
+            required:
+            - secretKeyRef
+            type: object
+          configPatches:
+            description: |-
+              ConfigPatches represents JSON patches to the configuration of the plugin.
+              Each item means a JSON patch to add something in the configuration,
+              where path is specified in `path` and value is in `valueFrom` referencing
+              a key in a secret.
+              When Config is specified, patches will be applied to the configuration in Config.
+              Otherwise, patches will be applied to an empty object.
+            items:
+              description: |-
+                ConfigPatch is a JSON patch (RFC6902) to add values from Secret to the generated configuration.
+                It is an equivalent of the following patch:
+                `{"op": "add", "path": {.Path}, "value": {.ComputedValueFrom}}`.
+              properties:
+                path:
+                  description: Path is the JSON-Pointer value (RFC6901) that references
+                    a location within the target configuration.
+                  type: string
+                valueFrom:
+                  description: ValueFrom is the reference to a key of a secret where
+                    the patched value comes from.
+                  properties:
+                    secretKeyRef:
+                      description: Specifies a name and a key of a secret to refer
+                        to. The namespace is implicitly set to the one of referring
+                        object.
+                      properties:
+                        key:
+                          description: The key containing the value.
+                          type: string
+                        name:
+                          description: The secret containing the key.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                  required:
+                  - secretKeyRef
+                  type: object
+              required:
+              - path
+              - valueFrom
+              type: object
+            type: array
+          consumerRef:
+            description: ConsumerRef is a reference to a particular consumer.
+            type: string
+          disabled:
+            description: Disabled set if the plugin is disabled or not.
+            type: boolean
+          instance_name:
+            description: |-
+              InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the
+              same plugin in multiple contexts, for example, on multiple services.
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          ordering:
+            description: |-
+              Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise.
+              `<phase>` is a request processing phase (for example, `access` or `body_filter`) and
+              `<plugin>` is the name of the plugin that will run before or after the KongPlugin.
+              For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]`
+              will create a rate limiting plugin that limits requests _before_ they are authenticated.
+            properties:
+              after:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: PluginOrderingPhase indicates which plugins in a phase
+                  should affect the target plugin's order
+                type: object
+              before:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: PluginOrderingPhase indicates which plugins in a phase
+                  should affect the target plugin's order
+                type: object
+            type: object
+          plugin:
+            description: PluginName is the name of the plugin to which to apply the
+              config.
+            type: string
+          protocols:
+            description: |-
+              Protocols configures plugin to run on requests received on specific
+              protocols.
+            items:
+              description: |-
+                KongProtocol is a valid Kong protocol.
+                This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
+              enum:
+              - http
+              - https
+              - grpc
+              - grpcs
+              - tcp
+              - tls
+              - udp
+              type: string
+            type: array
+          run_on:
+            description: |-
+              RunOn configures the plugin to run on the first or the second or both
+              nodes in case of a service mesh deployment.
+            enum:
+            - first
+            - second
+            - all
+            type: string
+          status:
+            description: Status represents the current status of the KongPlugin resource.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the KongPluginStatus.
+
+                  Known condition types are:
+
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - plugin
+        type: object
+        x-kubernetes-validations:
+        - message: Using both config and configFrom fields is not allowed.
+          rule: '!(has(self.config) && has(self.configFrom))'
+        - message: Using both configFrom and configPatches fields is not allowed.
+          rule: '!(has(self.configFrom) && has(self.configPatches))'
+        - message: The plugin field is immutable
+          rule: self.plugin == oldSelf.plugin
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongroutes.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongRoute
+    listKind: KongRouteList
+    plural: kongroutes
+    singular: kongroute
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongRoute is the schema for Routes API which defines a Kong Route.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongRouteSpec defines specification of a Kong Route.
+            properties:
+              controlPlaneRef:
+                description: |-
+                  ControlPlaneRef is a reference to a ControlPlane this KongRoute is associated with.
+                  Route can either specify a ControlPlaneRef and be 'serviceless' route or
+                  specify a ServiceRef and be associated with a Service.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              destinations:
+                description: A list of IP destinations of incoming connections that
+                  match this Route when using stream routing. Each entry is an object
+                  with fields "ip" (optionally in CIDR range notation) and/or "port".
+                items:
+                  properties:
+                    ip:
+                      type: string
+                    port:
+                      format: int64
+                      type: integer
+                  type: object
+                type: array
+              headers:
+                additionalProperties:
+                  type: string
+                description: 'One or more lists of values indexed by header name that
+                  will cause this Route to match if present in the request. The `Host`
+                  header cannot be used with this attribute: hosts should be specified
+                  using the `hosts` attribute. When `headers` contains only one value
+                  and that value starts with the special prefix `~*`, the value is
+                  interpreted as a regular expression.'
+                type: object
+              hosts:
+                description: A list of domain names that match this Route. Note that
+                  the hosts value is case sensitive.
+                items:
+                  type: string
+                type: array
+              https_redirect_status_code:
+                description: 'The status code Kong responds with when all properties
+                  of a Route match except the protocol i.e. if the protocol of the
+                  request is `HTTP` instead of `HTTPS`. `Location` header is injected
+                  by Kong if the field is set to 301, 302, 307 or 308. Note: This
+                  config applies only if the Route is configured to only accept the
+                  `https` protocol.'
+                format: int64
+                type: integer
+              methods:
+                description: A list of HTTP methods that match this Route.
+                items:
+                  type: string
+                type: array
+              name:
+                description: The name of the Route. Route names must be unique, and
+                  they are case sensitive. For example, there can be two different
+                  Routes named "test" and "Test".
+                type: string
+              path_handling:
+                description: Controls how the Service path, Route path and requested
+                  path are combined when sending a request to the upstream. See above
+                  for a detailed description of each behavior.
+                type: string
+              paths:
+                description: A list of paths that match this Route.
+                items:
+                  type: string
+                type: array
+              preserve_host:
+                description: When matching a Route via one of the `hosts` domain names,
+                  use the request `Host` header in the upstream request headers. If
+                  set to `false`, the upstream `Host` header will be that of the Service's
+                  `host`.
+                type: boolean
+              protocols:
+                description: An array of the protocols this Route should allow. See
+                  KongRoute for a list of accepted protocols. When set to only `"https"`,
+                  HTTP requests are answered with an upgrade error. When set to only
+                  `"http"`, HTTPS requests are answered with an error.
+                items:
+                  type: string
+                type: array
+              regex_priority:
+                description: A number used to choose which route resolves a given
+                  request when several routes match it using regexes simultaneously.
+                  When two routes match the path and have the same `regex_priority`,
+                  the older one (lowest `created_at`) is used. Note that the priority
+                  for non-regex routes is different (longer non-regex routes are matched
+                  before shorter ones).
+                format: int64
+                type: integer
+              request_buffering:
+                description: Whether to enable request body buffering or not. With
+                  HTTP 1.1, it may make sense to turn this off on services that receive
+                  data with chunked transfer encoding.
+                type: boolean
+              response_buffering:
+                description: Whether to enable response body buffering or not. With
+                  HTTP 1.1, it may make sense to turn this off on services that send
+                  data with chunked transfer encoding.
+                type: boolean
+              serviceRef:
+                description: |-
+                  ServiceRef is a reference to a Service this KongRoute is associated with.
+                  Route can either specify a ControlPlaneRef and be 'serviceless' route or
+                  specify a ServiceRef and be associated with a Service.
+                properties:
+                  namespacedRef:
+                    description: NamespacedRef is a reference to a KongService.
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - namespacedRef
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: when type is namespacedRef, namespacedRef must be set
+                  rule: 'self.type == ''namespacedRef'' ? has(self.namespacedRef)
+                    : true'
+              snis:
+                description: A list of SNIs that match this Route when using stream
+                  routing.
+                items:
+                  type: string
+                type: array
+              sources:
+                description: A list of IP sources of incoming connections that match
+                  this Route when using stream routing. Each entry is an object with
+                  fields "ip" (optionally in CIDR range notation) and/or "port".
+                items:
+                  properties:
+                    ip:
+                      type: string
+                    port:
+                      format: int64
+                      type: integer
+                  type: object
+                type: array
+              strip_path:
+                description: When matching a Route via one of the `paths`, strip the
+                  matching prefix from the upstream request URL.
+                type: boolean
+              tags:
+                description: An optional set of strings associated with the Route
+                  for grouping and filtering.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongRouteStatus represents the current status of the Kong
+              Route resource.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this entity is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                  serviceID:
+                    description: ServiceID is the Konnect ID of the Service this entity
+                      is associated with.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: serviceRef is required once set
+          rule: '!has(oldSelf.spec.serviceRef) || has(self.spec.serviceRef)'
+        - message: If protocols has 'http', at least one of 'hosts', 'methods', 'paths'
+            or 'headers' must be set
+          rule: 'has(self.spec.protocols) && self.spec.protocols.exists(p, p == ''http'')
+            ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths)
+            || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers)
+            ) : true'
+        - message: Only one of controlPlaneRef or serviceRef can be set
+          rule: has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || !has(self.spec.controlPlaneRef)
+            && has(self.spec.serviceRef)
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef)
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+        - message: spec.serviceRef is immutable when an entity is already Programmed
+          rule: '!has(self.spec.serviceRef) ? true : (!self.status.conditions.exists(c,
+            c.type == ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.serviceRef
+            == self.spec.serviceRef'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '!has(self.spec.controlPlaneRef) ? true :(!self.status.conditions.exists(c,
+            c.type == ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
+            == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongservices.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongService
+    listKind: KongServiceList
+    plural: kongservices
+    singular: kongservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Host of the service
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: Protocol of the service
+      jsonPath: .spec.procol
+      name: Protocol
+      type: string
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongService is the schema for Services API which defines a Kong
+          Service.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongServiceSpec defines specification of a Kong Route.
+            properties:
+              connect_timeout:
+                description: The timeout in milliseconds for establishing a connection
+                  to the upstream server.
+                format: int64
+                type: integer
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a ControlPlane this
+                  KongService is associated with.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              enabled:
+                description: 'Whether the Service is active. If set to `false`, the
+                  proxy behavior will be as if any routes attached to it do not exist
+                  (404). Default: `true`.'
+                type: boolean
+              host:
+                description: The host of the upstream server. Note that the host value
+                  is case sensitive.
+                type: string
+              name:
+                description: The Service name.
+                type: string
+              path:
+                description: The path to be used in requests to the upstream server.
+                type: string
+              port:
+                description: The upstream server port.
+                format: int64
+                type: integer
+              protocol:
+                description: The protocol used to communicate with the upstream.
+                type: string
+              read_timeout:
+                description: The timeout in milliseconds between two successive read
+                  operations for transmitting a request to the upstream server.
+                format: int64
+                type: integer
+              retries:
+                description: The number of retries to execute upon failure to proxy.
+                format: int64
+                type: integer
+              tags:
+                description: An optional set of strings associated with the Service
+                  for grouping and filtering.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+              tls_verify:
+                description: Whether to enable verification of upstream server TLS
+                  certificate. If set to `null`, then the Nginx default is respected.
+                type: boolean
+              tls_verify_depth:
+                description: Maximum depth of chain while verifying Upstream server's
+                  TLS certificate. If set to `null`, then the Nginx default is respected.
+                format: int64
+                type: integer
+              url:
+                description: Helper field to set `protocol`, `host`, `port` and `path`
+                  using a URL. This field is write-only and is not returned in responses.
+                type: string
+              write_timeout:
+                description: The timeout in milliseconds between two successive write
+                  operations for transmitting a request to the upstream server.
+                format: int64
+                type: integer
+            required:
+            - host
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongServiceStatus represents the current status of the Kong
+              Service resource.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongsnis.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongSNI
+    listKind: KongSNIList
+    plural: kongsnis
+    singular: kongsni
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongSNI is the schema for SNI API which defines a Kong SNI.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongSNISpec defines specification of a Kong SNI.
+            properties:
+              certificateRef:
+                description: CertificateRef is the reference to the certificate to
+                  which the KongSNI is attached.
+                properties:
+                  name:
+                    description: |-
+                      Name is the name of the entity.
+
+                      NOTE: the `Required` validation rule does not reject empty strings so we use `MinLength` to reject empty string here.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              name:
+                description: Name is the name of the SNI. Required and must be a host
+                  or wildcard host.
+                minLength: 1
+                type: string
+              tags:
+                description: Tags is an optional set of strings associated with the
+                  SNI for grouping and filtering.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - certificateRef
+            - name
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongSNIStatus defines the status for a KongSNI.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  certificateID:
+                    description: CertificateID is the Konnect ID of the Certificate
+                      this entity is associated with.
+                    type: string
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this entity is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.certificateRef is immutable when programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.certificateRef == self.spec.certificateRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongtargets.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongTarget
+    listKind: KongTargetList
+    plural: kongtargets
+    singular: kongtarget
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongTarget is the schema for Target API which defines a Kong
+          Target attached to a Kong Upstream.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KongTargetSpec defines the specification of a Kong Target.
+              KongTargetSpec defines the desired state of KongTarget.
+            properties:
+              tags:
+                description: Tags is an optional set of strings associated with the
+                  Target for grouping and filtering.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+              target:
+                description: Target is the target address of the upstream.
+                type: string
+              upstreamRef:
+                description: UpstreamRef is a reference to a KongUpstream this KongTarget
+                  is attached to.
+                properties:
+                  name:
+                    description: Name is the name of the entity.
+                    type: string
+                required:
+                - name
+                type: object
+              weight:
+                default: 100
+                description: Weight is the weight this target gets within the upstream
+                  loadbalancer.
+                maximum: 65535
+                minimum: 0
+                type: integer
+            required:
+            - target
+            - upstreamRef
+            - weight
+            type: object
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongTargetStatus defines the observed state of KongTarget.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this entity is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                  upstreamID:
+                    description: UpstreamID is the Konnect ID of the Upstream this
+                      entity is associated with.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: spec.upstreamRef is immutable
+          rule: oldSelf.spec.upstreamRef == self.spec.upstreamRef
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    gateway.networking.k8s.io/policy: direct
+  name: kongupstreampolicies.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongUpstreamPolicy
+    listKind: KongUpstreamPolicyList
+    plural: kongupstreampolicies
+    shortNames:
+    - kup
+    singular: kongupstreampolicy
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KongUpstreamPolicy allows configuring algorithm that should be used for load balancing traffic between Kong
+          Upstream's Targets. It also allows configuring health checks for Kong Upstream's Targets.
+
+          Its configuration is similar to Kong Upstream object (https://docs.konghq.com/gateway/latest/admin-api/#upstream-object),
+          and it is applied to Kong Upstream objects created by the controller.
+
+          It can be attached to Services. To attach it to a Service, it has to be annotated with
+          `konghq.com/upstream-policy: <name>`, where `<name>` is the name of the KongUpstreamPolicy
+          object in the same namespace as the Service.
+
+          When attached to a Service, it will affect all Kong Upstreams created for the Service.
+
+          When attached to a Service used in a Gateway API *Route rule with multiple BackendRefs, all of its Services MUST
+          be configured with the same KongUpstreamPolicy. Otherwise, the controller will *ignore* the KongUpstreamPolicy.
+
+          Note: KongUpstreamPolicy doesn't implement Gateway API's GEP-713 strictly.
+          In particular, it doesn't use the TargetRef for attaching to Services and Gateway API *Routes - annotations are
+          used instead. This is to allow reusing the same KongUpstreamPolicy for multiple Services and Gateway API *Routes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the configuration of the Kong upstream.
+            properties:
+              algorithm:
+                description: |-
+                  Algorithm is the load balancing algorithm to use.
+                  Accepted values are: "round-robin", "consistent-hashing", "least-connections", "latency".
+                enum:
+                - round-robin
+                - consistent-hashing
+                - least-connections
+                - latency
+                type: string
+              hashOn:
+                description: |-
+                  HashOn defines how to calculate hash for consistent-hashing load balancing algorithm.
+                  Algorithm must be set to "consistent-hashing" for this field to have effect.
+                properties:
+                  cookie:
+                    description: Cookie is the name of the cookie to use as hash input.
+                    type: string
+                  cookiePath:
+                    description: CookiePath is cookie path to set in the response
+                      headers.
+                    type: string
+                  header:
+                    description: Header is the name of the header to use as hash input.
+                    type: string
+                  input:
+                    description: |-
+                      Input allows using one of the predefined inputs (ip, consumer, path).
+                      For other parametrized inputs, use one of the fields below.
+                    enum:
+                    - ip
+                    - consumer
+                    - path
+                    type: string
+                  queryArg:
+                    description: QueryArg is the name of the query argument to use
+                      as hash input.
+                    type: string
+                  uriCapture:
+                    description: URICapture is the name of the URI capture group to
+                      use as hash input.
+                    type: string
+                type: object
+              hashOnFallback:
+                description: |-
+                  HashOnFallback defines how to calculate hash for consistent-hashing load balancing algorithm if the primary hash
+                  function fails.
+                  Algorithm must be set to "consistent-hashing" for this field to have effect.
+                properties:
+                  cookie:
+                    description: Cookie is the name of the cookie to use as hash input.
+                    type: string
+                  cookiePath:
+                    description: CookiePath is cookie path to set in the response
+                      headers.
+                    type: string
+                  header:
+                    description: Header is the name of the header to use as hash input.
+                    type: string
+                  input:
+                    description: |-
+                      Input allows using one of the predefined inputs (ip, consumer, path).
+                      For other parametrized inputs, use one of the fields below.
+                    enum:
+                    - ip
+                    - consumer
+                    - path
+                    type: string
+                  queryArg:
+                    description: QueryArg is the name of the query argument to use
+                      as hash input.
+                    type: string
+                  uriCapture:
+                    description: URICapture is the name of the URI capture group to
+                      use as hash input.
+                    type: string
+                type: object
+              healthchecks:
+                description: Healthchecks defines the health check configurations
+                  in Kong.
+                properties:
+                  active:
+                    description: Active configures active health check probing.
+                    properties:
+                      concurrency:
+                        description: Concurrency is the number of targets to check
+                          concurrently.
+                        minimum: 1
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Headers is a list of HTTP headers to add to the
+                          probe request.
+                        type: object
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          httpStatuses:
+                            description: HTTPStatuses is a list of HTTP status codes
+                              that Kong considers a success.
+                            items:
+                              description: HTTPStatus is an HTTP status code.
+                              maximum: 599
+                              minimum: 100
+                              type: integer
+                            type: array
+                          interval:
+                            description: Interval is the interval between active health
+                              checks for an upstream in seconds when in a healthy
+                              state.
+                            minimum: 0
+                            type: integer
+                          successes:
+                            description: Successes is the number of successes to consider
+                              a target healthy.
+                            minimum: 0
+                            type: integer
+                        type: object
+                      httpPath:
+                        description: HTTPPath is the path to use in GET HTTP request
+                          to run as a probe.
+                        pattern: ^/.*$
+                        type: string
+                      httpsSni:
+                        description: HTTPSSNI is the SNI to use in GET HTTPS request
+                          to run as a probe.
+                        type: string
+                      httpsVerifyCertificate:
+                        description: HTTPSVerifyCertificate is a boolean value that
+                          indicates if the certificate should be verified.
+                        type: boolean
+                      timeout:
+                        description: Timeout is the probe timeout in seconds.
+                        minimum: 0
+                        type: integer
+                      type:
+                        description: |-
+                          Type determines whether to perform active health checks using HTTP or HTTPS, or just attempt a TCP connection.
+                          Accepted values are "http", "https", "tcp", "grpc", "grpcs".
+                        enum:
+                        - http
+                        - https
+                        - tcp
+                        - grpc
+                        - grpcs
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy for an upstream.
+                        properties:
+                          httpFailures:
+                            description: HTTPFailures is the number of failures to
+                              consider a target unhealthy.
+                            minimum: 0
+                            type: integer
+                          httpStatuses:
+                            description: HTTPStatuses is a list of HTTP status codes
+                              that Kong considers a failure.
+                            items:
+                              description: HTTPStatus is an HTTP status code.
+                              maximum: 599
+                              minimum: 100
+                              type: integer
+                            type: array
+                          interval:
+                            description: Interval is the interval between active health
+                              checks for an upstream in seconds when in an unhealthy
+                              state.
+                            minimum: 0
+                            type: integer
+                          tcpFailures:
+                            description: TCPFailures is the number of TCP failures
+                              in a row to consider a target unhealthy.
+                            minimum: 0
+                            type: integer
+                          timeouts:
+                            description: Timeouts is the number of timeouts in a row
+                              to consider a target unhealthy.
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  passive:
+                    description: Passive configures passive health check probing.
+                    properties:
+                      healthy:
+                        description: Healthy configures thresholds and HTTP status
+                          codes to mark targets healthy for an upstream.
+                        properties:
+                          httpStatuses:
+                            description: HTTPStatuses is a list of HTTP status codes
+                              that Kong considers a success.
+                            items:
+                              description: HTTPStatus is an HTTP status code.
+                              maximum: 599
+                              minimum: 100
+                              type: integer
+                            type: array
+                          interval:
+                            description: Interval is the interval between active health
+                              checks for an upstream in seconds when in a healthy
+                              state.
+                            minimum: 0
+                            type: integer
+                          successes:
+                            description: Successes is the number of successes to consider
+                              a target healthy.
+                            minimum: 0
+                            type: integer
+                        type: object
+                      type:
+                        description: |-
+                          Type determines whether to perform passive health checks interpreting HTTP/HTTPS statuses,
+                          or just check for TCP connection success.
+                          Accepted values are "http", "https", "tcp", "grpc", "grpcs".
+                        enum:
+                        - http
+                        - https
+                        - tcp
+                        - grpc
+                        - grpcs
+                        type: string
+                      unhealthy:
+                        description: Unhealthy configures thresholds and HTTP status
+                          codes to mark targets unhealthy.
+                        properties:
+                          httpFailures:
+                            description: HTTPFailures is the number of failures to
+                              consider a target unhealthy.
+                            minimum: 0
+                            type: integer
+                          httpStatuses:
+                            description: HTTPStatuses is a list of HTTP status codes
+                              that Kong considers a failure.
+                            items:
+                              description: HTTPStatus is an HTTP status code.
+                              maximum: 599
+                              minimum: 100
+                              type: integer
+                            type: array
+                          interval:
+                            description: Interval is the interval between active health
+                              checks for an upstream in seconds when in an unhealthy
+                              state.
+                            minimum: 0
+                            type: integer
+                          tcpFailures:
+                            description: TCPFailures is the number of TCP failures
+                              in a row to consider a target unhealthy.
+                            minimum: 0
+                            type: integer
+                          timeouts:
+                            description: Timeouts is the number of timeouts in a row
+                              to consider a target unhealthy.
+                            minimum: 0
+                            type: integer
+                        type: object
+                    type: object
+                  threshold:
+                    description: |-
+                      Threshold is the minimum percentage of the upstream’s targets’ weight that must be available for the whole
+                      upstream to be considered healthy.
+                    type: integer
+                type: object
+              slots:
+                description: |-
+                  Slots is the number of slots in the load balancer algorithm.
+                  If not set, the default value in Kong for the algorithm is used.
+                maximum: 65536
+                minimum: 10
+                type: integer
+            type: object
+          status:
+            description: Status defines the current state of KongUpstreamPolicy
+            properties:
+              ancestors:
+                description: |-
+                  Ancestors is a list of ancestor resources (usually Gateways) that are
+                  associated with the policy, and the status of the policy with respect to
+                  each ancestor. When this policy attaches to a parent, the controller that
+                  manages the parent and the ancestors MUST add an entry to this list when
+                  the controller first sees the policy and SHOULD update the entry as
+                  appropriate when the relevant ancestor is modified.
+
+                  Note that choosing the relevant ancestor is left to the Policy designers;
+                  an important part of Policy design is designing the right object level at
+                  which to namespace this status.
+
+                  Note also that implementations MUST ONLY populate ancestor status for
+                  the Ancestor resources they are responsible for. Implementations MUST
+                  use the ControllerName field to uniquely identify the entries in this list
+                  that they are responsible for.
+
+                  Note that to achieve this, the list of PolicyAncestorStatus structs
+                  MUST be treated as a map with a composite key, made up of the AncestorRef
+                  and ControllerName fields combined.
+
+                  A maximum of 16 ancestors will be represented in this list. An empty list
+                  means the Policy is not relevant for any ancestors.
+
+                  If this slice is full, implementations MUST NOT add further entries.
+                  Instead they MUST consider the policy unimplementable and signal that
+                  on any related resources such as the ancestor that would be referenced
+                  here. For example, if this list was full on BackendTLSPolicy, no
+                  additional Gateways would be able to reference the Service targeted by
+                  the BackendTLSPolicy.
+                items:
+                  description: |-
+                    PolicyAncestorStatus describes the status of a route with respect to an
+                    associated Ancestor.
+
+                    Ancestors refer to objects that are either the Target of a policy or above it
+                    in terms of object hierarchy. For example, if a policy targets a Service, the
+                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                    useful object to place Policy status on, so we recommend that implementations
+                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                    have a _very_ good reason otherwise.
+
+                    In the context of policy attachment, the Ancestor is used to distinguish which
+                    resource results in a distinct application of this policy. For example, if a policy
+                    targets a Service, it may have a distinct result per attached Gateway.
+
+                    Policies targeting the same resource may have different effects depending on the
+                    ancestors of those resources. For example, different Gateways targeting the same
+                    Service may have different capabilities, especially if they have different underlying
+                    implementations.
+
+                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                    In this case, the relevant object for status is the Gateway, and that is the
+                    ancestor object referred to in this status.
+
+                    Note that a parent is also an ancestor, so for objects where the parent is the
+                    relevant object for status, this struct SHOULD still be used.
+
+                    This struct is intended to be used in a slice that's effectively a map,
+                    with a composite key made up of the AncestorRef and the ControllerName.
+                  properties:
+                    ancestorRef:
+                      description: |-
+                        AncestorRef corresponds with a ParentRef in the spec that this
+                        PolicyAncestorStatus struct describes the status of.
+                      properties:
+                        group:
+                          default: gateway.networking.k8s.io
+                          description: |-
+                            Group is the group of the referent.
+                            When unspecified, "gateway.networking.k8s.io" is inferred.
+                            To set the core API group (such as for a "Service" kind referent),
+                            Group must be explicitly set to "" (empty string).
+
+                            Support: Core
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Gateway
+                          description: |-
+                            Kind is kind of the referent.
+
+                            There are two kinds of parent resources with "Core" support:
+
+                            * Gateway (Gateway conformance profile)
+                            * Service (Mesh conformance profile, ClusterIP Services only)
+
+                            Support for other resources is Implementation-Specific.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the referent.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace is the namespace of the referent. When unspecified, this refers
+                            to the local namespace of the Route.
+
+                            Note that there are specific rules for ParentRefs which cross namespace
+                            boundaries. Cross-namespace references are only valid if they are explicitly
+                            allowed by something in the namespace they are referring to. For example:
+                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                            generic way to enable any other kind of cross-namespace reference.
+
+                            <gateway:experimental:description>
+                            ParentRefs from a Route to a Service in the same namespace are "producer"
+                            routes, which apply default routing rules to inbound connections from
+                            any namespace to the Service.
+
+                            ParentRefs from a Route to a Service in a different namespace are
+                            "consumer" routes, and these routing rules are only applied to outbound
+                            connections originating from the same namespace as the Route, for which
+                            the intended destination of the connections are a Service targeted as a
+                            ParentRef of the Route.
+                            </gateway:experimental:description>
+
+                            Support: Core
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          description: |-
+                            Port is the network port this Route targets. It can be interpreted
+                            differently based on the type of parent resource.
+
+                            When the parent resource is a Gateway, this targets all listeners
+                            listening on the specified port that also support this kind of Route(and
+                            select this Route). It's not recommended to set `Port` unless the
+                            networking behaviors specified in a Route must apply to a specific port
+                            as opposed to a listener(s) whose port(s) may be changed. When both Port
+                            and SectionName are specified, the name and port of the selected listener
+                            must match both specified values.
+
+                            <gateway:experimental:description>
+                            When the parent resource is a Service, this targets a specific port in the
+                            Service spec. When both Port (experimental) and SectionName are specified,
+                            the name and port of the selected port must match both specified values.
+                            </gateway:experimental:description>
+
+                            Implementations MAY choose to support other parent resources.
+                            Implementations supporting other types of parent resources MUST clearly
+                            document how/if Port is interpreted.
+
+                            For the purpose of status, an attachment is considered successful as
+                            long as the parent resource accepts it partially. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                            from the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route,
+                            the Route MUST be considered detached from the Gateway.
+
+                            Support: Extended
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        sectionName:
+                          description: |-
+                            SectionName is the name of a section within the target resource. In the
+                            following resources, SectionName is interpreted as the following:
+
+                            * Gateway: Listener name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+                            * Service: Port name. When both Port (experimental) and SectionName
+                            are specified, the name and port of the selected listener must match
+                            both specified values.
+
+                            Implementations MAY choose to support attaching Routes to other resources.
+                            If that is the case, they MUST clearly document how SectionName is
+                            interpreted.
+
+                            When unspecified (empty string), this will reference the entire resource.
+                            For the purpose of status, an attachment is considered successful if at
+                            least one section in the parent resource accepts it. For example, Gateway
+                            listeners can restrict which Routes can attach to them by Route kind,
+                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                            the referencing Route, the Route MUST be considered successfully
+                            attached. If no Gateway listeners accept attachment from this Route, the
+                            Route MUST be considered detached from the Gateway.
+
+                            Support: Core
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    conditions:
+                      description: Conditions describes the status of the Policy with
+                        respect to the given Ancestor.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      maxItems: 8
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    controllerName:
+                      description: |-
+                        ControllerName is a domain/path string that indicates the name of the
+                        controller that wrote this status. This corresponds with the
+                        controllerName field on GatewayClass.
+
+                        Example: "example.net/gateway-controller".
+
+                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                        valid Kubernetes names
+                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                        Controllers MUST populate this field when writing status. Controllers should ensure that
+                        entries to status populated with their ControllerName are cleaned up when they are no
+                        longer necessary.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                      type: string
+                  required:
+                  - ancestorRef
+                  - controllerName
+                  type: object
+                maxItems: 16
+                type: array
+            required:
+            - ancestors
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: Only one of spec.hashOn.(input|cookie|header|uriCapture|queryArg)
+            can be set.
+          rule: 'has(self.spec.hashOn) ? [has(self.spec.hashOn.input), has(self.spec.hashOn.cookie),
+            has(self.spec.hashOn.header), has(self.spec.hashOn.uriCapture), has(self.spec.hashOn.queryArg)].filter(fieldSet,
+            fieldSet == true).size() <= 1 : true'
+        - message: When spec.hashOn.cookie is set, spec.hashOn.cookiePath is required.
+          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? has(self.spec.hashOn.cookiePath)
+            : true'
+        - message: When spec.hashOn.cookiePath is set, spec.hashOn.cookie is required.
+          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookiePath) ? has(self.spec.hashOn.cookie)
+            : true'
+        - message: spec.algorithm must be set to "consistent-hashing" when spec.hashOn
+            is set.
+          rule: 'has(self.spec.hashOn) ? has(self.spec.algorithm) && self.spec.algorithm
+            == "consistent-hashing" : true'
+        - message: Only one of spec.hashOnFallback.(input|header|uriCapture|queryArg)
+            can be set.
+          rule: 'has(self.spec.hashOnFallback) ? [has(self.spec.hashOnFallback.input),
+            has(self.spec.hashOnFallback.header), has(self.spec.hashOnFallback.uriCapture),
+            has(self.spec.hashOnFallback.queryArg)].filter(fieldSet, fieldSet == true).size()
+            <= 1 : true'
+        - message: spec.algorithm must be set to "consistent-hashing" when spec.hashOnFallback
+            is set.
+          rule: 'has(self.spec.hashOnFallback) ? has(self.spec.algorithm) && self.spec.algorithm
+            == "consistent-hashing" : true'
+        - message: spec.hashOnFallback.cookie must not be set.
+          rule: 'has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookie)
+            : true'
+        - message: spec.hashOnFallback.cookiePath must not be set.
+          rule: 'has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookiePath)
+            : true'
+        - message: spec.healthchecks.passive.healthy.interval must not be set.
+          rule: 'has(self.spec.healthchecks) && has(self.spec.healthchecks.passive)
+            && has(self.spec.healthchecks.passive.healthy) ? !has(self.spec.healthchecks.passive.healthy.interval)
+            : true'
+        - message: spec.healthchecks.passive.unhealthy.interval must not be set.
+          rule: 'has(self.spec.healthchecks) && has(self.spec.healthchecks.passive)
+            && has(self.spec.healthchecks.passive.unhealthy) ? !has(self.spec.healthchecks.passive.unhealthy.interval)
+            : true'
+        - message: spec.hashOnFallback must not be set when spec.hashOn.cookie is
+            set.
+          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? !has(self.spec.hashOnFallback)
+            : true'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongupstreams.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    kind: KongUpstream
+    listKind: KongUpstreamList
+    plural: kongupstreams
+    singular: kongupstream
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KongUpstream is the schema for Upstream API which defines a Kong
+          Upstream.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongUpstreamSpec defines specification of a Kong Upstream.
+            properties:
+              algorithm:
+                description: Which load balancing algorithm to use.
+                type: string
+              client_certificate:
+                description: If set, the certificate to be used as client certificate
+                  while TLS handshaking to the upstream server.
+                properties:
+                  id:
+                    type: string
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a ControlPlane this
+                  KongUpstream is associated with.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              hash_fallback:
+                description: What to use as hashing input if the primary `hash_on`
+                  does not return a hash (eg. header is missing, or no Consumer identified).
+                  Not available if `hash_on` is set to `cookie`.
+                type: string
+              hash_fallback_header:
+                description: The header name to take the value from as hash input.
+                  Only required when `hash_fallback` is set to `header`.
+                type: string
+              hash_fallback_query_arg:
+                description: The name of the query string argument to take the value
+                  from as hash input. Only required when `hash_fallback` is set to
+                  `query_arg`.
+                type: string
+              hash_fallback_uri_capture:
+                description: The name of the route URI capture to take the value from
+                  as hash input. Only required when `hash_fallback` is set to `uri_capture`.
+                type: string
+              hash_on:
+                description: What to use as hashing input. Using `none` results in
+                  a weighted-round-robin scheme with no hashing.
+                type: string
+              hash_on_cookie:
+                description: The cookie name to take the value from as hash input.
+                  Only required when `hash_on` or `hash_fallback` is set to `cookie`.
+                  If the specified cookie is not in the request, Kong will generate
+                  a value and set the cookie in the response.
+                type: string
+              hash_on_cookie_path:
+                description: The cookie path to set in the response headers. Only
+                  required when `hash_on` or `hash_fallback` is set to `cookie`.
+                type: string
+              hash_on_header:
+                description: The header name to take the value from as hash input.
+                  Only required when `hash_on` is set to `header`.
+                type: string
+              hash_on_query_arg:
+                description: The name of the query string argument to take the value
+                  from as hash input. Only required when `hash_on` is set to `query_arg`.
+                type: string
+              hash_on_uri_capture:
+                description: The name of the route URI capture to take the value from
+                  as hash input. Only required when `hash_on` is set to `uri_capture`.
+                type: string
+              healthchecks:
+                properties:
+                  active:
+                    properties:
+                      concurrency:
+                        format: int64
+                        type: integer
+                      headers:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      healthy:
+                        properties:
+                          http_statuses:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          interval:
+                            type: number
+                          successes:
+                            format: int64
+                            type: integer
+                        required:
+                        - interval
+                        - successes
+                        type: object
+                      http_path:
+                        type: string
+                      https_sni:
+                        type: string
+                      https_verify_certificate:
+                        type: boolean
+                      timeout:
+                        type: number
+                      type:
+                        type: string
+                      unhealthy:
+                        properties:
+                          http_failures:
+                            format: int64
+                            type: integer
+                          http_statuses:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          interval:
+                            type: number
+                          tcp_failures:
+                            format: int64
+                            type: integer
+                          timeouts:
+                            format: int64
+                            type: integer
+                        required:
+                        - http_failures
+                        - interval
+                        - tcp_failures
+                        - timeouts
+                        type: object
+                    required:
+                    - concurrency
+                    - http_path
+                    - https_verify_certificate
+                    - timeout
+                    - type
+                    type: object
+                  passive:
+                    properties:
+                      healthy:
+                        properties:
+                          http_statuses:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          successes:
+                            format: int64
+                            type: integer
+                        required:
+                        - successes
+                        type: object
+                      type:
+                        type: string
+                      unhealthy:
+                        properties:
+                          http_failures:
+                            format: int64
+                            type: integer
+                          http_statuses:
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          tcp_failures:
+                            format: int64
+                            type: integer
+                          timeouts:
+                            format: int64
+                            type: integer
+                        required:
+                        - http_failures
+                        - tcp_failures
+                        - timeouts
+                        type: object
+                    required:
+                    - type
+                    type: object
+                  threshold:
+                    type: number
+                required:
+                - threshold
+                type: object
+              host_header:
+                description: The hostname to be used as `Host` header when proxying
+                  requests through Kong.
+                type: string
+              name:
+                description: This is a hostname, which must be equal to the `host`
+                  of a Service.
+                type: string
+              slots:
+                description: The number of slots in the load balancer algorithm. If
+                  `algorithm` is set to `round-robin`, this setting determines the
+                  maximum number of slots. If `algorithm` is set to `consistent-hashing`,
+                  this setting determines the actual number of slots in the algorithm.
+                  Accepts an integer in the range `10`-`65536`.
+                format: int64
+                maximum: 65536
+                minimum: 10
+                type: integer
+              tags:
+                description: An optional set of strings associated with the Upstream
+                  for grouping and filtering.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+              use_srv_name:
+                description: If set, the balancer will use SRV hostname(if DNS Answer
+                  has SRV record) as the proxy upstream `Host`.
+                type: boolean
+            type: object
+            x-kubernetes-validations:
+            - message: hash_fallback_header is required when `hash_fallback` is set
+                to `header`.
+              rule: '!has(self.hash_fallback) || (self.hash_fallback != ''header''
+                || has(self.hash_fallback_header))'
+            - message: hash_fallback_query_arg is required when `hash_fallback` is
+                set to `query_arg`.
+              rule: '!has(self.hash_fallback) || (self.hash_fallback != ''query_arg''
+                || has(self.hash_fallback_query_arg))'
+            - message: hash_fallback_uri_capture is required when `hash_fallback`
+                is set to `uri_capture`.
+              rule: '!has(self.hash_fallback) || (self.hash_fallback != ''uri_capture''
+                || has(self.hash_fallback_uri_capture))'
+            - message: hash_on_cookie is required when hash_fallback is set to `cookie`.
+              rule: '!has(self.hash_fallback) || (self.hash_fallback != ''cookie''
+                || has(self.hash_on_cookie))'
+            - message: hash_on_cookie is required when hash_on is set to `cookie`.
+              rule: '!has(self.hash_on) || (self.hash_on != ''cookie'' || has(self.hash_on_cookie))'
+            - message: hash_on_cookie_path is required when hash_fallback is set to
+                `cookie`.
+              rule: '!has(self.hash_fallback) || (self.hash_fallback != ''cookie''
+                || has(self.hash_on_cookie_path))'
+            - message: hash_on_cookie_path is required when hash_on is set to `cookie`.
+              rule: '!has(self.hash_on) || (self.hash_on != ''cookie'' || has(self.hash_on_cookie_path))'
+            - message: hash_on_header is required when hash_on is set to `header`.
+              rule: '!has(self.hash_on) || (self.hash_on != ''header'' || has(self.hash_on_header))'
+            - message: hash_on_query_arg is required when `hash_on` is set to `query_arg`.
+              rule: '!has(self.hash_on) || (self.hash_on != ''query_arg'' || has(self.hash_on_query_arg))'
+            - message: hash_on_uri_capture is required when `hash_on` is set to `uri_capture`.
+              rule: '!has(self.hash_on) || (self.hash_on != ''uri_capture'' || has(self.hash_on_uri_capture))'
+          status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Pending
+                status: Unknown
+                type: Programmed
+            description: KongUpstreamStatus represents the current status of the Kong
+              Upstream resource.
+            properties:
+              conditions:
+                description: Conditions describe the status of the Konnect entity.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: kongvaults.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: KongVault
+    listKind: KongVaultList
+    plural: kongvaults
+    shortNames:
+    - kv
+    singular: kongvault
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the backend of the vault
+      jsonPath: .spec.backend
+      name: Backend Type
+      type: string
+    - description: Prefix of vault URI to reference the values in the vault
+      jsonPath: .spec.prefix
+      name: Prefix
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Description
+      jsonPath: .spec.description
+      name: Description
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+      name: Programmed
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KongVault is the schema for kongvaults API which defines a custom Kong vault.
+          A Kong vault is a storage to store sensitive data, where the values can be referenced in configuration of plugins.
+          See: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KongVaultSpec defines specification of a custom Kong vault.
+            properties:
+              backend:
+                description: |-
+                  Backend is the type of the backend storing the secrets in the vault.
+                  The supported backends of Kong is listed here:
+                  https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/backends/
+                minLength: 1
+                type: string
+              config:
+                description: Config is the configuration of the vault. Varies for
+                  different backends.
+                x-kubernetes-preserve-unknown-fields: true
+              controlPlaneRef:
+                description: ControlPlaneRef is a reference to a Konnect ControlPlane
+                  this KongVault is associated with.
+                properties:
+                  konnectID:
+                    description: |-
+                      KonnectID is the schema for the KonnectID type.
+                      This field is required when the Type is konnectID.
+                    type: string
+                  konnectNamespacedRef:
+                    description: |-
+                      KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster.
+                      It contains the name of the Konnect Control Plane.
+                      This field is required when the Type is konnectNamespacedRef.
+                    properties:
+                      name:
+                        description: Name is the name of the Konnect Control Plane.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: |-
+                      Type can be one of:
+                      - konnectID
+                      - konnectNamespacedRef
+                      - kic
+                    enum:
+                    - konnectID
+                    - konnectNamespacedRef
+                    - kic
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: when type is konnectNamespacedRef, konnectNamespacedRef
+                    must be set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
+                - message: when type is konnectID, konnectID must be set
+                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
+              description:
+                description: Description is the additional information about the vault.
+                type: string
+              prefix:
+                description: |-
+                  Prefix is the prefix of vault URI for referencing values in the vault.
+                  It is immutable after created.
+                minLength: 1
+                type: string
+              tags:
+                description: Tags are the tags associated to the vault for grouping
+                  and filtering.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-validations:
+                - message: tags entries must not be longer than 128 characters
+                  rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
+            required:
+            - backend
+            - prefix
+            type: object
+          status:
+            description: KongVaultStatus represents the current status of the KongVault
+              resource.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the KongVaultStatus.
+
+                  Known condition types are:
+
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              konnect:
+                description: Konnect contains the Konnect entity status.
+                properties:
+                  controlPlaneID:
+                    description: ControlPlaneID is the Konnect ID of the ControlPlane
+                      this Route is associated with.
+                    type: string
+                  id:
+                    description: |-
+                      ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                      If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                    type: string
+                  organizationID:
+                    description: OrgID is ID of Konnect Org that this entity has been
+                      created in.
+                    type: string
+                  serverURL:
+                    description: ServerURL is the URL of the Konnect server in which
+                      the entity exists.
+                    type: string
+                type: object
+            required:
+            - conditions
+            type: object
+        required:
+        - spec
+        type: object
+        x-kubernetes-validations:
+        - message: The spec.prefix field is immutable
+          rule: self.spec.prefix == oldSelf.spec.prefix
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
+            ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
+            == self.spec.controlPlaneRef'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: konnectapiauthconfigurations.konnect.konghq.com
+spec:
+  group: konnect.konghq.com
+  names:
+    kind: KonnectAPIAuthConfiguration
+    listKind: KonnectAPIAuthConfigurationList
+    plural: konnectapiauthconfigurations
+    singular: konnectapiauthconfiguration
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The API authentication information is valid
+      jsonPath: .status.conditions[?(@.type=='APIAuthValid')].status
+      name: Valid
+      type: string
+    - description: Konnect Organization ID this API authentication configuration belongs
+        to.
+      jsonPath: .status.organizationID
+      name: OrgID
+      type: string
+    - description: Configured server URL.
+      jsonPath: .status.serverURL
+      name: ServerURL
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KonnectAPIAuthConfiguration is the Schema for the Konnect configuration
+          type.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the specification of the KonnectAPIAuthConfiguration
+              resource.
+            properties:
+              secretRef:
+                description: |-
+                  SecretRef is a reference to a Kubernetes Secret containing the Konnect token.
+                  This secret is required to have the konghq.com/credential label set to "konnect".
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              serverURL:
+                description: |-
+                  ServerURL is the URL of the Konnect server.
+                  It can be either a full URL with an HTTPs scheme or just a hostname.
+                  Please refer to https://docs.konghq.com/konnect/network/ for the list of supported hostnames.
+                type: string
+                x-kubernetes-validations:
+                - message: Server URL is required
+                  rule: size(self) > 0
+                - message: Server URL is immutable
+                  rule: self == oldSelf
+                - message: Server URL must use HTTPs if specifying scheme
+                  rule: 'isURL(self) ? url(self).getScheme() == ''https'' : true'
+                - message: Server URL must satisfy hostname (RFC 1123) regex if not
+                    a valid absolute URL
+                  rule: 'size(self) > 0 && !isURL(self) ? self.matches(''^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]).)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$'')
+                    : true'
+              token:
+                description: Token is the Konnect token used to authenticate with
+                  the Konnect API.
+                type: string
+              type:
+                description: KonnectAPIAuthType is the type of authentication used
+                  to authenticate with the Konnect API.
+                enum:
+                - token
+                - secretRef
+                type: string
+            required:
+            - serverURL
+            - type
+            type: object
+            x-kubernetes-validations:
+            - message: spec.token is required if auth type is set to token
+              rule: 'self.type == ''token'' ? size(self.token) > 0 : true'
+            - message: spec.secretRef is required if auth type is set to secretRef
+              rule: 'self.type == ''secretRef'' ? has(self.secretRef) : true'
+            - message: spec.token and spec.secretRef cannot be set at the same time
+              rule: '!(has(self.token) && has(self.secretRef))'
+          status:
+            description: Status is the status of the KonnectAPIAuthConfiguration resource.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Valid
+                description: Conditions describe the status of the Konnect configuration.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              organizationID:
+                description: OrganizationID is the unique identifier of the organization
+                  in Konnect.
+                type: string
+              serverURL:
+                description: ServerURL is configured server URL.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: Konnect tokens have to start with spat_ or kpat_
+          rule: self.spec.type != 'token' || (self.spec.token.startsWith('spat_')
+            || self.spec.token.startsWith('kpat_'))
+        - message: Token is required once set
+          rule: self.spec.type != 'token' || (!has(oldSelf.spec.token) || has(self.spec.token))
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: konnectgatewaycontrolplanes.konnect.konghq.com
+spec:
+  group: konnect.konghq.com
+  names:
+    kind: KonnectGatewayControlPlane
+    listKind: KonnectGatewayControlPlaneList
+    plural: konnectgatewaycontrolplanes
+    singular: konnectgatewaycontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The Resource is Programmed on Konnect
+      jsonPath: .status.conditions[?(@.type=='Programmed')].status
+      name: Programmed
+      type: string
+    - description: Konnect ID
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Konnect Organization ID this resource belongs to.
+      jsonPath: .status.organizationID
+      name: OrgID
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KonnectGatewayControlPlane is the Schema for the KonnectGatewayControlplanes
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of KonnectGatewayControlPlane.
+            properties:
+              auth_type:
+                description: The auth type value of the cluster associated with the
+                  Runtime Group.
+                type: string
+              cloud_gateway:
+                description: Whether this control-plane can be used for cloud-gateways.
+                type: boolean
+              cluster_type:
+                description: The ClusterType value of the cluster associated with
+                  the Control Plane.
+                type: string
+              description:
+                description: The description of the control plane in Konnect.
+                type: string
+              konnect:
+                description: KonnectConfiguration is the Schema for the KonnectConfiguration
+                  API.
+                properties:
+                  authRef:
+                    description: |-
+                      APIAuthConfigurationRef is the reference to the API Auth Configuration
+                      that should be used for this Konnect Configuration.
+                    properties:
+                      name:
+                        description: Name is the name of the KonnectAPIAuthConfiguration
+                          resource.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - authRef
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types.
+
+                  Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".
+                type: object
+              members:
+                description: |-
+                  Members is a list of references to the KonnectGatewayControlPlaneMembers that are part of this control plane group.
+                  Only applicable for ControlPlanes that are created as groups.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              name:
+                description: The name of the control plane.
+                type: string
+              proxy_urls:
+                description: Array of proxy URLs associated with reaching the data-planes
+                  connected to a control-plane.
+                items:
+                  description: ProxyURL - Proxy URL associated with reaching the data-planes
+                    connected to a control-plane.
+                  properties:
+                    host:
+                      description: Hostname of the proxy URL.
+                      type: string
+                    port:
+                      description: Port of the proxy URL.
+                      format: int64
+                      type: integer
+                    protocol:
+                      description: Protocol of the proxy URL.
+                      type: string
+                  required:
+                  - host
+                  - port
+                  - protocol
+                  type: object
+                type: array
+            required:
+            - name
+            type: object
+            x-kubernetes-validations:
+            - message: spec.labels must not have more than 40 entries
+              rule: 'has(self.labels) ? size(self.labels) <= 40 : true'
+            - message: spec.labels keys must be of length 1-63 characters
+              rule: 'has(self.labels) ? self.labels.all(key, size(key) >= 1 && size(key)
+                <= 63) : true'
+            - message: spec.labels values must be of length 1-63 characters
+              rule: 'has(self.labels) ? self.labels.all(key, size(self.labels[key])
+                >= 1 && size(self.labels[key]) <= 63) : true'
+            - message: spec.labels keys must not start with 'k8s', 'kong', 'konnect',
+                'mesh', 'kic', 'insomnia' or '_'
+              rule: 'has(self.labels) ? self.labels.all(key, !key.startsWith(''k8s'')
+                && !key.startsWith(''kong'') && !key.startsWith(''konnect'') && !key.startsWith(''mesh'')
+                && !key.startsWith(''kic'') && !key.startsWith(''_'') && !key.startsWith(''insomnia''))
+                : true'
+            - message: spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
+                pattern
+              rule: 'has(self.labels) ? self.labels.all(key, key.matches(''^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$''))
+                : true'
+            - message: when specified, spec.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP',
+                'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'
+              rule: '!has(self.cluster_type) ? true : [''CLUSTER_TYPE_CONTROL_PLANE_GROUP'',
+                ''CLUSTER_TYPE_CONTROL_PLANE'', ''CLUSTER_TYPE_K8S_INGRESS_CONTROLLER''].exists(ct,
+                ct == self.cluster_type)'
+            - message: spec.members is only applicable for ControlPlanes that are
+                created as groups
+              rule: '(has(self.cluster_type) && self.cluster_type != ''CLUSTER_TYPE_CONTROL_PLANE_GROUP'')
+                ? !has(self.members) : true'
+          status:
+            description: Status defines the observed state of KonnectGatewayControlPlane.
+            properties:
+              conditions:
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Pending
+                  status: Unknown
+                  type: Programmed
+                description: |-
+                  Conditions describe the current conditions of the KonnectGatewayControlPlane.
+
+                  Known condition types are:
+
+                  * "Programmed"
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: |-
+                  ID is the unique identifier of the Konnect entity as assigned by Konnect API.
+                  If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+                type: string
+              organizationID:
+                description: OrgID is ID of Konnect Org that this entity has been
+                  created in.
+                type: string
+              serverURL:
+                description: ServerURL is the URL of the Konnect server in which the
+                  entity exists.
+                type: string
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: spec.konnect.authRef is immutable when an entity is already Programmed
+          rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+        - message: spec.konnect.authRef is immutable when an entity refers to a Valid
+            API Auth Configuration
+          rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status
+            == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+        - message: spec.cluster_type is immutable
+          rule: self.spec.cluster_type == oldSelf.spec.cluster_type
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: tcpingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: TCPIngress
+    listKind: TCPIngressList
+    plural: tcpingresses
+    singular: tcpingress
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TCPIngress is the Schema for the tcpingresses API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the TCPIngress specification.
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: |-
+                    IngressRule represents a rule to apply against incoming requests.
+                    Matching is performed based on an (optional) SNI and port.
+                  properties:
+                    backend:
+                      description: |-
+                        Backend defines the referenced service endpoint to which the traffic
+                        will be forwarded to.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          minLength: 1
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    host:
+                      description: |-
+                        Host is the fully qualified domain name of a network host, as defined
+                        by RFC 3986.
+                        If a Host is not specified, then port-based TCP routing is performed. Kong
+                        doesn't care about the content of the TCP stream in this case.
+                        If a Host is specified, the protocol must be TLS over TCP.
+                        A plain-text TCP request cannot be routed based on Host. It can only
+                        be routed based on Port.
+                      type: string
+                    port:
+                      description: |-
+                        Port is the port on which to accept TCP or TLS over TCP sessions and
+                        route. It is a required field. If a Host is not specified, the requested
+                        are routed based only on Port.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - backend
+                  - port
+                  type: object
+                type: array
+              tls:
+                description: |-
+                  TLS configuration. This is similar to the `tls` section in the
+                  Ingress resource in networking.v1beta1 group.
+                  The mapping of SNIs to TLS cert-key pair defined here will be
+                  used for HTTP Ingress rules as well. Once can define the mapping in
+                  this resource or the original Ingress resource, both have the same
+                  effect.
+                items:
+                  description: IngressTLS describes the transport layer security.
+                  properties:
+                    hosts:
+                      description: |-
+                        Hosts are a list of hosts included in the TLS certificate. The values in
+                        this list must match the name/s used in the tlsSecret. Defaults to the
+                        wildcard host setting for the loadbalancer controller fulfilling this
+                        Ingress, if left unspecified.
+                      items:
+                        type: string
+                      type: array
+                    secretName:
+                      description: SecretName is the name of the secret used to terminate
+                        SSL traffic.
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TCPIngressStatus defines the observed state of TCPIngress.
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: |-
+                      Ingress is a list containing ingress points for the load-balancer.
+                      Traffic intended for the service should be sent to these ingress points.
+                    items:
+                      description: |-
+                        LoadBalancerIngress represents the status of a load-balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname is set for load-balancer ingress points that are DNS based
+                            (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: |-
+                            IP is set for load-balancer ingress points that are IP based
+                            (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ipMode:
+                          description: |-
+                            IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                            Setting this to "VIP" indicates that traffic is delivered to the node with
+                            the destination set to the load-balancer's IP and port.
+                            Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                            the destination set to the node's IP and node port or the pod's IP and port.
+                            Service implementations may use this information to adjust traffic routing.
+                          type: string
+                        ports:
+                          description: |-
+                            Ports is a list of records of service ports
+                            If used, every port defined in the service should have an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: |-
+                                  Error is to record the problem with the service port
+                                  The format of the error shall comply with the following rules:
+                                  - built-in error values shall be specified in this file and those shall use
+                                    CamelCase names
+                                  - cloud provider specific error values must have names that comply with the
+                                    format foo.example.com/CamelCase.
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                description: |-
+                                  Protocol is the protocol of the service port of which status is recorded here
+                                  The supported values are: "TCP", "UDP", "SCTP"
+                                type: string
+                            required:
+                            - error
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  name: udpingresses.configuration.konghq.com
+spec:
+  group: configuration.konghq.com
+  names:
+    categories:
+    - kong-ingress-controller
+    kind: UDPIngress
+    listKind: UDPIngressList
+    plural: udpingresses
+    singular: udpingress
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address of the load balancer
+      jsonPath: .status.loadBalancer.ingress[*].ip
+      name: Address
+      type: string
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UDPIngress is the Schema for the udpingresses API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the UDPIngress specification.
+            properties:
+              rules:
+                description: A list of rules used to configure the Ingress.
+                items:
+                  description: |-
+                    UDPIngressRule represents a rule to apply against incoming requests
+                    wherein no Host matching is available for request routing, only the port
+                    is used to match requests.
+                  properties:
+                    backend:
+                      description: |-
+                        Backend defines the Kubernetes service which accepts traffic from the
+                        listening Port defined above.
+                      properties:
+                        serviceName:
+                          description: Specifies the name of the referenced service.
+                          minLength: 1
+                          type: string
+                        servicePort:
+                          description: Specifies the port of the referenced service.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                      required:
+                      - serviceName
+                      - servicePort
+                      type: object
+                    port:
+                      description: |-
+                        Port indicates the port for the Kong proxy to accept incoming traffic
+                        on, which will then be routed to the service Backend.
+                      format: int32
+                      maximum: 65535
+                      minimum: 1
+                      type: integer
+                  required:
+                  - backend
+                  - port
+                  type: object
+                type: array
+            type: object
+          status:
+            description: UDPIngressStatus defines the observed state of UDPIngress.
+            properties:
+              loadBalancer:
+                description: LoadBalancer contains the current status of the load-balancer.
+                properties:
+                  ingress:
+                    description: |-
+                      Ingress is a list containing ingress points for the load-balancer.
+                      Traffic intended for the service should be sent to these ingress points.
+                    items:
+                      description: |-
+                        LoadBalancerIngress represents the status of a load-balancer ingress point:
+                        traffic intended for the service should be sent to an ingress point.
+                      properties:
+                        hostname:
+                          description: |-
+                            Hostname is set for load-balancer ingress points that are DNS based
+                            (typically AWS load-balancers)
+                          type: string
+                        ip:
+                          description: |-
+                            IP is set for load-balancer ingress points that are IP based
+                            (typically GCE or OpenStack load-balancers)
+                          type: string
+                        ipMode:
+                          description: |-
+                            IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                            Setting this to "VIP" indicates that traffic is delivered to the node with
+                            the destination set to the load-balancer's IP and port.
+                            Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                            the destination set to the node's IP and node port or the pod's IP and port.
+                            Service implementations may use this information to adjust traffic routing.
+                          type: string
+                        ports:
+                          description: |-
+                            Ports is a list of records of service ports
+                            If used, every port defined in the service should have an entry in it
+                          items:
+                            properties:
+                              error:
+                                description: |-
+                                  Error is to record the problem with the service port
+                                  The format of the error shall comply with the following rules:
+                                  - built-in error values shall be specified in this file and those shall use
+                                    CamelCase names
+                                  - cloud provider specific error values must have names that comply with the
+                                    format foo.example.com/CamelCase.
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              port:
+                                description: Port is the port number of the service
+                                  port of which status is recorded here
+                                format: int32
+                                type: integer
+                              protocol:
+                                description: |-
+                                  Protocol is the protocol of the service port of which status is recorded here
+                                  The supported values are: "TCP", "UDP", "SCTP"
+                                type: string
+                            required:
+                            - error
+                            - port
+                            - protocol
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -40,6 +40,10 @@ podLabels: {}
 kic-crds:
   enabled: true
 
+# Install Kong's Kubernetes Configuration CRDs (https://github.com/Kong/kubernetes-configuration)
+kubernetes-configuration-crds:
+  enabled: false
+
 # Install Gateway API standard CRDs
 gwapi-standard-crds:
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a `kubernetes-configuration-crds` subchart to the `gateway-operator` chart so that users can install the CRDs by setting `kubernetes-configuration-crds.enabled=true`. 

#### Which issue this PR fixes

Part of https://github.com/Kong/gateway-operator/issues/720.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
