### PR TITLE
chore: prepare ingress 0.15.1

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.15.1
+
+### Improvements
+
+- Bumped dependencies on `kong/kong` chart to `==2.44.0`. Review the [kong chart
+  changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#2440)
+  for details.
+
 ## 0.15.0
 
 ### Improvements

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.43.0
+  version: 2.44.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.43.0
-digest: sha256:f9bc19c1d20e57fdfeba5283d5e20602d61b704022c04e443a66070143350fa0
-generated: "2024-12-02T15:45:02.724949+01:00"
+  version: 2.44.0
+digest: sha256:58a4e8a71ce164f70ccf271bafa1c755c50d268d4b23ae349d6ec05bc7347001
+generated: "2024-12-03T15:12:43.905029+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.15.0
+version: 0.15.1
 appVersion: "3.7"
 dependencies:
   - name: kong
-    version: "=2.43.0"
+    version: "=2.44.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: "=2.43.0"
+    version: "=2.44.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: gateway-2.43.0
+    helm.sh/chart: gateway-2.44.0
   name: chartsnap-gateway
   namespace: default
 ---
@@ -33,7 +33,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -65,7 +65,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller-admin-api-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -81,7 +81,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller-admin-api-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -94,7 +94,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller
 rules:
   - apiGroups:
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -409,7 +409,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller
   namespace: default
 rules:
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller
   namespace: default
 roleRef:
@@ -493,7 +493,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller-validation-webhook
   namespace: default
 spec:
@@ -508,7 +508,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller-metrics
   namespace: default
 spec:
@@ -537,7 +537,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
 ---
 apiVersion: v1
 kind: Service
@@ -547,7 +547,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: gateway-2.43.0
+    helm.sh/chart: gateway-2.44.0
   name: chartsnap-gateway-admin
   namespace: default
 spec:
@@ -571,7 +571,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: gateway-2.43.0
+    helm.sh/chart: gateway-2.44.0
   name: chartsnap-gateway-manager
   namespace: default
 spec:
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: gateway-2.43.0
+    helm.sh/chart: gateway-2.44.0
   name: chartsnap-gateway-proxy
   namespace: default
 spec:
@@ -627,7 +627,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller
   namespace: default
 spec:
@@ -653,7 +653,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: controller
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: controller-2.43.0
+        helm.sh/chart: controller-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -785,7 +785,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: gateway-2.43.0
+    helm.sh/chart: gateway-2.44.0
   name: chartsnap-gateway
   namespace: default
 spec:
@@ -809,7 +809,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: gateway
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: gateway-2.43.0
+        helm.sh/chart: gateway-2.44.0
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -1037,7 +1037,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.43.0
+    helm.sh/chart: controller-2.44.0
   name: chartsnap-controller-validations
   namespace: default
 webhooks:
@@ -1055,6 +1055,10 @@ webhooks:
       matchExpressions:
         - key: konghq.com/credential
           operator: Exists
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""
@@ -1082,6 +1086,10 @@ webhooks:
           operator: NotIn
           values:
             - helm
+        - key: konghq.com/credential
+          operator: NotIn
+          values:
+            - konnect
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -8,7 +8,7 @@
   * `secrets.credentials.validation.ingress-controller.konghq.com`
   * and `secrets.plugins.validation.ingress-controller.konghq.com`
   to not validate Konnect (`konnect`) credentials in `Secret`s which are reconciled by KGO.
-  [#1078](https://github.com/Kong/charts/pull/1078)
+  [#1186](https://github.com/Kong/charts/pull/1186)
 
 ## 2.43.0
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Prepare ingress 0.15.1, include kong [2.44.0](https://github.com/Kong/charts/releases/tag/kong-2.44.0) as dependency.

Includes #1186

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
