### PR TITLE
ci: run kube-linter for all charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ shellcheck: mise
 tools: kube-linter chartsnap shellcheck
 
 .PHONY: lint
-lint: tools lint.charts.kong lint.shellcheck
+lint: tools lint.charts lint.shellcheck
 
-.PHONY: lint.charts.kong
-lint.charts.kong:
-	$(KUBE_LINTER) lint charts/kong
+.PHONY: lint.charts
+lint.charts:
+	$(KUBE_LINTER) lint charts/
 
 .PHONY: lint.shellcheck
 lint.shellcheck: shellcheck

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -69,6 +69,10 @@ spec:
           capabilities:
             drop:
             - ALL
+        ports:
+        - containerPort: 8081
+          name: probe
+          protocol: TCP
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
       - args:


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

`kube-linter` in CI has been added in #751.

Since then we've added `ingress` and `gateway-operator` chart.

This PR makes the CI run `kube-linter` against those 2 charts in addition to `kong` chart.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
