### PR TITLE
chore: prepare ingress 0.16.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,6 @@ _chartsnap.ingress:
 
 .PHONY: _chartsnap
 _chartsnap: chartsnap
-	@ helm repo update
+	@ helm repo update kong
 	@ helm dependencies update charts/ingress
 	@ helm chartsnap -c ./charts/$(GOLDEN_TEST_CHART) -f $(GOLDEN_TEST_CHART_VALUES_DIR) $(CHARTSNAP_ARGS)

--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.16.0
+
+### Fixes
+
+- Bumped dependencies on `kong/kong` chart to `==2.45.0`. Review the [kong chart
+  changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#2450)
+  for details.
+
 ## 0.15.2
 
 ### Fixes

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.44.1
+  version: 2.45.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.44.1
-digest: sha256:81f18087a88702437a09db4562d12c2912a030cf6037243118dce13853d26880
-generated: "2024-12-12T15:30:27.400011+01:00"
+  version: 2.45.0
+digest: sha256:fa46a9ce4d8c3d5f83aa8e39b5e2edeebce1a5b42aba20c3c88cdf5c9dfeae66
+generated: "2024-12-13T19:17:05.515194+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.15.2
-appVersion: "3.7"
+version: 0.16.0
+appVersion: "3.8"
 dependencies:
   - name: kong
-    version: "=2.44.1"
+    version: "=2.45.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: "=2.44.1"
+    version: "=2.45.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller
   namespace: default
 ---
@@ -17,8 +17,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: gateway-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: gateway-2.45.0
   name: chartsnap-gateway
   namespace: default
 ---
@@ -32,8 +32,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -48,8 +48,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -64,8 +64,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller-admin-api-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -80,8 +80,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller-admin-api-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -93,8 +93,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller
 rules:
   - apiGroups:
@@ -389,8 +389,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -408,8 +408,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller
   namespace: default
 rules:
@@ -472,8 +472,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller
   namespace: default
 roleRef:
@@ -492,8 +492,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller-validation-webhook
   namespace: default
 spec:
@@ -507,8 +507,8 @@ spec:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
 ---
 apiVersion: v1
 kind: Service
@@ -517,8 +517,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller-metrics
   namespace: default
 spec:
@@ -536,8 +536,8 @@ spec:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
 ---
 apiVersion: v1
 kind: Service
@@ -546,8 +546,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: gateway-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: gateway-2.45.0
   name: chartsnap-gateway-admin
   namespace: default
 spec:
@@ -570,8 +570,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: gateway-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: gateway-2.45.0
   name: chartsnap-gateway-manager
   namespace: default
 spec:
@@ -597,9 +597,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
     enable-metrics: "true"
-    helm.sh/chart: gateway-2.44.1
+    helm.sh/chart: gateway-2.45.0
   name: chartsnap-gateway-proxy
   namespace: default
 spec:
@@ -626,8 +626,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller
   namespace: default
 spec:
@@ -652,9 +652,9 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: controller
-        app.kubernetes.io/version: "3.7"
-        helm.sh/chart: controller-2.44.1
-        version: "3.7"
+        app.kubernetes.io/version: "3.8"
+        helm.sh/chart: controller-2.45.0
+        version: "3.8"
     spec:
       automountServiceAccountToken: false
       containers:
@@ -784,8 +784,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: gateway-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: gateway-2.45.0
   name: chartsnap-gateway
   namespace: default
 spec:
@@ -808,9 +808,9 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: gateway
-        app.kubernetes.io/version: "3.7"
-        helm.sh/chart: gateway-2.44.1
-        version: "3.7"
+        app.kubernetes.io/version: "3.8"
+        helm.sh/chart: gateway-2.45.0
+        version: "3.8"
     spec:
       automountServiceAccountToken: false
       containers:
@@ -867,7 +867,7 @@ spec:
               value: "off"
             - name: KONG_NGINX_DAEMON
               value: "off"
-          image: kong:3.7
+          image: kong:3.8
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -982,7 +982,7 @@ spec:
               value: 0.0.0.0:8100, [::]:8100
             - name: KONG_STREAM_LISTEN
               value: "off"
-          image: kong:3.7
+          image: kong:3.8
           imagePullPolicy: IfNotPresent
           name: clear-stale-pid
           resources: {}
@@ -1036,8 +1036,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.7"
-    helm.sh/chart: controller-2.44.1
+    app.kubernetes.io/version: "3.8"
+    helm.sh/chart: controller-2.45.0
   name: chartsnap-controller-validations
   namespace: default
 webhooks:

--- a/charts/ingress/ci/__snapshots__/kic-3.4-values.snap
+++ b/charts/ingress/ci/__snapshots__/kic-3.4-values.snap
@@ -8,10 +8,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 ---
 # Source: ingress/charts/gateway/templates/service-account.yaml
 apiVersion: v1
@@ -21,10 +21,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.44.1
+    helm.sh/chart: gateway-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 ---
 # Source: ingress/charts/controller/templates/admission-webhook.yaml
 apiVersion: v1
@@ -34,10 +34,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 type: kubernetes.io/tls
 data:
   tls.crt: '###DYNAMIC_FIELD###'
@@ -51,10 +51,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 type: kubernetes.io/tls
 data:
   tls.crt: '###DYNAMIC_FIELD###'
@@ -68,10 +68,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 type: kubernetes.io/tls
 data:
   tls.crt: '###DYNAMIC_FIELD###'
@@ -85,10 +85,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 type: kubernetes.io/tls
 data:
   tls.crt: '###DYNAMIC_FIELD###'
@@ -100,10 +100,10 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
   name: chartsnap-controller
 rules:
 - apiGroups:
@@ -421,10 +421,10 @@ metadata:
   name: chartsnap-controller
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -442,10 +442,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 rules:
 - apiGroups:
   - ""
@@ -512,10 +512,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -533,10 +533,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 spec:
   ports:
   - name: webhook
@@ -545,10 +545,10 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
     app.kubernetes.io/component: app
 ---
 # Source: ingress/charts/controller/templates/controller-service-metrics.yaml
@@ -559,10 +559,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 spec:
   ports:
   - name: cmetrics
@@ -575,10 +575,10 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
     app.kubernetes.io/component: app
 ---
 # Source: ingress/charts/gateway/templates/service-kong-admin.yaml
@@ -589,10 +589,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.44.1
+    helm.sh/chart: gateway-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 spec:
   type: ClusterIP
   ports:
@@ -614,10 +614,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.44.1
+    helm.sh/chart: gateway-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 spec:
   type: NodePort
   ports:
@@ -642,10 +642,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.44.1
+    helm.sh/chart: gateway-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
     enable-metrics: "true"
 spec:
   type: LoadBalancer
@@ -671,10 +671,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
     app.kubernetes.io/component: app
 spec:
   replicas: 1
@@ -694,13 +694,13 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: controller
-        helm.sh/chart: controller-2.44.1
+        helm.sh/chart: controller-2.45.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/version: "3.7"
+        app.kubernetes.io/version: "3.8"
         app.kubernetes.io/component: app
         app: chartsnap-controller
-        version: "3.7"
+        version: "3.8"
     spec:
       serviceAccountName: chartsnap-controller
       automountServiceAccountToken: false
@@ -830,10 +830,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.44.1
+    helm.sh/chart: gateway-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
     app.kubernetes.io/component: app
 spec:
   replicas: 1
@@ -851,19 +851,19 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: gateway
-        helm.sh/chart: gateway-2.44.1
+        helm.sh/chart: gateway-2.45.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/version: "3.7"
+        app.kubernetes.io/version: "3.8"
         app.kubernetes.io/component: app
         app: chartsnap-gateway
-        version: "3.7"
+        version: "3.8"
     spec:
       serviceAccountName: chartsnap-gateway
       automountServiceAccountToken: false
       initContainers:
       - name: clear-stale-pid
-        image: kong:3.7
+        image: kong:3.8
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -938,7 +938,7 @@ spec:
           mountPath: /tmp
       containers:
       - name: "proxy"
-        image: kong:3.7
+        image: kong:3.8
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -1084,10 +1084,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.44.1
+    helm.sh/chart: controller-2.45.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.7"
+    app.kubernetes.io/version: "3.8"
 webhooks:
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump default Kong tag to 3.8. Release `ingress` 0.16.0.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
