### PR TITLE
ci: renovate use kindest/node instead of kubernetes

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -13,7 +13,7 @@ on:
       - release/kong-2.x
       - release/kong-3.x
       - prepare-kgo-chart
-    workflow_dispatch: {}
+  workflow_dispatch: {}
 
 env:
   # Specify this here because these tests rely on ktf to run kind for cluster creation.
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        kubernetes-version:
+          # renovate: datasource=docker depName=kindest/node
+          - "1.31.0"
         chart-name:
           - kong
           - ingress
@@ -90,17 +93,17 @@ jobs:
     strategy:
       matrix:
         kubernetes-version:
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes
+          # renovate: datasource=docker depName=kindest/node
           - "1.26.15"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes
+          # renovate: datasource=docker depName=kindest/node
           - "1.27.13"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes
+          # renovate: datasource=docker depName=kindest/node
           - "1.28.9"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes
+          # renovate: datasource=docker depName=kindest/node
           - "1.29.4"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes
+          # renovate: datasource=docker depName=kindest/node
           - "1.30.0"
-          # renovate: datasource=github-tags depName=kubernetes/kubernetes
+          # renovate: datasource=docker depName=kindest/node
           - "1.31.0"
         chart-name:
           - kong
@@ -156,6 +159,7 @@ jobs:
 
       - name: setup testing environment (kind-cluster)
         env:
+          KUBERNETES_VERSION: "1.29.2"
           CHART_NAME: ${{ matrix.chart-name }}
         run: ./scripts/test-env.sh
 

--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,7 @@
       ],
       "enabled": false,
       "matchDepNames": [
-        "kubernetes/kubernetes"
+        "kindest/node"
       ]
     },
     {
@@ -42,9 +42,9 @@
       "matchUpdateTypes": [
         "patch"
       ],
-      "groupName": "kubernetes/kubernetes",
+      "groupName": "kindest/node",
       "matchDepNames": [
-        "kubernetes/kubernetes"
+        "kindest/node"
       ]
     }
   ]

--- a/scripts/test-env.sh
+++ b/scripts/test-env.sh
@@ -30,13 +30,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_DIR}/.."
-KIND_VERSION="${KIND_VERSION:-v0.22.0}"
-KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.29.2}"
 GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.0.0}"
 CHART_NAME="${CHART_NAME:-ingress}"
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
 KTF_URL=https://github.com/Kong/kubernetes-testing-framework/releases/latest/download/ktf.${OS}.${ARCH}
+
+[[ -z ${KUBERNETES_VERSION} ]] && echo "ERROR: KUBERNETES_VERSION is not set" && exit 1
+[[ -z ${KIND_VERSION} ]] && echo "ERROR: KIND_VERSION is not set" && exit 1
 
 # ------------------------------------------------------------------------------
 # Setup Tools - Docker
@@ -59,7 +60,7 @@ docker info 1>/dev/null
 # ensure kind command is accessible
 if ! command -v kind &> /dev/null
 then
-    go install sigs.k8s.io/kind@"${KIND_VERSION}"
+    go install sigs.k8s.io/kind@v"${KIND_VERSION}"
 fi
 
 # ensure kind is functional


### PR DESCRIPTION
#### What this PR does / why we need it:

#1180 missed the fact that `kind` uses `kindest/node` and not `kubernetes/kubernetes`.

This PR fixes this.

Tested in https://github.com/pmalek/renovate1/pull/3

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
