### PR TITLE
docs(kgo): use gateway-operator kconf channel

### DIFF
--- a/charts/gateway-operator/UPGRADE.md
+++ b/charts/gateway-operator/UPGRADE.md
@@ -33,11 +33,11 @@ them before upgrading your release.
 
 [hip0011]: https://github.com/helm/community/blob/main/hips/hip-0011.md
 
-For example, upgrading Kong's [kubernetes-configuration][kcfg] CRDs to v0.0.38 requires
+For example, upgrading Kong's [kubernetes-configuration][kcfg] CRDs to v0.0.45 requires
 running:
 
 ```
-kustomize build github.com/Kong/kubernetes-configuration/config/crd\?rev\=v0.0.38 | kubectl apply -f -
+kustomize build github.com/Kong/kubernetes-configuration/config/crd/gateway-operator?ref=v0.0.45 | kubectl apply -f -
 ```
 
 [kcfg]: https://github.com/Kong/kubernetes-configuration

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/README.md
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/README.md
@@ -11,5 +11,5 @@ This sub-chart contains Kong's [Kubernetes Configuration][kconf] CRDs, allowing 
 To update the CRDs, you can run the following command:
 
 ```bash
-kustomize build github.com/kong/kubernetes-configuration/config/crd > ./charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
+kustomize build github.com/kong/kubernetes-configuration/config/crd/gateway-operator > ./charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
 ```

--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -1,6 +1,7 @@
 module github.com/kong/charts/tools
 
-go 1.21
+go 1.23.3
+
 require golang.stackrox.io/kube-linter v0.7.1
 
 require (


### PR DESCRIPTION
#### What this PR does / why we need it:

Starts using `config/crd/gateway-operator` channel from `kong/kubernetes-configuration` in the gateway-operator chart's docs.

#### Which issue this PR fixes

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6580

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
