### PR TITLE
fix(kong): add missing RBAC policy rules for ConfigMaps and BackendTLSPolicy

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.44.1
+
+### Fixes
+
+* Added missing RBAC policy rules for `BackendTLSPolicy` and `ConfigMap`s
+  [#1191](https://github.com/Kong/charts/pull/1191)
+
 ## 2.44.0
 
 ### Fixes

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.44.0
+version: 2.44.1
 appVersion: "3.7"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-admin
   namespace: default
 spec:
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -119,7 +119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -144,7 +144,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -882,7 +882,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -371,7 +371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -436,7 +436,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -484,7 +484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -504,7 +504,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -544,7 +544,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -573,7 +573,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -598,7 +598,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -902,7 +902,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.5"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.5"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -502,7 +502,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -540,7 +540,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -568,7 +568,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -592,7 +592,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -897,7 +897,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -923,7 +923,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -374,7 +374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -473,7 +473,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -502,7 +502,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -512,7 +512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -540,7 +540,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -568,7 +568,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -592,7 +592,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -897,7 +897,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -912,7 +912,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -364,7 +364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -447,7 +447,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -467,7 +467,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -482,7 +482,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -492,7 +492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -511,7 +511,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -521,7 +521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -549,7 +549,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -601,7 +601,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -906,7 +906,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -965,7 +965,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -330,7 +330,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -349,7 +349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -413,7 +413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -433,7 +433,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -448,7 +448,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -458,7 +458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -477,7 +477,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -487,7 +487,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -567,7 +567,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -872,7 +872,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
@@ -1,0 +1,1056 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: kong/templates/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-kong
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+---
+# Source: kong/templates/admission-webhook.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-kong-validation-webhook-ca-keypair
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+type: kubernetes.io/tls
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+---
+# Source: kong/templates/admission-webhook.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chartsnap-kong-validation-webhook-keypair
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+type: kubernetes.io/tls
+data:
+  tls.crt: '###DYNAMIC_FIELD###'
+  tls.key: '###DYNAMIC_FIELD###'
+---
+# Source: kong/templates/controller-rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+  name: chartsnap-kong
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongcustomentities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongcustomentities/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongupstreampolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongupstreampolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumergroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumergroups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - ingressclassparameterses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongconsumers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - tcpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - konglicenses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongvaults
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongvaults/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+# Source: kong/templates/controller-rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chartsnap-kong
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-kong
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-kong
+  namespace: default
+---
+# Source: kong/templates/controller-rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-kong
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  # Defaults to "<election-id>-<ingress-class>"
+  # Here: "<kong-ingress-controller-leader-nginx>-<nginx>"
+  # This has to be adapted if you change either parameter
+  # when launching the nginx-ingress-controller.
+  - "kong-ingress-controller-leader-kong-kong"
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+# Begin KIC 2.x leader permissions
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+---
+# Source: kong/templates/controller-rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-kong
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-kong
+subjects:
+- kind: ServiceAccount
+  name: chartsnap-kong
+  namespace: default
+---
+# Source: kong/templates/admission-webhook.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-kong-validation-webhook
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: webhook
+  selector:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/component: app
+---
+# Source: kong/templates/controller-service-metrics.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-kong-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+spec:
+  ports:
+  - name: cmetrics
+    port: 10255
+    protocol: TCP
+    targetPort: cmetrics
+  - name: status
+    port: 10254
+    protocol: TCP
+    targetPort: cstatus
+  selector:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/component: app
+---
+# Source: kong/templates/service-kong-manager.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-kong-manager
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+spec:
+  type: NodePort
+  ports:
+  - name: kong-manager
+    port: 8002
+    targetPort: 8002
+    protocol: TCP
+  - name: kong-manager-tls
+    port: 8445
+    targetPort: 8445
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: "chartsnap"
+---
+# Source: kong/templates/service-kong-proxy.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-kong-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+    enable-metrics: "true"
+spec:
+  type: LoadBalancer
+  ports:
+  - name: kong-proxy
+    port: 80
+    targetPort: 8000
+    protocol: TCP
+  - name: kong-proxy-tls
+    port: 443
+    targetPort: 8443
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: "chartsnap"
+---
+# Source: kong/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-kong
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/component: app
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kong
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: "chartsnap"
+  template:
+    metadata:
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        kuma.io/gateway: "enabled"
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app.kubernetes.io/name: kong
+        helm.sh/chart: kong-2.44.1
+        app.kubernetes.io/instance: "chartsnap"
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/version: "3.7"
+        app.kubernetes.io/component: app
+        app: chartsnap-kong
+        version: "3.7"
+    spec:
+      serviceAccountName: chartsnap-kong
+      automountServiceAccountToken: false
+      initContainers:
+      - name: clear-stale-pid
+        image: kong:3.7
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        resources: {}
+        command:
+        - "rm"
+        - "-vrf"
+        - "$KONG_PREFIX/pids"
+        env:
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_GUI_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_GUI_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_LISTEN
+          value: "127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl"
+        - name: KONG_ANONYMOUS_REPORTS
+          value: "off"
+        - name: KONG_CLUSTER_LISTEN
+          value: "off"
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_KIC
+          value: "on"
+        - name: KONG_LUA_PACKAGE_PATH
+          value: "/opt/?.lua;/opt/?/init.lua;;"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_PORTAL_API_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PORTAL_API_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
+        - name: KONG_PREFIX
+          value: "/kong_prefix/"
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PROXY_LISTEN
+          value: "0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl"
+        - name: KONG_PROXY_STREAM_ACCESS_LOG
+          value: "/dev/stdout basic"
+        - name: KONG_PROXY_STREAM_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ROUTER_FLAVOR
+          value: "traditional"
+        - name: KONG_STATUS_ACCESS_LOG
+          value: "off"
+        - name: KONG_STATUS_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_STATUS_LISTEN
+          value: "0.0.0.0:8100, [::]:8100"
+        - name: KONG_STREAM_LISTEN
+          value: "off"
+        volumeMounts:
+        - name: chartsnap-kong-prefix-dir
+          mountPath: /kong_prefix/
+        - name: chartsnap-kong-tmp
+          mountPath: /tmp
+      containers:
+      - name: ingress-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        args:
+        ports:
+        - name: webhook
+          containerPort: 8080
+          protocol: TCP
+        - name: cmetrics
+          containerPort: 10255
+          protocol: TCP
+        - name: cstatus
+          containerPort: 10254
+          protocol: TCP
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
+          value: "0.0.0.0:8080"
+        - name: CONTROLLER_ANONYMOUS_REPORTS
+          value: "false"
+        - name: CONTROLLER_ELECTION_ID
+          value: "kong-ingress-controller-leader-kong"
+        - name: CONTROLLER_INGRESS_CLASS
+          value: "kong"
+        - name: CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY
+          value: "true"
+        - name: CONTROLLER_KONG_ADMIN_URL
+          value: "https://localhost:8444"
+        - name: CONTROLLER_PUBLISH_SERVICE
+          value: "default/chartsnap-kong-proxy"
+        image: kong/nightly-ingress-controller:2024-12-12
+        imagePullPolicy: IfNotPresent
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources: {}
+        volumeMounts:
+        - name: webhook-cert
+          mountPath: /admission-webhook
+          readOnly: true
+        - name: chartsnap-kong-token
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+      - name: "proxy"
+        image: kong:3.7
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_GUI_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_GUI_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_LISTEN
+          value: "127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl"
+        - name: KONG_ANONYMOUS_REPORTS
+          value: "off"
+        - name: KONG_CLUSTER_LISTEN
+          value: "off"
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_KIC
+          value: "on"
+        - name: KONG_LUA_PACKAGE_PATH
+          value: "/opt/?.lua;/opt/?/init.lua;;"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_PORTAL_API_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PORTAL_API_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
+        - name: KONG_PREFIX
+          value: "/kong_prefix/"
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PROXY_LISTEN
+          value: "0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl"
+        - name: KONG_PROXY_STREAM_ACCESS_LOG
+          value: "/dev/stdout basic"
+        - name: KONG_PROXY_STREAM_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ROUTER_FLAVOR
+          value: "traditional"
+        - name: KONG_STATUS_ACCESS_LOG
+          value: "off"
+        - name: KONG_STATUS_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_STATUS_LISTEN
+          value: "0.0.0.0:8100, [::]:8100"
+        - name: KONG_STREAM_LISTEN
+          value: "off"
+        - name: KONG_NGINX_DAEMON
+          value: "off"
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - kong
+              - quit
+              - --wait=15
+        ports:
+        - name: proxy
+          containerPort: 8000
+          protocol: TCP
+        - name: proxy-tls
+          containerPort: 8443
+          protocol: TCP
+        - name: status
+          containerPort: 8100
+          protocol: TCP
+        volumeMounts:
+        - name: chartsnap-kong-prefix-dir
+          mountPath: /kong_prefix/
+        - name: chartsnap-kong-tmp
+          mountPath: /tmp
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status/ready
+            port: status
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 5
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: status
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources: {}
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: chartsnap-kong-prefix-dir
+        emptyDir:
+          sizeLimit: 256Mi
+      - name: chartsnap-kong-tmp
+        emptyDir:
+          sizeLimit: 1Gi
+      - name: chartsnap-kong-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+      - name: webhook-cert
+        secret:
+          secretName: chartsnap-kong-validation-webhook-keypair
+---
+# Source: kong/templates/admission-webhook.yaml
+kind: ValidatingWebhookConfiguration
+apiVersion: admissionregistration.k8s.io/v1
+metadata:
+  name: chartsnap-kong-validations
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-2.44.1
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.7"
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: '###DYNAMIC_FIELD###'
+    service:
+      name: chartsnap-kong-validation-webhook
+      namespace: default
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: secrets.credentials.validation.ingress-controller.konghq.com
+  objectSelector:
+    matchExpressions:
+    - key: "konghq.com/credential"
+      operator: "Exists"
+    - key: "konghq.com/credential"
+      operator: "NotIn"
+      values:
+      - "konnect"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: '###DYNAMIC_FIELD###'
+    service:
+      name: chartsnap-kong-validation-webhook
+      namespace: default
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: secrets.plugins.validation.ingress-controller.konghq.com
+  objectSelector:
+    matchExpressions:
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
+    - key: "konghq.com/credential"
+      operator: "NotIn"
+      values:
+      - "konnect"
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+  sideEffects: None
+- name: validations.kong.konghq.com
+  matchPolicy: Equivalent
+  objectSelector:
+    matchExpressions:
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
+  failurePolicy: Ignore
+  sideEffects: None
+  admissionReviewVersions: ["v1beta1"]
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+  - apiGroups:
+    - ''
+    apiVersions:
+    - 'v1'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - 'v1'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - 'v1alpha2'
+    - 'v1beta1'
+    - 'v1'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+  clientConfig:
+    caBundle: '###DYNAMIC_FIELD###'
+    service:
+      name: chartsnap-kong-validation-webhook
+      namespace: default

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -561,7 +561,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -585,7 +585,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -890,7 +890,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: my-kong-sa
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -888,7 +888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.4"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.4"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -365,7 +365,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -449,7 +449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -464,7 +464,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -474,7 +474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -493,7 +493,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -559,7 +559,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -583,7 +583,7 @@ spec:
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
         environment: test
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -951,7 +951,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -975,7 +975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -78,7 +78,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -90,7 +90,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -165,7 +165,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -248,7 +248,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-default
   namespace: default
 rules:
@@ -482,7 +482,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-default
   namespace: default
 roleRef:
@@ -572,7 +572,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -587,7 +587,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -654,7 +654,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -690,7 +690,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -719,7 +719,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -1332,7 +1332,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1348,7 +1348,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1581,7 +1581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1605,7 +1605,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1743,7 +1743,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1759,7 +1759,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1998,7 +1998,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -2014,7 +2014,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -121,7 +121,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -129,7 +129,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -367,7 +367,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -71,7 +71,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -83,7 +83,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -379,7 +379,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -398,7 +398,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 rules:
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -547,7 +547,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -557,7 +557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -576,7 +576,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
 ---
 apiVersion: v1
 kind: Service
@@ -586,7 +586,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -614,7 +614,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong
   namespace: default
 spec:
@@ -671,7 +671,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
         version: "3.7"
     spec:
       automountServiceAccountToken: false
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1271,7 +1271,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1489,7 +1489,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1513,7 +1513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-validations
   namespace: default
 webhooks:
@@ -1650,7 +1650,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1666,7 +1666,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -1890,7 +1890,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.7"
-    helm.sh/chart: kong-2.44.0
+    helm.sh/chart: kong-2.44.1
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -1906,7 +1906,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.7"
-        helm.sh/chart: kong-2.44.0
+        helm.sh/chart: kong-2.44.1
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/kong-ingress-5-3.4-rbac-values.yaml
+++ b/charts/kong/ci/kong-ingress-5-3.4-rbac-values.yaml
@@ -2,7 +2,9 @@ ingressController:
   env:
     anonymous_reports: "false"
   image:
-    tag: "3.1"
+    repository: kong/nightly-ingress-controller
+    tag: "2024-12-12"
+    effectiveSemver: "3.4"
 
 # NOTE: The purpose of those values below is to:
 # - to speed up, the test

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1304,6 +1304,33 @@ role sets used in the charts. Updating these requires separating out cluster
 resource roles into their separate templates.
 */}}
 {{- define "kong.kubernetesRBACRules" -}}
+{{- if (semverCompare ">= 3.4.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+{{- if or (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha3") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
+{{- end }}
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies/status
+  verbs:
+  - patch
+  - update
+{{- end }}
 {{- if (semverCompare ">= 3.2.0" (include "kong.effectiveVersion" .Values.ingressController.image)) }}
 - apiGroups:
   - configuration.konghq.com


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds missing RBAC policy rules.

Prepare for 2.44.1 release.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
