### PR TITLE
chore(ci): configure renovate for k8s versions

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -90,11 +90,17 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-          - "1.25.16"
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch versioning=semver
           - "1.26.15"
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch versioning=semver
           - "1.27.13"
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch versioning=semver
           - "1.28.9"
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch versioning=semver
           - "1.29.4"
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch versioning=semver
+          - "1.30.0"
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch versioning=semver
           - "1.30.0"
         chart-name:
           - kong

--- a/renovate.json
+++ b/renovate.json
@@ -14,13 +14,36 @@
   "schedule": "before 5am every weekday",
   "customManagers": [
     {
-      "description": "Match dependencies in .tools_verisons.yaml that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "description": "Match dependencies in .tools_verisons.yaml and .github/workflows/* that are properly annotated with `# renovate: datasource={} depName={}.`",
       "customType": "regex",
       "fileMatch": [
-        "\\.tools_versions\\.yaml$"
+        "\\.tools_versions\\.yaml$",
+        "\\.github/workflows/.*\\.yaml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+\"(?<currentValue>.*?)\""
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Ignore minor updates if depName has `@only-patch` suffix.",
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "enabled": false,
+      "matchDepNames": [
+        "/.*@only-patch/"
+      ]
+    },
+    {
+      "description": "Group Kubernetes updates together.",
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "groupName": "kubernetes",
+      "matchDepNames": [
+        "kubernetes/kubernetes"
       ]
     }
   ]


### PR DESCRIPTION
#### What this PR does / why we need it:

Configure renovate for k8s versions in integration tests matrix.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
