### PR TITLE
fix(kong): do not validate Konnect credentials in KIC's webhook

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Unreleased
+## 2.44.0
+
+### Fixes
+
+* Added admission webhook `objectSelector` for:
+  * `secrets.credentials.validation.ingress-controller.konghq.com`
+  * and `secrets.plugins.validation.ingress-controller.konghq.com`
+  to not validate Konnect (`konnect`) credentials in `Secret`s which are reconciled by KGO.
+  [#1078](https://github.com/Kong/charts/pull/1078)
 
 ## 2.43.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.43.0
+version: 2.44.0
 appVersion: "3.7"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-admin
   namespace: default
 spec:
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -119,7 +119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -144,7 +144,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -882,7 +882,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -900,6 +900,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -926,6 +930,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/validate
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -906,6 +906,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -933,6 +937,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -371,7 +371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -436,7 +436,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -484,7 +484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -504,7 +504,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -544,7 +544,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -573,7 +573,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -598,7 +598,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -902,7 +902,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -920,6 +920,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -947,6 +951,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -906,6 +906,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -933,6 +937,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.5"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.5"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -502,7 +502,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -540,7 +540,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -568,7 +568,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -592,7 +592,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -897,7 +897,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -923,7 +923,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -941,6 +941,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -968,6 +972,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -502,7 +502,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -540,7 +540,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -568,7 +568,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -592,7 +592,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -897,7 +897,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -943,6 +943,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -970,6 +974,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -912,7 +912,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -930,6 +930,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -957,6 +961,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -364,7 +364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -447,7 +447,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -467,7 +467,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -482,7 +482,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -492,7 +492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -511,7 +511,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -521,7 +521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -549,7 +549,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -601,7 +601,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -906,7 +906,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -965,7 +965,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -983,6 +983,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -1010,6 +1014,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +433,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +448,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -477,7 +477,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -487,7 +487,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -567,7 +567,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -872,7 +872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -890,6 +890,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -917,6 +921,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -561,7 +561,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -585,7 +585,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -890,7 +890,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -908,6 +908,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -935,6 +939,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: my-kong-sa
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -906,6 +906,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -933,6 +937,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -906,6 +906,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -933,6 +937,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.4"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.4"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
         environment: test
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -951,7 +951,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -975,7 +975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -993,6 +993,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -1020,6 +1024,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -78,7 +78,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -90,7 +90,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -248,7 +248,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-default
   namespace: default
 rules:
@@ -482,7 +482,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-default
   namespace: default
 roleRef:
@@ -572,7 +572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -587,7 +587,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -654,7 +654,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -690,7 +690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -719,7 +719,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -1332,7 +1332,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1348,7 +1348,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1581,7 +1581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1605,7 +1605,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1623,6 +1623,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -1649,6 +1653,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/validate
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -1735,7 +1743,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1751,7 +1759,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1990,7 +1998,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -2006,7 +2014,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -121,7 +121,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -129,7 +129,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -367,7 +367,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -71,7 +71,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -83,7 +83,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -379,7 +379,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -547,7 +547,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -557,7 +557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -576,7 +576,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -586,7 +586,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -614,7 +614,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -671,7 +671,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1271,7 +1271,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1489,7 +1489,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1513,7 +1513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1531,6 +1531,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -1558,6 +1562,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -1642,7 +1650,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1658,7 +1666,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1882,7 +1890,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.43.0
+    helm.sh/chart: kong-2.44.0
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -1898,7 +1906,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.43.0
+        helm.sh/chart: kong-2.44.0
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -68,6 +68,11 @@ webhooks:
     matchExpressions:
     - key: "konghq.com/credential"
       operator: "Exists"
+    {{- /* Do not validate Konnect credentials, these are targeted for KGO */}}
+    - key: "konghq.com/credential"
+      operator: "NotIn"
+      values:
+      - "konnect"
   rules:
   - apiGroups:
     - ""
@@ -107,6 +112,11 @@ webhooks:
     matchExpressions:
     - key: "konghq.com/validate"
       operator: "Exists"
+    {{- /* Do not validate Konnect credentials, these are targeted for KGO */}}
+    - key: "konghq.com/credential"
+      operator: "NotIn"
+      values:
+      - "konnect"
   {{- else }}
   objectSelector:
     matchExpressions:
@@ -114,6 +124,11 @@ webhooks:
       operator: NotIn
       values:
       - helm
+    {{- /* Do not validate Konnect credentials, these are targeted for KGO */}}
+    - key: "konghq.com/credential"
+      operator: "NotIn"
+      values:
+      - "konnect"
   {{- end }}
   rules:
   - apiGroups:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -590,6 +590,8 @@ ingressController:
   admissionWebhook:
     matchPolicy: Equivalent
     enabled: true
+    # Limit the `secrets.plugins.validation.ingress-controller.konghq.com` webhook
+    # to only Secrets with the appropriate KIC "konghq.com/validate" label.
     filterSecrets: false
     failurePolicy: Ignore
     port: 8080


### PR DESCRIPTION
#### What this PR does / why we need it:

Using `konnect` label value for `konghq.com/credential` label is only used in KGO's Konnect entities feature so do not validate those credentials in KIC.

#### Which issue this PR fixes

Reported in https://kongstrong.slack.com/archives/C069PUWHZ0D/p1733131164118439

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
