### PR TITLE
ci: fix release-push workflow

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -12,7 +12,6 @@ on:
       - main
       - release/kong-2.x
       - release/kong-3.x
-      - prepare-kgo-chart
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -6,12 +6,19 @@ on:
       - main
       - release/kong-2.x
 
+env:
+  # Specify this here because these tests rely on ktf to run kind for cluster creation.
+  KIND_VERSION: v0.23.0
+
 jobs:
   lint-test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        kubernetes-version:
+          # renovate: datasource=docker depName=kindest/node
+          - "1.31.0"
         chart-name:
           - kong
           - ingress
@@ -43,6 +50,7 @@ jobs:
 
       - name: setup testing environment (kind-cluster)
         env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
           CHART_NAME: ${{ matrix.chart-name }}
         run: ./scripts/test-env.sh
 
@@ -58,6 +66,7 @@ jobs:
 
       - name: cleanup integration tests (cleanup)
         run: ./scripts/test-env.sh cleanup
+
   release:
     timeout-minutes: 30
     needs: lint-test


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes missing env in `release-push.yaml` workflow.

Follow up on #1180 and #1182.

Failing workflow in https://github.com/Kong/charts/actions/runs/12087707958/job/33709720081

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
