### PR TITLE
feat(conf): Add support for `excludeMigrationPod` to userDefinedVolumes and userDefinedVolumeMounts

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Added serviceMonitor.trustCRDsExist for render based deployments
+* Add support for `excludeMigrationPod` to userDefinedVolumes and userDefinedVolumeMounts
 
 ### Changes
 

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -584,9 +584,33 @@ The name of the Service which will be used by the controller to update the Ingre
 
 {{- end -}}
 
+{{- define "kong.migrationPodFilter" -}}
+{{ $newList := list }}
+{{- range . }}
+{{- if or (eq .excludeMigrationPod false) (not (hasKey . "excludeMigrationPod")) }}
+{{ $newList = append $newList (omit . "excludeMigrationPod") }}
+{{- end }}
+{{- end }}
+{{ toJson $newList }}
+{{- end }}
+
+{{- define "kong.userDefinedMigrationVolumes" -}}
+{{- if .Values.deployment.userDefinedVolumes }}
+{{- include "kong.migrationPodFilter" .Values.deployment.userDefinedVolumes | fromJsonArray | toYaml }}
+{{- end }}
+{{- end -}}
+
+{{- define "kong.migrationPropertyFilter" -}}
+{{ $newList := list }}
+{{- range . }}
+{{ $newList = append $newList (omit . "excludeMigrationPod") }}
+{{- end }}
+{{ toJson $newList }}
+{{- end }}
+
 {{- define "kong.userDefinedVolumes" -}}
 {{- if .Values.deployment.userDefinedVolumes }}
-{{- toYaml .Values.deployment.userDefinedVolumes }}
+{{- include "kong.migrationPropertyFilter" .Values.deployment.userDefinedVolumes | fromJsonArray | toYaml }}
 {{- end }}
 {{- end -}}
 
@@ -746,9 +770,15 @@ The name of the Service which will be used by the controller to update the Ingre
 {{- end -}}
 {{- end -}}
 
+{{- define "kong.userDefinedMigrationVolumeMounts" -}}
+{{- if .userDefinedVolumeMounts }}
+{{- include "kong.migrationPodFilter" .userDefinedVolumeMounts | fromJsonArray | toYaml }}
+{{- end }}
+{{- end -}}
+
 {{- define "kong.userDefinedVolumeMounts" -}}
 {{- if .userDefinedVolumeMounts }}
-{{- toYaml .userDefinedVolumeMounts }}
+{{- include "kong.migrationPropertyFilter" .userDefinedVolumeMounts | fromJsonArray | toYaml }}
 {{- end }}
 {{- end -}}
 

--- a/charts/kong/templates/migrations-post-upgrade.yaml
+++ b/charts/kong/templates/migrations-post-upgrade.yaml
@@ -72,7 +72,7 @@ spec:
         args: [ "kong", "migrations", "finish" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:
@@ -92,6 +92,6 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations-pre-upgrade.yaml
+++ b/charts/kong/templates/migrations-pre-upgrade.yaml
@@ -74,7 +74,7 @@ spec:
         args: [ "kong", "migrations", "up" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources| nindent 10 }}
       securityContext:
@@ -94,6 +94,6 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}

--- a/charts/kong/templates/migrations.yaml
+++ b/charts/kong/templates/migrations.yaml
@@ -82,7 +82,7 @@ spec:
         args: [ "kong", "migrations", "bootstrap" ]
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-        {{- include "kong.userDefinedVolumeMounts" .Values.deployment | nindent 8 }}
+        {{- include "kong.userDefinedMigrationVolumeMounts" .Values.deployment | nindent 8 }}
         resources:
         {{- toYaml .Values.migrations.resources | nindent 10 }}
       securityContext:
@@ -102,7 +102,7 @@ spec:
       restartPolicy: OnFailure
       volumes:
       {{- include "kong.volumes" . | nindent 6 -}}
-      {{- include "kong.userDefinedVolumes" . | nindent 6 -}}
+      {{- include "kong.userDefinedMigrationVolumes" . | nindent 6 -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -57,6 +57,28 @@ deployment:
   # userDefinedVolumeMounts:
   # - name: "volumeName"
   #   mountPath: "/opt/user/dir/mount"
+
+  ## userDefinedVolumes & userDefinedVolumeMounts can be specified with excludeMigrationPod which disables adding the volumes and mounts to migration pods
+  # userDefinedVolumes:
+  # - name: "volumeNameAlways"
+  #   emptyDir: { }
+  # - name: "volumeNameNever"
+  #   excludeMigrationPod: true
+  #   emptyDir: {}
+  # - name: "volumeNameYes"
+  #   excludeMigrationPod: false
+  #   persistentVolumeClaim:
+  #     claimName: "my_claim"
+  # userDefinedVolumeMounts:
+  # - name: "volumeNameAlways"
+  #   mountPath: "/opt/user/dir/mountAlways"
+  # - name: "volumeNameNever"
+  #   excludeMigrationPod: true
+  #   mountPath: "/opt/user/dir/volumeNameNever"
+  # - name: "volumeNameYes"
+  #   excludeMigrationPod: false
+  #   mountPath: "/opt/user/dir/volumeNameYes"
+
   test:
     # Enable creation of test resources for use with "helm test"
     enabled: false


### PR DESCRIPTION
#### What this PR does / why we need it:

At the moment Kong threats migrations PODs the same way as proxy PODs, and mounts all user defined PVs to both proxy and migration PODs. 

While this might be useful in some situations, in most cases it is unnecessary to have user defined volumes mounted to migration PODs, and in some cases even not desired by the user. 

This PR allows users to exclude user defined PODs from being mounted for migration.

This could be possible in the following ways:

1. Introduce additional property to _ userDefinedVolumeMounts_ and _ userDefinedVolumes_ to allows exclusion of user defined PODs from being mounted to migration jobs.

2. Obsolete current _userDefinedVolumeMounts_ and _ userDefinedVolumes_ properties (located under root element "deployment") in favour of dedicated mounts for proxy and migration in a similar fashion as it is done for the ingress controller, where _userDefinedVolumeMounts_ and _ userDefinedVolumes_ are defined under "ingressController" root property. 

This might be done by adding _userDefinedVolumeMounts_ and _ userDefinedVolumes_ under root section called "migrations" for migrations PODs, and for proxy under root section "proxy".


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
