### PR TITLE
chore(kgo): bump KGO and kconf

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0
+
+### Changes
+
+- Bump the operator's default version to 1.4.0 and `kong/kubernetes-configuration` CRDs to 0.0.41.
+  [#1161](https://github.com/Kong/charts/pull/1161)
+
 ## 0.3.0
 
 ### Changes

--- a/charts/gateway-operator/Chart.lock
+++ b/charts/gateway-operator/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.0
 - name: kubernetes-configuration-crds
   repository: ""
-  version: 0.0.38
-digest: sha256:bb2e90569c330baac439854178279982b4e0558771ca5da7fe38c8a4d281cf5f
-generated: "2024-10-30T20:35:30.928038+01:00"
+  version: 0.0.41
+digest: sha256:7833a0a6b9d736a0227f77212df4ad2eec572b367da2c8d1fece5eb617d45a95
+generated: "2024-11-07T10:09:06.705774+01:00"

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,8 +8,8 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.3.1
-appVersion: "1.3"
+version: 0.4.0
+appVersion: "1.4"
 annotations:
   artifacthub.io/prerelease: "false"
 
@@ -24,5 +24,5 @@ dependencies:
     version: 1.1.0
     condition: gwapi-experimental-crds.enabled
   - name: kubernetes-configuration-crds
-    version: 0.0.38
+    version: 0.0.41
     condition: kubernetes-configuration-crds.enabled

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubernetes-configuration-crds
-version: 0.0.38
-appVersion: "0.0.38"
+version: 0.0.41
+appVersion: "0.0.41"
 description: A Helm chart for Kong's Kubernetes Configuration CRDs

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
@@ -7015,8 +7015,8 @@ spec:
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
-            ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
-            == self.spec.controlPlaneRef'
+            ''Programmed'' && c.status == ''True'') || !has(self.spec.controlPlaneRef))
+            ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
     served: true
     storage: true
     subresources:

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/kong/gateway-operator
-  tag: 1.3
+  tag: 1.4
 
 kubeRBACProxy:
   # Additional pod containers in the controller.


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Bumps KGO default version to v1.4.0 and bumps `kong/kubernetes-configuration` CRDs to v0.0.41.