### PR TITLE
feat(conf): Add migrations.ttlSecondsAfterFinished to chart template

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Added serviceMonitor.trustCRDsExist for render based deployments
+* Add migrations.ttlSecondsAfterFinished option to chart
 
 ### Changes
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Added serviceMonitor.trustCRDsExist for render based deployments
 * Add `migrations.ttlSecondsAfterFinished` option to chart
+[#1174](https://github.com/Kong/charts/pull/1174)
 
 ### Changes
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 * Added serviceMonitor.trustCRDsExist for render based deployments
-* Add migrations.ttlSecondsAfterFinished option to chart
+* Add `migrations.ttlSecondsAfterFinished` option to chart
 
 ### Changes
 

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -621,6 +621,7 @@ directory.
 | migrations.preUpgrade              | Run "kong migrations up" jobs                                                         | `true`              |
 | migrations.postUpgrade             | Run "kong migrations finish" jobs                                                     | `true`              |
 | migrations.annotations             | Annotations for migration job pods                                                    | `{"sidecar.istio.io/inject": "false" |
+| migrations.ttlSecondsAfterFinished | Automatically deletes completed pods after a specified time to clean up resources     |                     |
 | migrations.jobAnnotations          | Additional annotations for migration jobs                                             | `{}`                |
 | migrations.backoffLimit            | Override the system backoffLimit                                                      | `{}`                |
 | waitImage.enabled                  | Spawn init containers that wait for the database before starting Kong                 | `true`              |

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -584,9 +584,33 @@ The name of the Service which will be used by the controller to update the Ingre
 
 {{- end -}}
 
+{{- define "kong.migrationPodFilter" -}}
+{{ $newList := list }}
+{{- range . }}
+{{- if or (eq .excludeMigrationPod false) (not (hasKey . "excludeMigrationPod")) }}
+{{ $newList = append $newList (omit . "excludeMigrationPod") }}
+{{- end }}
+{{- end }}
+{{ toJson $newList }}
+{{- end }}
+
+{{- define "kong.userDefinedMigrationVolumes" -}}
+{{- if .Values.deployment.userDefinedVolumes }}
+{{- include "kong.migrationPodFilter" .Values.deployment.userDefinedVolumes | fromJsonArray | toYaml }}
+{{- end }}
+{{- end -}}
+
+{{- define "kong.migrationPropertyFilter" -}}
+{{ $newList := list }}
+{{- range . }}
+{{ $newList = append $newList (omit . "excludeMigrationPod") }}
+{{- end }}
+{{ toJson $newList }}
+{{- end }}
+
 {{- define "kong.userDefinedVolumes" -}}
 {{- if .Values.deployment.userDefinedVolumes }}
-{{- toYaml .Values.deployment.userDefinedVolumes }}
+{{- include "kong.migrationPropertyFilter" .Values.deployment.userDefinedVolumes | fromJsonArray | toYaml }}
 {{- end }}
 {{- end -}}
 
@@ -746,9 +770,15 @@ The name of the Service which will be used by the controller to update the Ingre
 {{- end -}}
 {{- end -}}
 
+{{- define "kong.userDefinedMigrationVolumeMounts" -}}
+{{- if .userDefinedVolumeMounts }}
+{{- include "kong.migrationPodFilter" .userDefinedVolumeMounts | fromJsonArray | toYaml }}
+{{- end }}
+{{- end -}}
+
 {{- define "kong.userDefinedVolumeMounts" -}}
 {{- if .userDefinedVolumeMounts }}
-{{- toYaml .userDefinedVolumeMounts }}
+{{- include "kong.migrationPropertyFilter" .userDefinedVolumeMounts | fromJsonArray | toYaml }}
 {{- end }}
 {{- end -}}
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -584,33 +584,9 @@ The name of the Service which will be used by the controller to update the Ingre
 
 {{- end -}}
 
-{{- define "kong.migrationPodFilter" -}}
-{{ $newList := list }}
-{{- range . }}
-{{- if or (eq .excludeMigrationPod false) (not (hasKey . "excludeMigrationPod")) }}
-{{ $newList = append $newList (omit . "excludeMigrationPod") }}
-{{- end }}
-{{- end }}
-{{ toJson $newList }}
-{{- end }}
-
-{{- define "kong.userDefinedMigrationVolumes" -}}
-{{- if .Values.deployment.userDefinedVolumes }}
-{{- include "kong.migrationPodFilter" .Values.deployment.userDefinedVolumes | fromJsonArray | toYaml }}
-{{- end }}
-{{- end -}}
-
-{{- define "kong.migrationPropertyFilter" -}}
-{{ $newList := list }}
-{{- range . }}
-{{ $newList = append $newList (omit . "excludeMigrationPod") }}
-{{- end }}
-{{ toJson $newList }}
-{{- end }}
-
 {{- define "kong.userDefinedVolumes" -}}
 {{- if .Values.deployment.userDefinedVolumes }}
-{{- include "kong.migrationPropertyFilter" .Values.deployment.userDefinedVolumes | fromJsonArray | toYaml }}
+{{- toYaml .Values.deployment.userDefinedVolumes }}
 {{- end }}
 {{- end -}}
 
@@ -770,15 +746,9 @@ The name of the Service which will be used by the controller to update the Ingre
 {{- end -}}
 {{- end -}}
 
-{{- define "kong.userDefinedMigrationVolumeMounts" -}}
-{{- if .userDefinedVolumeMounts }}
-{{- include "kong.migrationPodFilter" .userDefinedVolumeMounts | fromJsonArray | toYaml }}
-{{- end }}
-{{- end -}}
-
 {{- define "kong.userDefinedVolumeMounts" -}}
 {{- if .userDefinedVolumeMounts }}
-{{- include "kong.migrationPropertyFilter" .userDefinedVolumeMounts | fromJsonArray | toYaml }}
+{{- toYaml .userDefinedVolumeMounts }}
 {{- end }}
 {{- end -}}
 

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -18,6 +18,9 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}
+  {{- if .Values.migrations.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ template "kong.name" . }}-post-upgrade-migrations

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -72,7 +72,7 @@ spec:
         args: [ "kong", "migrations", "finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:
@@ -92,6 +92,6 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -75,7 +75,7 @@ spec:
         args: [ "kong", "migrations", "finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:
@@ -95,6 +95,6 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -77,7 +77,7 @@ spec:
         args: [ "kong", "migrations", "up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources| nindent 10 }}
       securityContext:
@@ -97,6 +97,6 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -20,6 +20,9 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}
+  {{- if .Values.migrations.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ template "kong.name" . }}-pre-upgrade-migrations

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -74,7 +74,7 @@ spec:
         args: [ "kong", "migrations", "up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources| nindent 10 }}
       securityContext:
@@ -94,6 +94,6 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -28,6 +28,9 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.migrations.backoffLimit }}
+  {{- if .Values.migrations.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migrations.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ template "kong.name" . }}-init-migrations

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -82,7 +82,7 @@ spec:
         args: [ "kong", "migrations", "bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:
@@ -102,7 +102,7 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -85,7 +85,7 @@ spec:
         args: [ "kong", "migrations", "bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:
@@ -105,7 +105,7 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -483,6 +483,8 @@ migrations:
   jobAnnotations: {}
   # Optionally set a backoffLimit. If none is set, Jobs will use the cluster default
   backoffLimit:
+  # Optionally set to specify the time-to-live (TTL) for a pod after it has completed its execution before automatic deletion. If left unset, pod lifetime is indefinite.
+  ttlSecondsAfterFinished:
   resources: {}
   # Example reasonable setting for "resources":
   # resources:


### PR DESCRIPTION
#### What this PR does / why we need it:
Adds `migrations.ttlSecondsAfterFinished` as an option in the chart template for allowing removal of migrations containers after a specified time.

The use of ttlSecondsAfterFinished was first discussed [here](https://github.com/Kong/charts/issues/203), however the TTL mechanism was in beta at the time.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
