### PR TITLE
chore(kgo): bump kconf-crds dependency

### DIFF
--- a/charts/gateway-operator/Chart.lock
+++ b/charts/gateway-operator/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.0
 - name: kubernetes-configuration-crds
   repository: ""
-  version: 0.0.35
-digest: sha256:ce87c26c263258a5258892fef8266f4e6d5760663de1ae36e1846e74f8481918
-generated: "2024-10-24T17:00:35.905215+02:00"
+  version: 0.0.38
+digest: sha256:bb2e90569c330baac439854178279982b4e0558771ca5da7fe38c8a4d281cf5f
+generated: "2024-10-30T20:35:30.928038+01:00"

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.3"
 annotations:
   artifacthub.io/prerelease: "false"
@@ -24,5 +24,5 @@ dependencies:
     version: 1.1.0
     condition: gwapi-experimental-crds.enabled
   - name: kubernetes-configuration-crds
-    version: 0.0.35
+    version: 0.0.38
     condition: kubernetes-configuration-crds.enabled

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubernetes-configuration-crds
-version: 0.0.35
-appVersion: "0.0.35"
+version: 0.0.38
+appVersion: "0.0.38"
 description: A Helm chart for Kong's Kubernetes Configuration CRDs

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/README.md
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/README.md
@@ -11,5 +11,5 @@ This sub-chart contains Kong's [Kubernetes Configuration][kconf] CRDs, allowing 
 To update the CRDs, you can run the following command:
 
 ```bash
-kustomize build github.com/kong/kubernetes-configuration/config/crd > ./charts/gateway-operator/charts/kubernetes-configuration/crds/kubernetes-configuration-crds.yaml
+kustomize build github.com/kong/kubernetes-configuration/config/crd > ./charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
 ```

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: ingressclassparameterses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -59,7 +59,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongcacertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -291,7 +291,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -538,7 +538,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -844,7 +844,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1084,7 +1084,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1351,7 +1351,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongcredentialacls.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1538,7 +1538,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1725,7 +1725,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1916,7 +1916,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2109,7 +2109,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongcredentialjwts.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2326,7 +2326,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongcustomentities.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2509,7 +2509,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2741,7 +2741,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3132,7 +3132,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongkeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3443,7 +3443,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongkeysets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3675,7 +3675,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3873,7 +3873,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongpluginbindings.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4255,7 +4255,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4555,7 +4555,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongroutes.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4941,7 +4941,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongservices.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5233,7 +5233,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongsnis.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5421,7 +5421,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongtargets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5613,7 +5613,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   labels:
     gateway.networking.k8s.io/policy: direct
   name: kongupstreampolicies.configuration.konghq.com
@@ -6299,7 +6299,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongupstreams.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -6747,7 +6747,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -7026,7 +7026,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -7227,7 +7227,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -7396,6 +7396,9 @@ spec:
                 created as groups
               rule: '(has(self.cluster_type) && self.cluster_type != ''CLUSTER_TYPE_CONTROL_PLANE_GROUP'')
                 ? !has(self.members) : true'
+            - message: spec.cluster_type is immutable
+              rule: '!has(self.cluster_type) ? !has(oldSelf.cluster_type) : self.cluster_type
+                == oldSelf.cluster_type'
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
@@ -7494,8 +7497,6 @@ spec:
             API Auth Configuration
           rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status
             == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
-        - message: spec.cluster_type is immutable
-          rule: self.spec.cluster_type == oldSelf.spec.cluster_type
     served: true
     storage: true
     subresources:
@@ -7505,7 +7506,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: tcpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -7712,7 +7713,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
+    controller-gen.kubebuilder.io/version: v0.16.5
   name: udpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com


### PR DESCRIPTION

#### What this PR does / why we need it:

Bumps kconf CRDs and releases a patch.
