### PR TITLE
chore(ci): fix renovate @only-patch

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -90,17 +90,17 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes
           - "1.26.15"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes
           - "1.27.13"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes
           - "1.28.9"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes
           - "1.29.4"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes
           - "1.30.0"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes@only-patch
+          # renovate: datasource=github-tags depName=kubernetes/kubernetes
           - "1.31.0"
         chart-name:
           - kong

--- a/renovate.json
+++ b/renovate.json
@@ -27,13 +27,14 @@
   ],
   "packageRules": [
     {
-      "description": "Ignore minor updates if depName has `@only-patch` suffix.",
+      "description": "Only update patch versions for selected dependencies.",
       "matchUpdateTypes": [
+        "major",
         "minor"
       ],
       "enabled": false,
       "matchDepNames": [
-        "/.*@only-patch/"
+        "kubernetes/kubernetes"
       ]
     },
     {
@@ -41,7 +42,7 @@
       "matchUpdateTypes": [
         "patch"
       ],
-      "groupName": "kubernetes",
+      "groupName": "kubernetes/kubernetes",
       "matchDepNames": [
         "kubernetes/kubernetes"
       ]


### PR DESCRIPTION
#### What this PR does / why we need it:

Do not use custom suffixes in `depName` (like `@only-patch`) which seems to be broken recently. 

Related issue: https://github.com/Kong/kubernetes-ingress-controller/issues/6744

Removal of those suffixes has been tested in https://github.com/pmalek/renovate1/pull/2.