### PR TITLE
chore(kgo): bump kubernetes-configuration CRDs to 1.0.3

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 
-- Update kubernetes-configuration CRDs to 1.0.0
+- Update kubernetes-configuration CRDs to 1.0.3
   [#1203](https://github.com/Kong/charts/pull/1203)
 
 ## 0.4.1

--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.2
+
+### Changes
+
+- Update kubernetes-configuration CRDs to 1.0.0
+  [#1203](https://github.com/Kong/charts/pull/1203)
+
 ## 0.4.1
 
 ### Changes

--- a/charts/gateway-operator/Chart.lock
+++ b/charts/gateway-operator/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.0
 - name: kubernetes-configuration-crds
   repository: ""
-  version: 0.0.41
-digest: sha256:7833a0a6b9d736a0227f77212df4ad2eec572b367da2c8d1fece5eb617d45a95
-generated: "2024-11-07T10:09:06.705774+01:00"
+  version: 1.0.0
+digest: sha256:aada875705523f6cf423247ed04ccd199e65ce503ca4d4f7301ad5b79d07bf1c
+generated: "2024-12-23T17:45:41.861667+01:00"

--- a/charts/gateway-operator/Chart.lock
+++ b/charts/gateway-operator/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.0
 - name: kubernetes-configuration-crds
   repository: ""
-  version: 1.0.0
-digest: sha256:aada875705523f6cf423247ed04ccd199e65ce503ca4d4f7301ad5b79d07bf1c
-generated: "2024-12-23T17:45:41.861667+01:00"
+  version: 1.0.3
+digest: sha256:2e65234a2398cd6b463374f55abc6c88f51ec8c6535304ff6cce7a81c468526f
+generated: "2025-01-07T18:13:01.488691+01:00"

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.4.1
+version: 0.4.2
 appVersion: "1.4"
 annotations:
   artifacthub.io/prerelease: "false"
@@ -24,5 +24,5 @@ dependencies:
     version: 1.1.0
     condition: gwapi-experimental-crds.enabled
   - name: kubernetes-configuration-crds
-    version: 0.0.41
+    version: 1.0.0
     condition: kubernetes-configuration-crds.enabled

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -24,5 +24,5 @@ dependencies:
     version: 1.1.0
     condition: gwapi-experimental-crds.enabled
   - name: kubernetes-configuration-crds
-    version: 1.0.0
+    version: 1.0.3
     condition: kubernetes-configuration-crds.enabled

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubernetes-configuration-crds
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.0.3
+appVersion: "1.0.3"
 description: A Helm chart for Kong's Kubernetes Configuration CRDs

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubernetes-configuration-crds
-version: 0.0.41
-appVersion: "0.0.41"
+version: 1.0.0
+appVersion: "1.0.0"
 description: A Helm chart for Kong's Kubernetes Configuration CRDs

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
@@ -2,64 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
-  name: ingressclassparameterses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    kind: IngressClassParameters
-    listKind: IngressClassParametersList
-    plural: ingressclassparameterses
-    singular: ingressclassparameters
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: IngressClassParameters is the Schema for the IngressClassParameters
-          API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec is the IngressClassParameters specification.
-            properties:
-              enableLegacyRegexDetection:
-                default: false
-                description: |-
-                  EnableLegacyRegexDetection automatically detects if ImplementationSpecific Ingress paths are regular expression
-                  paths using the legacy 2.x heuristic. The controller adds the "~" prefix to those paths if the Kong version is
-                  3.0 or higher.
-                type: boolean
-              serviceUpstream:
-                default: false
-                description: Offload load-balancing to kube-proxy or sidecar.
-                type: boolean
-            type: object
-        type: object
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongcacertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -132,39 +75,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               tags:
                 description: Tags is an optional set of tags applied to the certificate.
                 items:
@@ -176,7 +124,12 @@ spec:
                   rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
             required:
             - cert
+            - controlPlaneRef
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:
@@ -278,7 +231,8 @@ spec:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+          rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
@@ -291,7 +245,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -370,39 +324,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               key:
                 description: Key is the PEM-encoded private key.
                 type: string
@@ -424,8 +383,13 @@ spec:
                   rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
             required:
             - cert
+            - controlPlaneRef
             - key
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:
@@ -526,6 +490,9 @@ spec:
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
@@ -538,313 +505,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
-  name: kongclusterplugins.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    categories:
-    - kong-ingress-controller
-    kind: KongClusterPlugin
-    listKind: KongClusterPluginList
-    plural: kongclusterplugins
-    shortNames:
-    - kcp
-    singular: kongclusterplugin
-  scope: Cluster
-  versions:
-  - additionalPrinterColumns:
-    - description: Name of the plugin
-      jsonPath: .plugin
-      name: Plugin-Type
-      type: string
-    - description: Age
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - description: Indicates if the plugin is disabled
-      jsonPath: .disabled
-      name: Disabled
-      priority: 1
-      type: boolean
-    - description: Configuration of the plugin
-      jsonPath: .config
-      name: Config
-      priority: 1
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
-      name: Programmed
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: KongClusterPlugin is the Schema for the kongclusterplugins API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          config:
-            description: |-
-              Config contains the plugin configuration. It's a list of keys and values
-              required to configure the plugin.
-              Please read the documentation of the plugin being configured to set values
-              in here. For any plugin in Kong, anything that goes in the `config` JSON
-              key in the Admin API request, goes into this property.
-              Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once.
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-          configFrom:
-            description: |-
-              ConfigFrom references a secret containing the plugin configuration.
-              This should be used when the plugin configuration contains sensitive information,
-              such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin.
-              Only one of `config` or `configFrom` may be used in a KongClusterPlugin, not both at once.
-            properties:
-              secretKeyRef:
-                description: Specifies a name, a namespace, and a key of a secret
-                  to refer to.
-                properties:
-                  key:
-                    description: The key containing the value.
-                    type: string
-                  name:
-                    description: The secret containing the key.
-                    type: string
-                  namespace:
-                    description: The namespace containing the secret.
-                    type: string
-                required:
-                - key
-                - name
-                - namespace
-                type: object
-            required:
-            - secretKeyRef
-            type: object
-          configPatches:
-            description: |-
-              ConfigPatches represents JSON patches to the configuration of the plugin.
-              Each item means a JSON patch to add something in the configuration,
-              where path is specified in `path` and value is in `valueFrom` referencing
-              a key in a secret.
-              When Config is specified, patches will be applied to the configuration in Config.
-              Otherwise, patches will be applied to an empty object.
-            items:
-              description: |-
-                NamespacedConfigPatch is a JSON patch to add values from secrets to KongClusterPlugin
-                to the generated configuration of plugin in Kong.
-              properties:
-                path:
-                  description: Path is the JSON path to add the patch.
-                  type: string
-                valueFrom:
-                  description: ValueFrom is the reference to a key of a secret where
-                    the patched value comes from.
-                  properties:
-                    secretKeyRef:
-                      description: Specifies a name, a namespace, and a key of a secret
-                        to refer to.
-                      properties:
-                        key:
-                          description: The key containing the value.
-                          type: string
-                        name:
-                          description: The secret containing the key.
-                          type: string
-                        namespace:
-                          description: The namespace containing the secret.
-                          type: string
-                      required:
-                      - key
-                      - name
-                      - namespace
-                      type: object
-                  required:
-                  - secretKeyRef
-                  type: object
-              required:
-              - path
-              - valueFrom
-              type: object
-            type: array
-          consumerRef:
-            description: ConsumerRef is a reference to a particular consumer.
-            type: string
-          disabled:
-            description: Disabled set if the plugin is disabled or not.
-            type: boolean
-          instance_name:
-            description: |-
-              InstanceName is an optional custom name to identify an instance of the plugin. This is useful when running the
-              same plugin in multiple contexts, for example, on multiple services.
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          ordering:
-            description: |-
-              Ordering overrides the normal plugin execution order. It's only available on Kong Enterprise.
-              `<phase>` is a request processing phase (for example, `access` or `body_filter`) and
-              `<plugin>` is the name of the plugin that will run before or after the KongPlugin.
-              For example, a KongPlugin with `plugin: rate-limiting` and `before.access: ["key-auth"]`
-              will create a rate limiting plugin that limits requests _before_ they are authenticated.
-            properties:
-              after:
-                additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                description: PluginOrderingPhase indicates which plugins in a phase
-                  should affect the target plugin's order
-                type: object
-              before:
-                additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                description: PluginOrderingPhase indicates which plugins in a phase
-                  should affect the target plugin's order
-                type: object
-            type: object
-          plugin:
-            description: PluginName is the name of the plugin to which to apply the
-              config.
-            type: string
-          protocols:
-            description: |-
-              Protocols configures plugin to run on requests received on specific
-              protocols.
-            items:
-              description: |-
-                KongProtocol is a valid Kong protocol.
-                This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
-              enum:
-              - http
-              - https
-              - grpc
-              - grpcs
-              - tcp
-              - tls
-              - udp
-              type: string
-            type: array
-          run_on:
-            description: |-
-              RunOn configures the plugin to run on the first or the second or both
-              nodes in case of a service mesh deployment.
-            enum:
-            - first
-            - second
-            - all
-            type: string
-          status:
-            description: Status represents the current status of the KongClusterPlugin
-              resource.
-            properties:
-              conditions:
-                default:
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: Programmed
-                description: |-
-                  Conditions describe the current conditions of the KongClusterPluginStatus.
-
-                  Known condition types are:
-
-                  * "Programmed"
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                maxItems: 8
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-            type: object
-        required:
-        - plugin
-        type: object
-        x-kubernetes-validations:
-        - message: Using both config and configFrom fields is not allowed.
-          rule: '!(has(self.config) && has(self.configFrom))'
-        - message: Using both configFrom and configPatches fields is not allowed.
-          rule: '!(has(self.configFrom) && has(self.configPatches))'
-        - message: The plugin field is immutable
-          rule: self.plugin == oldSelf.plugin
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -919,39 +580,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               name:
                 description: Name is the name of the ConsumerGroup in Kong.
                 type: string
@@ -1084,7 +750,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1184,39 +850,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               tags:
                 description: Tags is an optional set of tags applied to the consumer.
                 items:
@@ -1351,7 +1022,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongcredentialacls.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1538,7 +1209,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1725,7 +1396,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1916,7 +1587,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2109,7 +1780,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongcredentialjwts.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2326,190 +1997,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
-  name: kongcustomentities.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    categories:
-    - kong-ingress-controller
-    kind: KongCustomEntity
-    listKind: KongCustomEntityList
-    plural: kongcustomentities
-    shortNames:
-    - kce
-    singular: kongcustomentity
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: type of the Kong entity
-      jsonPath: .spec.type
-      name: Entity Type
-      type: string
-    - description: Age
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.conditions[?(@.type=="Programmed")].status
-      name: Programmed
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: KongCustomEntity defines a "custom" Kong entity that KIC cannot
-          support the entity type directly.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: KongCustomEntitySpec defines the specification of the KongCustomEntity.
-            properties:
-              controllerName:
-                description: ControllerName specifies the controller that should reconcile
-                  it, like ingress class.
-                type: string
-              fields:
-                description: Fields defines the fields of the Kong entity itself.
-                x-kubernetes-preserve-unknown-fields: true
-              parentRef:
-                description: |-
-                  ParentRef references the kubernetes resource it attached to when its scope is "attached".
-                  Currently only KongPlugin/KongClusterPlugin allowed. This will make the custom entity to be attached
-                  to the entity(service/route/consumer) where the plugin is attached.
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    description: Empty namespace means the same namespace of the owning
-                      object.
-                    type: string
-                required:
-                - name
-                type: object
-              type:
-                description: EntityType is the type of the Kong entity. The type is
-                  used in generating declarative configuration.
-                type: string
-            required:
-            - controllerName
-            - fields
-            - type
-            type: object
-          status:
-            description: Status stores the reconciling status of the resource.
-            properties:
-              conditions:
-                default:
-                - lastTransitionTime: "1970-01-01T00:00:00Z"
-                  message: Waiting for controller
-                  reason: Pending
-                  status: Unknown
-                  type: Programmed
-                description: |-
-                  Conditions describe the current conditions of the KongCustomEntityStatus.
-
-                  Known condition types are:
-
-                  * "Programmed"
-                items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
-                  properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                maxItems: 8
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-            required:
-            - conditions
-            type: object
-        required:
-        - spec
-        type: object
-        x-kubernetes-validations:
-        - message: The spec.type field is immutable
-          rule: self.spec.type == oldSelf.spec.type
-        - message: The spec.type field cannot be known Kong entity types
-          rule: '!(self.spec.type in [''services'',''routes'',''upstreams'',''targets'',''plugins'',''consumers'',''consumer_groups''])'
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2584,42 +2072,52 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
             required:
             - cert
+            - controlPlaneRef
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:
@@ -2729,8 +2227,7 @@ spec:
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.cert == self.spec.cert'
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-            - it's not supported yet
-          rule: '!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef)
+          rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
             ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
     served: true
     storage: true
@@ -2741,398 +2238,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
-  name: kongingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    categories:
-    - kong-ingress-controller
-    kind: KongIngress
-    listKind: KongIngressList
-    plural: kongingresses
-    shortNames:
-    - ki
-    singular: kongingress
-  scope: Namespaced
-  versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: KongIngress is the Schema for the kongingresses API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          proxy:
-            description: |-
-              Proxy defines additional connection options for the routes to be configured in the
-              Kong Gateway, e.g. `connection_timeout`, `retries`, etc.
-            properties:
-              connect_timeout:
-                description: "The timeout in milliseconds for\testablishing a connection
-                  to the upstream server.\nDeprecated: use Service's \"konghq.com/connect-timeout\"
-                  annotation instead."
-                minimum: 0
-                type: integer
-              path:
-                description: |-
-                  (optional) The path to be used in requests to the upstream server.
-                  Deprecated: use Service's "konghq.com/path" annotation instead.
-                pattern: ^/.*$
-                type: string
-              protocol:
-                description: |-
-                  The protocol used to communicate with the upstream.
-                  Deprecated: use Service's "konghq.com/protocol" annotation instead.
-                enum:
-                - http
-                - https
-                - grpc
-                - grpcs
-                - tcp
-                - tls
-                - udp
-                type: string
-              read_timeout:
-                description: |-
-                  The timeout in milliseconds between two successive read operations
-                  for transmitting a request to the upstream server.
-                  Deprecated: use Service's "konghq.com/read-timeout" annotation instead.
-                minimum: 0
-                type: integer
-              retries:
-                description: |-
-                  The number of retries to execute upon failure to proxy.
-                  Deprecated: use Service's "konghq.com/retries" annotation instead.
-                minimum: 0
-                type: integer
-              write_timeout:
-                description: |-
-                  The timeout in milliseconds between two successive write operations
-                  for transmitting a request to the upstream server.
-                  Deprecated: use Service's "konghq.com/write-timeout" annotation instead.
-                minimum: 0
-                type: integer
-            type: object
-          route:
-            description: |-
-              Route define rules to match client requests.
-              Each Route is associated with a Service,
-              and a Service may have multiple Routes associated to it.
-            properties:
-              headers:
-                additionalProperties:
-                  items:
-                    type: string
-                  type: array
-                description: |-
-                  Headers contains one or more lists of values indexed by header name
-                  that will cause this Route to match if present in the request.
-                  The Host header cannot be used with this attribute.
-                  Deprecated: use Ingress' "konghq.com/headers" annotation instead.
-                type: object
-              https_redirect_status_code:
-                description: |-
-                  HTTPSRedirectStatusCode is the status code Kong responds with
-                  when all properties of a Route match except the protocol.
-                  Deprecated: use Ingress' "ingress.kubernetes.io/force-ssl-redirect" or
-                  "konghq.com/https-redirect-status-code" annotations instead.
-                type: integer
-              methods:
-                description: |-
-                  Methods is a list of HTTP methods that match this Route.
-                  Deprecated: use Ingress' "konghq.com/methods" annotation instead.
-                items:
-                  type: string
-                type: array
-              path_handling:
-                description: |-
-                  PathHandling controls how the Service path, Route path and requested path
-                  are combined when sending a request to the upstream.
-                  Deprecated: use Ingress' "konghq.com/path-handling" annotation instead.
-                enum:
-                - v0
-                - v1
-                type: string
-              preserve_host:
-                description: |-
-                  PreserveHost sets When matching a Route via one of the hosts domain names,
-                  use the request Host header in the upstream request headers.
-                  If set to false, the upstream Host header will be that of the Service’s host.
-                  Deprecated: use Ingress' "konghq.com/preserve-host" annotation instead.
-                type: boolean
-              protocols:
-                description: |-
-                  Protocols is an array of the protocols this Route should allow.
-                  Deprecated: use Ingress' "konghq.com/protocols" annotation instead.
-                items:
-                  description: |-
-                    KongProtocol is a valid Kong protocol.
-                    This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
-                  enum:
-                  - http
-                  - https
-                  - grpc
-                  - grpcs
-                  - tcp
-                  - tls
-                  - udp
-                  type: string
-                type: array
-              regex_priority:
-                description: |-
-                  RegexPriority is a number used to choose which route resolves a given request
-                  when several routes match it using regexes simultaneously.
-                  Deprecated: use Ingress' "konghq.com/regex-priority" annotation instead.
-                type: integer
-              request_buffering:
-                description: |-
-                  RequestBuffering sets whether to enable request body buffering or not.
-                  Deprecated: use Ingress' "konghq.com/request-buffering" annotation instead.
-                type: boolean
-              response_buffering:
-                description: |-
-                  ResponseBuffering sets whether to enable response body buffering or not.
-                  Deprecated: use Ingress' "konghq.com/response-buffering" annotation instead.
-                type: boolean
-              snis:
-                description: |-
-                  SNIs is a list of SNIs that match this Route when using stream routing.
-                  Deprecated: use Ingress' "konghq.com/snis" annotation instead.
-                items:
-                  type: string
-                type: array
-              strip_path:
-                description: |-
-                  StripPath sets When matching a Route via one of the paths
-                  strip the matching prefix from the upstream request URL.
-                  Deprecated: use Ingress' "konghq.com/strip-path" annotation instead.
-                type: boolean
-            type: object
-          upstream:
-            description: |-
-              Upstream represents a virtual hostname and can be used to loadbalance
-              incoming requests over multiple targets (e.g. Kubernetes `Services` can
-              be a target, OR `Endpoints` can be targets).
-            properties:
-              algorithm:
-                description: |-
-                  Algorithm is the load balancing algorithm to use.
-                  Accepted values are: "round-robin", "consistent-hashing", "least-connections", "latency".
-                enum:
-                - round-robin
-                - consistent-hashing
-                - least-connections
-                - latency
-                type: string
-              hash_fallback:
-                description: |-
-                  HashFallback defines What to use as hashing input
-                  if the primary hash_on does not return a hash.
-                  Accepted values are: "none", "consumer", "ip", "header", "cookie".
-                type: string
-              hash_fallback_header:
-                description: |-
-                  HashFallbackHeader is the header name to take the value from as hash input.
-                  Only required when "hash_fallback" is set to "header".
-                type: string
-              hash_fallback_query_arg:
-                description: HashFallbackQueryArg is the "hash_fallback" version of
-                  HashOnQueryArg.
-                type: string
-              hash_fallback_uri_capture:
-                description: HashFallbackURICapture is the "hash_fallback" version
-                  of HashOnURICapture.
-                type: string
-              hash_on:
-                description: |-
-                  HashOn defines what to use as hashing input.
-                  Accepted values are: "none", "consumer", "ip", "header", "cookie", "path", "query_arg", "uri_capture".
-                type: string
-              hash_on_cookie:
-                description: |-
-                  The cookie name to take the value from as hash input.
-                  Only required when "hash_on" or "hash_fallback" is set to "cookie".
-                type: string
-              hash_on_cookie_path:
-                description: |-
-                  The cookie path to set in the response headers.
-                  Only required when "hash_on" or "hash_fallback" is set to "cookie".
-                type: string
-              hash_on_header:
-                description: |-
-                  HashOnHeader defines the header name to take the value from as hash input.
-                  Only required when "hash_on" is set to "header".
-                type: string
-              hash_on_query_arg:
-                description: HashOnQueryArg is the query string parameter whose value
-                  is the hash input when "hash_on" is set to "query_arg".
-                type: string
-              hash_on_uri_capture:
-                description: |-
-                  HashOnURICapture is the name of the capture group whose value is the hash input when "hash_on" is set to
-                  "uri_capture".
-                type: string
-              healthchecks:
-                description: Healthchecks defines the health check configurations
-                  in Kong.
-                properties:
-                  active:
-                    description: ActiveHealthcheck configures active health check
-                      probing.
-                    properties:
-                      concurrency:
-                        minimum: 1
-                        type: integer
-                      headers:
-                        additionalProperties:
-                          items:
-                            type: string
-                          type: array
-                        type: object
-                      healthy:
-                        description: |-
-                          Healthy configures thresholds and HTTP status codes
-                          to mark targets healthy for an upstream.
-                        properties:
-                          http_statuses:
-                            items:
-                              type: integer
-                            type: array
-                          interval:
-                            minimum: 0
-                            type: integer
-                          successes:
-                            minimum: 0
-                            type: integer
-                        type: object
-                      http_path:
-                        pattern: ^/.*$
-                        type: string
-                      https_sni:
-                        type: string
-                      https_verify_certificate:
-                        type: boolean
-                      timeout:
-                        minimum: 0
-                        type: integer
-                      type:
-                        type: string
-                      unhealthy:
-                        description: |-
-                          Unhealthy configures thresholds and HTTP status codes
-                          to mark targets unhealthy.
-                        properties:
-                          http_failures:
-                            minimum: 0
-                            type: integer
-                          http_statuses:
-                            items:
-                              type: integer
-                            type: array
-                          interval:
-                            minimum: 0
-                            type: integer
-                          tcp_failures:
-                            minimum: 0
-                            type: integer
-                          timeouts:
-                            minimum: 0
-                            type: integer
-                        type: object
-                    type: object
-                  passive:
-                    description: |-
-                      PassiveHealthcheck configures passive checks around
-                      passive health checks.
-                    properties:
-                      healthy:
-                        description: |-
-                          Healthy configures thresholds and HTTP status codes
-                          to mark targets healthy for an upstream.
-                        properties:
-                          http_statuses:
-                            items:
-                              type: integer
-                            type: array
-                          interval:
-                            minimum: 0
-                            type: integer
-                          successes:
-                            minimum: 0
-                            type: integer
-                        type: object
-                      type:
-                        type: string
-                      unhealthy:
-                        description: |-
-                          Unhealthy configures thresholds and HTTP status codes
-                          to mark targets unhealthy.
-                        properties:
-                          http_failures:
-                            minimum: 0
-                            type: integer
-                          http_statuses:
-                            items:
-                              type: integer
-                            type: array
-                          interval:
-                            minimum: 0
-                            type: integer
-                          tcp_failures:
-                            minimum: 0
-                            type: integer
-                          timeouts:
-                            minimum: 0
-                            type: integer
-                        type: object
-                    type: object
-                  threshold:
-                    type: number
-                type: object
-              host_header:
-                description: |-
-                  HostHeader is The hostname to be used as Host header
-                  when proxying requests through Kong.
-                type: string
-              slots:
-                description: Slots is the number of slots in the load balancer algorithm.
-                minimum: 10
-                type: integer
-            type: object
-        type: object
-        x-kubernetes-validations:
-        - message: '''proxy'' field is no longer supported, use Service''s annotations
-            instead'
-          rule: '!has(self.proxy)'
-        - message: '''route'' field is no longer supported, use Ingress'' annotations
-            instead'
-          rule: '!has(self.route)'
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongkeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3201,39 +2307,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               jwk:
                 description: |-
                   JWK is a JSON Web Key represented as a string.
@@ -3263,13 +2374,15 @@ spec:
                     - name
                     type: object
                   type:
-                    description: |-
-                      Type defines type of the KeySet object reference. It can be one of:
+                    allOf:
+                    - enum:
                       - konnectID
                       - namespacedRef
-                    enum:
-                    - konnectID
-                    - namespacedRef
+                    - enum:
+                      - namespacedRef
+                    description: |-
+                      Type defines type of the KeySet object reference. It can be one of:
+                      - namespacedRef
                     type: string
                 required:
                 - type
@@ -3278,8 +2391,6 @@ spec:
                 - message: when type is namespacedRef, namespacedRef must be set
                   rule: 'self.type == ''namespacedRef'' ? has(self.namespacedRef)
                     : true'
-                - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
               kid:
                 description: |-
                   KID is a unique identifier for a key.
@@ -3321,6 +2432,9 @@ spec:
             - kid
             type: object
             x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
             - message: Either 'jwk' or 'pem' must be set
               rule: has(self.jwk) || has(self.pem)
           status:
@@ -3431,8 +2545,7 @@ spec:
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-            - it's not supported yet
-          rule: '!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef)
+          rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
             ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
     served: true
     storage: true
@@ -3443,7 +2556,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongkeysets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3512,39 +2625,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               name:
                 description: Name is a name of the KeySet.
                 minLength: 1
@@ -3560,8 +2678,13 @@ spec:
                 - message: tags entries must not be longer than 128 characters
                   rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
             required:
+            - controlPlaneRef
             - name
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:
@@ -3664,8 +2787,8 @@ spec:
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-            - it's not supported yet
-          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+          rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
     served: true
     storage: true
     subresources:
@@ -3675,7 +2798,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3873,7 +2996,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongpluginbindings.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3950,39 +3073,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               pluginRef:
                 description: PluginReference is a reference to the KongPlugin or KongClusterPlugin
                   resource.
@@ -4246,6 +3374,9 @@ spec:
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
     served: true
     storage: true
     subresources:
@@ -4255,7 +3386,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4555,7 +3686,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongroutes.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4594,7 +3725,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KongRouteSpec defines specification of a Kong Route.
+            description: KongRouteSpec defines spec of a Kong Route.
             properties:
               controlPlaneRef:
                 description: |-
@@ -4625,39 +3756,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               destinations:
                 description: A list of IP destinations of incoming connections that
                   match this Route when using stream routing. Each entry is an object
@@ -4759,6 +3895,8 @@ spec:
                     description: NamespacedRef is a reference to a KongService.
                     properties:
                       name:
+                        description: Name is the name of the entity.
+                        minLength: 1
                         type: string
                     required:
                     - name
@@ -4767,6 +3905,8 @@ spec:
                     description: |-
                       Type can be one of:
                       - namespacedRef
+                    enum:
+                    - namespacedRef
                     type: string
                 type: object
                 x-kubernetes-validations:
@@ -4807,6 +3947,10 @@ spec:
                 - message: tags entries must not be longer than 128 characters
                   rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:
@@ -4918,11 +4062,11 @@ spec:
             ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths)
             || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers)
             ) : true'
-        - message: Only one of controlPlaneRef or serviceRef can be set
+        - message: Has to set either controlPlaneRef or serviceRef
           rule: has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || !has(self.spec.controlPlaneRef)
             && has(self.spec.serviceRef)
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-          rule: '!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef)
+          rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
             ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.serviceRef is immutable when an entity is already Programmed
           rule: '!has(self.spec.serviceRef) ? true : (!self.status.conditions.exists(c,
@@ -4941,7 +4085,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongservices.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4958,7 +4102,7 @@ spec:
       name: Host
       type: string
     - description: Protocol of the service
-      jsonPath: .spec.procol
+      jsonPath: .spec.protocol
       name: Protocol
       type: string
     - description: The Resource is Programmed on Konnect
@@ -5023,39 +4167,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               enabled:
                 description: 'Whether the Service is active. If set to `false`, the
                   proxy behavior will be as if any routes attached to it do not exist
@@ -5116,8 +4265,13 @@ spec:
                 format: int64
                 type: integer
             required:
+            - controlPlaneRef
             - host
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:
@@ -5220,9 +4374,11 @@ spec:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+          rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
-          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+          rule: '(!has(self.spec.controlPlaneRef)) ? true : (!has(self.status) ||
+            !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
     served: true
     storage: true
@@ -5233,7 +4389,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongsnis.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5279,10 +4435,7 @@ spec:
                   which the KongSNI is attached.
                 properties:
                   name:
-                    description: |-
-                      Name is the name of the entity.
-
-                      NOTE: the `Required` validation rule does not reject empty strings so we use `MinLength` to reject empty string here.
+                    description: Name is the name of the entity.
                     minLength: 1
                     type: string
                 required:
@@ -5421,7 +4574,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongtargets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5461,9 +4614,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              KongTargetSpec defines the specification of a Kong Target.
-              KongTargetSpec defines the desired state of KongTarget.
+            description: KongTargetSpec defines the spec of KongTarget.
             properties:
               tags:
                 description: Tags is an optional set of strings associated with the
@@ -5613,693 +4764,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
-  labels:
-    gateway.networking.k8s.io/policy: direct
-  name: kongupstreampolicies.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    categories:
-    - kong-ingress-controller
-    kind: KongUpstreamPolicy
-    listKind: KongUpstreamPolicyList
-    plural: kongupstreampolicies
-    shortNames:
-    - kup
-    singular: kongupstreampolicy
-  scope: Namespaced
-  versions:
-  - name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: |-
-          KongUpstreamPolicy allows configuring algorithm that should be used for load balancing traffic between Kong
-          Upstream's Targets. It also allows configuring health checks for Kong Upstream's Targets.
-
-          Its configuration is similar to Kong Upstream object (https://docs.konghq.com/gateway/latest/admin-api/#upstream-object),
-          and it is applied to Kong Upstream objects created by the controller.
-
-          It can be attached to Services. To attach it to a Service, it has to be annotated with
-          `konghq.com/upstream-policy: <name>`, where `<name>` is the name of the KongUpstreamPolicy
-          object in the same namespace as the Service.
-
-          When attached to a Service, it will affect all Kong Upstreams created for the Service.
-
-          When attached to a Service used in a Gateway API *Route rule with multiple BackendRefs, all of its Services MUST
-          be configured with the same KongUpstreamPolicy. Otherwise, the controller will *ignore* the KongUpstreamPolicy.
-
-          Note: KongUpstreamPolicy doesn't implement Gateway API's GEP-713 strictly.
-          In particular, it doesn't use the TargetRef for attaching to Services and Gateway API *Routes - annotations are
-          used instead. This is to allow reusing the same KongUpstreamPolicy for multiple Services and Gateway API *Routes.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec contains the configuration of the Kong upstream.
-            properties:
-              algorithm:
-                description: |-
-                  Algorithm is the load balancing algorithm to use.
-                  Accepted values are: "round-robin", "consistent-hashing", "least-connections", "latency".
-                enum:
-                - round-robin
-                - consistent-hashing
-                - least-connections
-                - latency
-                type: string
-              hashOn:
-                description: |-
-                  HashOn defines how to calculate hash for consistent-hashing load balancing algorithm.
-                  Algorithm must be set to "consistent-hashing" for this field to have effect.
-                properties:
-                  cookie:
-                    description: Cookie is the name of the cookie to use as hash input.
-                    type: string
-                  cookiePath:
-                    description: CookiePath is cookie path to set in the response
-                      headers.
-                    type: string
-                  header:
-                    description: Header is the name of the header to use as hash input.
-                    type: string
-                  input:
-                    description: |-
-                      Input allows using one of the predefined inputs (ip, consumer, path).
-                      For other parametrized inputs, use one of the fields below.
-                    enum:
-                    - ip
-                    - consumer
-                    - path
-                    type: string
-                  queryArg:
-                    description: QueryArg is the name of the query argument to use
-                      as hash input.
-                    type: string
-                  uriCapture:
-                    description: URICapture is the name of the URI capture group to
-                      use as hash input.
-                    type: string
-                type: object
-              hashOnFallback:
-                description: |-
-                  HashOnFallback defines how to calculate hash for consistent-hashing load balancing algorithm if the primary hash
-                  function fails.
-                  Algorithm must be set to "consistent-hashing" for this field to have effect.
-                properties:
-                  cookie:
-                    description: Cookie is the name of the cookie to use as hash input.
-                    type: string
-                  cookiePath:
-                    description: CookiePath is cookie path to set in the response
-                      headers.
-                    type: string
-                  header:
-                    description: Header is the name of the header to use as hash input.
-                    type: string
-                  input:
-                    description: |-
-                      Input allows using one of the predefined inputs (ip, consumer, path).
-                      For other parametrized inputs, use one of the fields below.
-                    enum:
-                    - ip
-                    - consumer
-                    - path
-                    type: string
-                  queryArg:
-                    description: QueryArg is the name of the query argument to use
-                      as hash input.
-                    type: string
-                  uriCapture:
-                    description: URICapture is the name of the URI capture group to
-                      use as hash input.
-                    type: string
-                type: object
-              healthchecks:
-                description: Healthchecks defines the health check configurations
-                  in Kong.
-                properties:
-                  active:
-                    description: Active configures active health check probing.
-                    properties:
-                      concurrency:
-                        description: Concurrency is the number of targets to check
-                          concurrently.
-                        minimum: 1
-                        type: integer
-                      headers:
-                        additionalProperties:
-                          items:
-                            type: string
-                          type: array
-                        description: Headers is a list of HTTP headers to add to the
-                          probe request.
-                        type: object
-                      healthy:
-                        description: Healthy configures thresholds and HTTP status
-                          codes to mark targets healthy for an upstream.
-                        properties:
-                          httpStatuses:
-                            description: HTTPStatuses is a list of HTTP status codes
-                              that Kong considers a success.
-                            items:
-                              description: HTTPStatus is an HTTP status code.
-                              maximum: 599
-                              minimum: 100
-                              type: integer
-                            type: array
-                          interval:
-                            description: Interval is the interval between active health
-                              checks for an upstream in seconds when in a healthy
-                              state.
-                            minimum: 0
-                            type: integer
-                          successes:
-                            description: Successes is the number of successes to consider
-                              a target healthy.
-                            minimum: 0
-                            type: integer
-                        type: object
-                      httpPath:
-                        description: HTTPPath is the path to use in GET HTTP request
-                          to run as a probe.
-                        pattern: ^/.*$
-                        type: string
-                      httpsSni:
-                        description: HTTPSSNI is the SNI to use in GET HTTPS request
-                          to run as a probe.
-                        type: string
-                      httpsVerifyCertificate:
-                        description: HTTPSVerifyCertificate is a boolean value that
-                          indicates if the certificate should be verified.
-                        type: boolean
-                      timeout:
-                        description: Timeout is the probe timeout in seconds.
-                        minimum: 0
-                        type: integer
-                      type:
-                        description: |-
-                          Type determines whether to perform active health checks using HTTP or HTTPS, or just attempt a TCP connection.
-                          Accepted values are "http", "https", "tcp", "grpc", "grpcs".
-                        enum:
-                        - http
-                        - https
-                        - tcp
-                        - grpc
-                        - grpcs
-                        type: string
-                      unhealthy:
-                        description: Unhealthy configures thresholds and HTTP status
-                          codes to mark targets unhealthy for an upstream.
-                        properties:
-                          httpFailures:
-                            description: HTTPFailures is the number of failures to
-                              consider a target unhealthy.
-                            minimum: 0
-                            type: integer
-                          httpStatuses:
-                            description: HTTPStatuses is a list of HTTP status codes
-                              that Kong considers a failure.
-                            items:
-                              description: HTTPStatus is an HTTP status code.
-                              maximum: 599
-                              minimum: 100
-                              type: integer
-                            type: array
-                          interval:
-                            description: Interval is the interval between active health
-                              checks for an upstream in seconds when in an unhealthy
-                              state.
-                            minimum: 0
-                            type: integer
-                          tcpFailures:
-                            description: TCPFailures is the number of TCP failures
-                              in a row to consider a target unhealthy.
-                            minimum: 0
-                            type: integer
-                          timeouts:
-                            description: Timeouts is the number of timeouts in a row
-                              to consider a target unhealthy.
-                            minimum: 0
-                            type: integer
-                        type: object
-                    type: object
-                  passive:
-                    description: Passive configures passive health check probing.
-                    properties:
-                      healthy:
-                        description: Healthy configures thresholds and HTTP status
-                          codes to mark targets healthy for an upstream.
-                        properties:
-                          httpStatuses:
-                            description: HTTPStatuses is a list of HTTP status codes
-                              that Kong considers a success.
-                            items:
-                              description: HTTPStatus is an HTTP status code.
-                              maximum: 599
-                              minimum: 100
-                              type: integer
-                            type: array
-                          interval:
-                            description: Interval is the interval between active health
-                              checks for an upstream in seconds when in a healthy
-                              state.
-                            minimum: 0
-                            type: integer
-                          successes:
-                            description: Successes is the number of successes to consider
-                              a target healthy.
-                            minimum: 0
-                            type: integer
-                        type: object
-                      type:
-                        description: |-
-                          Type determines whether to perform passive health checks interpreting HTTP/HTTPS statuses,
-                          or just check for TCP connection success.
-                          Accepted values are "http", "https", "tcp", "grpc", "grpcs".
-                        enum:
-                        - http
-                        - https
-                        - tcp
-                        - grpc
-                        - grpcs
-                        type: string
-                      unhealthy:
-                        description: Unhealthy configures thresholds and HTTP status
-                          codes to mark targets unhealthy.
-                        properties:
-                          httpFailures:
-                            description: HTTPFailures is the number of failures to
-                              consider a target unhealthy.
-                            minimum: 0
-                            type: integer
-                          httpStatuses:
-                            description: HTTPStatuses is a list of HTTP status codes
-                              that Kong considers a failure.
-                            items:
-                              description: HTTPStatus is an HTTP status code.
-                              maximum: 599
-                              minimum: 100
-                              type: integer
-                            type: array
-                          interval:
-                            description: Interval is the interval between active health
-                              checks for an upstream in seconds when in an unhealthy
-                              state.
-                            minimum: 0
-                            type: integer
-                          tcpFailures:
-                            description: TCPFailures is the number of TCP failures
-                              in a row to consider a target unhealthy.
-                            minimum: 0
-                            type: integer
-                          timeouts:
-                            description: Timeouts is the number of timeouts in a row
-                              to consider a target unhealthy.
-                            minimum: 0
-                            type: integer
-                        type: object
-                    type: object
-                  threshold:
-                    description: |-
-                      Threshold is the minimum percentage of the upstream’s targets’ weight that must be available for the whole
-                      upstream to be considered healthy.
-                    type: integer
-                type: object
-              slots:
-                description: |-
-                  Slots is the number of slots in the load balancer algorithm.
-                  If not set, the default value in Kong for the algorithm is used.
-                maximum: 65536
-                minimum: 10
-                type: integer
-            type: object
-          status:
-            description: Status defines the current state of KongUpstreamPolicy
-            properties:
-              ancestors:
-                description: |-
-                  Ancestors is a list of ancestor resources (usually Gateways) that are
-                  associated with the policy, and the status of the policy with respect to
-                  each ancestor. When this policy attaches to a parent, the controller that
-                  manages the parent and the ancestors MUST add an entry to this list when
-                  the controller first sees the policy and SHOULD update the entry as
-                  appropriate when the relevant ancestor is modified.
-
-                  Note that choosing the relevant ancestor is left to the Policy designers;
-                  an important part of Policy design is designing the right object level at
-                  which to namespace this status.
-
-                  Note also that implementations MUST ONLY populate ancestor status for
-                  the Ancestor resources they are responsible for. Implementations MUST
-                  use the ControllerName field to uniquely identify the entries in this list
-                  that they are responsible for.
-
-                  Note that to achieve this, the list of PolicyAncestorStatus structs
-                  MUST be treated as a map with a composite key, made up of the AncestorRef
-                  and ControllerName fields combined.
-
-                  A maximum of 16 ancestors will be represented in this list. An empty list
-                  means the Policy is not relevant for any ancestors.
-
-                  If this slice is full, implementations MUST NOT add further entries.
-                  Instead they MUST consider the policy unimplementable and signal that
-                  on any related resources such as the ancestor that would be referenced
-                  here. For example, if this list was full on BackendTLSPolicy, no
-                  additional Gateways would be able to reference the Service targeted by
-                  the BackendTLSPolicy.
-                items:
-                  description: |-
-                    PolicyAncestorStatus describes the status of a route with respect to an
-                    associated Ancestor.
-
-                    Ancestors refer to objects that are either the Target of a policy or above it
-                    in terms of object hierarchy. For example, if a policy targets a Service, the
-                    Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
-                    the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
-                    useful object to place Policy status on, so we recommend that implementations
-                    SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
-                    have a _very_ good reason otherwise.
-
-                    In the context of policy attachment, the Ancestor is used to distinguish which
-                    resource results in a distinct application of this policy. For example, if a policy
-                    targets a Service, it may have a distinct result per attached Gateway.
-
-                    Policies targeting the same resource may have different effects depending on the
-                    ancestors of those resources. For example, different Gateways targeting the same
-                    Service may have different capabilities, especially if they have different underlying
-                    implementations.
-
-                    For example, in BackendTLSPolicy, the Policy attaches to a Service that is
-                    used as a backend in a HTTPRoute that is itself attached to a Gateway.
-                    In this case, the relevant object for status is the Gateway, and that is the
-                    ancestor object referred to in this status.
-
-                    Note that a parent is also an ancestor, so for objects where the parent is the
-                    relevant object for status, this struct SHOULD still be used.
-
-                    This struct is intended to be used in a slice that's effectively a map,
-                    with a composite key made up of the AncestorRef and the ControllerName.
-                  properties:
-                    ancestorRef:
-                      description: |-
-                        AncestorRef corresponds with a ParentRef in the spec that this
-                        PolicyAncestorStatus struct describes the status of.
-                      properties:
-                        group:
-                          default: gateway.networking.k8s.io
-                          description: |-
-                            Group is the group of the referent.
-                            When unspecified, "gateway.networking.k8s.io" is inferred.
-                            To set the core API group (such as for a "Service" kind referent),
-                            Group must be explicitly set to "" (empty string).
-
-                            Support: Core
-                          maxLength: 253
-                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                          type: string
-                        kind:
-                          default: Gateway
-                          description: |-
-                            Kind is kind of the referent.
-
-                            There are two kinds of parent resources with "Core" support:
-
-                            * Gateway (Gateway conformance profile)
-                            * Service (Mesh conformance profile, ClusterIP Services only)
-
-                            Support for other resources is Implementation-Specific.
-                          maxLength: 63
-                          minLength: 1
-                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                          type: string
-                        name:
-                          description: |-
-                            Name is the name of the referent.
-
-                            Support: Core
-                          maxLength: 253
-                          minLength: 1
-                          type: string
-                        namespace:
-                          description: |-
-                            Namespace is the namespace of the referent. When unspecified, this refers
-                            to the local namespace of the Route.
-
-                            Note that there are specific rules for ParentRefs which cross namespace
-                            boundaries. Cross-namespace references are only valid if they are explicitly
-                            allowed by something in the namespace they are referring to. For example:
-                            Gateway has the AllowedRoutes field, and ReferenceGrant provides a
-                            generic way to enable any other kind of cross-namespace reference.
-
-                            <gateway:experimental:description>
-                            ParentRefs from a Route to a Service in the same namespace are "producer"
-                            routes, which apply default routing rules to inbound connections from
-                            any namespace to the Service.
-
-                            ParentRefs from a Route to a Service in a different namespace are
-                            "consumer" routes, and these routing rules are only applied to outbound
-                            connections originating from the same namespace as the Route, for which
-                            the intended destination of the connections are a Service targeted as a
-                            ParentRef of the Route.
-                            </gateway:experimental:description>
-
-                            Support: Core
-                          maxLength: 63
-                          minLength: 1
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
-                          type: string
-                        port:
-                          description: |-
-                            Port is the network port this Route targets. It can be interpreted
-                            differently based on the type of parent resource.
-
-                            When the parent resource is a Gateway, this targets all listeners
-                            listening on the specified port that also support this kind of Route(and
-                            select this Route). It's not recommended to set `Port` unless the
-                            networking behaviors specified in a Route must apply to a specific port
-                            as opposed to a listener(s) whose port(s) may be changed. When both Port
-                            and SectionName are specified, the name and port of the selected listener
-                            must match both specified values.
-
-                            <gateway:experimental:description>
-                            When the parent resource is a Service, this targets a specific port in the
-                            Service spec. When both Port (experimental) and SectionName are specified,
-                            the name and port of the selected port must match both specified values.
-                            </gateway:experimental:description>
-
-                            Implementations MAY choose to support other parent resources.
-                            Implementations supporting other types of parent resources MUST clearly
-                            document how/if Port is interpreted.
-
-                            For the purpose of status, an attachment is considered successful as
-                            long as the parent resource accepts it partially. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
-                            from the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route,
-                            the Route MUST be considered detached from the Gateway.
-
-                            Support: Extended
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
-                        sectionName:
-                          description: |-
-                            SectionName is the name of a section within the target resource. In the
-                            following resources, SectionName is interpreted as the following:
-
-                            * Gateway: Listener name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-                            * Service: Port name. When both Port (experimental) and SectionName
-                            are specified, the name and port of the selected listener must match
-                            both specified values.
-
-                            Implementations MAY choose to support attaching Routes to other resources.
-                            If that is the case, they MUST clearly document how SectionName is
-                            interpreted.
-
-                            When unspecified (empty string), this will reference the entire resource.
-                            For the purpose of status, an attachment is considered successful if at
-                            least one section in the parent resource accepts it. For example, Gateway
-                            listeners can restrict which Routes can attach to them by Route kind,
-                            namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
-                            the referencing Route, the Route MUST be considered successfully
-                            attached. If no Gateway listeners accept attachment from this Route, the
-                            Route MUST be considered detached from the Gateway.
-
-                            Support: Core
-                          maxLength: 253
-                          minLength: 1
-                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    conditions:
-                      description: Conditions describes the status of the Policy with
-                        respect to the given Ancestor.
-                      items:
-                        description: Condition contains details for one aspect of
-                          the current state of this API Resource.
-                        properties:
-                          lastTransitionTime:
-                            description: |-
-                              lastTransitionTime is the last time the condition transitioned from one status to another.
-                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                            format: date-time
-                            type: string
-                          message:
-                            description: |-
-                              message is a human readable message indicating details about the transition.
-                              This may be an empty string.
-                            maxLength: 32768
-                            type: string
-                          observedGeneration:
-                            description: |-
-                              observedGeneration represents the .metadata.generation that the condition was set based upon.
-                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                              with respect to the current state of the instance.
-                            format: int64
-                            minimum: 0
-                            type: integer
-                          reason:
-                            description: |-
-                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected values and meanings for this field,
-                              and whether the values are considered a guaranteed API.
-                              The value should be a CamelCase string.
-                              This field may not be empty.
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - lastTransitionTime
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      maxItems: 8
-                      minItems: 1
-                      type: array
-                      x-kubernetes-list-map-keys:
-                      - type
-                      x-kubernetes-list-type: map
-                    controllerName:
-                      description: |-
-                        ControllerName is a domain/path string that indicates the name of the
-                        controller that wrote this status. This corresponds with the
-                        controllerName field on GatewayClass.
-
-                        Example: "example.net/gateway-controller".
-
-                        The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
-                        valid Kubernetes names
-                        (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
-
-                        Controllers MUST populate this field when writing status. Controllers should ensure that
-                        entries to status populated with their ControllerName are cleaned up when they are no
-                        longer necessary.
-                      maxLength: 253
-                      minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
-                      type: string
-                  required:
-                  - ancestorRef
-                  - controllerName
-                  type: object
-                maxItems: 16
-                type: array
-            required:
-            - ancestors
-            type: object
-        type: object
-        x-kubernetes-validations:
-        - message: Only one of spec.hashOn.(input|cookie|header|uriCapture|queryArg)
-            can be set.
-          rule: 'has(self.spec.hashOn) ? [has(self.spec.hashOn.input), has(self.spec.hashOn.cookie),
-            has(self.spec.hashOn.header), has(self.spec.hashOn.uriCapture), has(self.spec.hashOn.queryArg)].filter(fieldSet,
-            fieldSet == true).size() <= 1 : true'
-        - message: When spec.hashOn.cookie is set, spec.hashOn.cookiePath is required.
-          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? has(self.spec.hashOn.cookiePath)
-            : true'
-        - message: When spec.hashOn.cookiePath is set, spec.hashOn.cookie is required.
-          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookiePath) ? has(self.spec.hashOn.cookie)
-            : true'
-        - message: spec.algorithm must be set to "consistent-hashing" when spec.hashOn
-            is set.
-          rule: 'has(self.spec.hashOn) ? has(self.spec.algorithm) && self.spec.algorithm
-            == "consistent-hashing" : true'
-        - message: Only one of spec.hashOnFallback.(input|header|uriCapture|queryArg)
-            can be set.
-          rule: 'has(self.spec.hashOnFallback) ? [has(self.spec.hashOnFallback.input),
-            has(self.spec.hashOnFallback.header), has(self.spec.hashOnFallback.uriCapture),
-            has(self.spec.hashOnFallback.queryArg)].filter(fieldSet, fieldSet == true).size()
-            <= 1 : true'
-        - message: spec.algorithm must be set to "consistent-hashing" when spec.hashOnFallback
-            is set.
-          rule: 'has(self.spec.hashOnFallback) ? has(self.spec.algorithm) && self.spec.algorithm
-            == "consistent-hashing" : true'
-        - message: spec.hashOnFallback.cookie must not be set.
-          rule: 'has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookie)
-            : true'
-        - message: spec.hashOnFallback.cookiePath must not be set.
-          rule: 'has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookiePath)
-            : true'
-        - message: spec.healthchecks.passive.healthy.interval must not be set.
-          rule: 'has(self.spec.healthchecks) && has(self.spec.healthchecks.passive)
-            && has(self.spec.healthchecks.passive.healthy) ? !has(self.spec.healthchecks.passive.healthy.interval)
-            : true'
-        - message: spec.healthchecks.passive.unhealthy.interval must not be set.
-          rule: 'has(self.spec.healthchecks) && has(self.spec.healthchecks.passive)
-            && has(self.spec.healthchecks.passive.unhealthy) ? !has(self.spec.healthchecks.passive.unhealthy.interval)
-            : true'
-        - message: spec.hashOnFallback must not be set when spec.hashOn.cookie is
-            set.
-          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? !has(self.spec.hashOnFallback)
-            : true'
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: kongupstreams.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -6339,7 +4804,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KongUpstreamSpec defines specification of a Kong Upstream.
+            description: KongUpstreamSpec defines the spec of Kong Upstream.
             properties:
               algorithm:
                 description: Which load balancing algorithm to use.
@@ -6378,39 +4843,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               hash_fallback:
                 description: What to use as hashing input if the primary `hash_on`
                   does not return a hash (eg. header is missing, or no Consumer identified).
@@ -6478,9 +4948,6 @@ spec:
                           successes:
                             format: int64
                             type: integer
-                        required:
-                        - interval
-                        - successes
                         type: object
                       http_path:
                         type: string
@@ -6510,18 +4977,7 @@ spec:
                           timeouts:
                             format: int64
                             type: integer
-                        required:
-                        - http_failures
-                        - interval
-                        - tcp_failures
-                        - timeouts
                         type: object
-                    required:
-                    - concurrency
-                    - http_path
-                    - https_verify_certificate
-                    - timeout
-                    - type
                     type: object
                   passive:
                     properties:
@@ -6535,8 +4991,6 @@ spec:
                           successes:
                             format: int64
                             type: integer
-                        required:
-                        - successes
                         type: object
                       type:
                         type: string
@@ -6556,18 +5010,10 @@ spec:
                           timeouts:
                             format: int64
                             type: integer
-                        required:
-                        - http_failures
-                        - tcp_failures
-                        - timeouts
                         type: object
-                    required:
-                    - type
                     type: object
                   threshold:
                     type: number
-                required:
-                - threshold
                 type: object
               host_header:
                 description: The hostname to be used as `Host` header when proxying
@@ -6601,8 +5047,13 @@ spec:
                 description: If set, the balancer will use SRV hostname(if DNS Answer
                   has SRV record) as the proxy upstream `Host`.
                 type: boolean
+            required:
+            - controlPlaneRef
             type: object
             x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
             - message: hash_fallback_header is required when `hash_fallback` is set
                 to `header`.
               rule: '!has(self.hash_fallback) || (self.hash_fallback != ''header''
@@ -6734,7 +5185,8 @@ spec:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+          rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
@@ -6747,7 +5199,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -6849,39 +5301,44 @@ spec:
                     - name
                     type: object
                   type:
+                    default: kic
                     description: |-
-                      Type can be one of:
-                      - konnectID
+                      Type indicates the type of the control plane being referenced. Allowed values:
                       - konnectNamespacedRef
                       - kic
+
+                      The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
-                required:
-                - type
                 type: object
                 x-kubernetes-validations:
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? has(self.konnectNamespacedRef) : true'
                 - message: when type is konnectNamespacedRef, konnectID must not be
                     set
-                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
-                    : true'
+                  rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
+                    ? !has(self.konnectID) : true'
                 - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectNamespacedRef must not be
                     set
-                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                  rule: '(has(self.type) && self.type == ''konnectID'') ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectID)
+                    : true'
                 - message: when type is kic, konnectNamespacedRef must not be set
-                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
-                    true'
+                  rule: '(has(self.type) && self.type == ''kic'') ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is unset, konnectID must not be set
+                  rule: '!has(self.type) ? !has(self.konnectID) : true'
+                - message: when type is unset, konnectNamespacedRef must not be set
+                  rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
               description:
                 description: Description is the additional information about the vault.
                 type: string
@@ -7026,7 +5483,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -7227,7 +5684,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    kubernetes-configuration.konghq.com/channels: gateway-operator
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -7497,384 +5954,6 @@ spec:
             API Auth Configuration
           rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status
             == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
-  name: tcpingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    categories:
-    - kong-ingress-controller
-    kind: TCPIngress
-    listKind: TCPIngressList
-    plural: tcpingresses
-    singular: tcpingress
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Address of the load balancer
-      jsonPath: .status.loadBalancer.ingress[*].ip
-      name: Address
-      type: string
-    - description: Age
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: TCPIngress is the Schema for the tcpingresses API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec is the TCPIngress specification.
-            properties:
-              rules:
-                description: A list of rules used to configure the Ingress.
-                items:
-                  description: |-
-                    IngressRule represents a rule to apply against incoming requests.
-                    Matching is performed based on an (optional) SNI and port.
-                  properties:
-                    backend:
-                      description: |-
-                        Backend defines the referenced service endpoint to which the traffic
-                        will be forwarded to.
-                      properties:
-                        serviceName:
-                          description: Specifies the name of the referenced service.
-                          minLength: 1
-                          type: string
-                        servicePort:
-                          description: Specifies the port of the referenced service.
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
-                      required:
-                      - serviceName
-                      - servicePort
-                      type: object
-                    host:
-                      description: |-
-                        Host is the fully qualified domain name of a network host, as defined
-                        by RFC 3986.
-                        If a Host is not specified, then port-based TCP routing is performed. Kong
-                        doesn't care about the content of the TCP stream in this case.
-                        If a Host is specified, the protocol must be TLS over TCP.
-                        A plain-text TCP request cannot be routed based on Host. It can only
-                        be routed based on Port.
-                      type: string
-                    port:
-                      description: |-
-                        Port is the port on which to accept TCP or TLS over TCP sessions and
-                        route. It is a required field. If a Host is not specified, the requested
-                        are routed based only on Port.
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                  required:
-                  - backend
-                  - port
-                  type: object
-                type: array
-              tls:
-                description: |-
-                  TLS configuration. This is similar to the `tls` section in the
-                  Ingress resource in networking.v1beta1 group.
-                  The mapping of SNIs to TLS cert-key pair defined here will be
-                  used for HTTP Ingress rules as well. Once can define the mapping in
-                  this resource or the original Ingress resource, both have the same
-                  effect.
-                items:
-                  description: IngressTLS describes the transport layer security.
-                  properties:
-                    hosts:
-                      description: |-
-                        Hosts are a list of hosts included in the TLS certificate. The values in
-                        this list must match the name/s used in the tlsSecret. Defaults to the
-                        wildcard host setting for the loadbalancer controller fulfilling this
-                        Ingress, if left unspecified.
-                      items:
-                        type: string
-                      type: array
-                    secretName:
-                      description: SecretName is the name of the secret used to terminate
-                        SSL traffic.
-                      type: string
-                  type: object
-                type: array
-            type: object
-          status:
-            description: TCPIngressStatus defines the observed state of TCPIngress.
-            properties:
-              loadBalancer:
-                description: LoadBalancer contains the current status of the load-balancer.
-                properties:
-                  ingress:
-                    description: |-
-                      Ingress is a list containing ingress points for the load-balancer.
-                      Traffic intended for the service should be sent to these ingress points.
-                    items:
-                      description: |-
-                        LoadBalancerIngress represents the status of a load-balancer ingress point:
-                        traffic intended for the service should be sent to an ingress point.
-                      properties:
-                        hostname:
-                          description: |-
-                            Hostname is set for load-balancer ingress points that are DNS based
-                            (typically AWS load-balancers)
-                          type: string
-                        ip:
-                          description: |-
-                            IP is set for load-balancer ingress points that are IP based
-                            (typically GCE or OpenStack load-balancers)
-                          type: string
-                        ipMode:
-                          description: |-
-                            IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
-                            Setting this to "VIP" indicates that traffic is delivered to the node with
-                            the destination set to the load-balancer's IP and port.
-                            Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
-                            the destination set to the node's IP and node port or the pod's IP and port.
-                            Service implementations may use this information to adjust traffic routing.
-                          type: string
-                        ports:
-                          description: |-
-                            Ports is a list of records of service ports
-                            If used, every port defined in the service should have an entry in it
-                          items:
-                            properties:
-                              error:
-                                description: |-
-                                  Error is to record the problem with the service port
-                                  The format of the error shall comply with the following rules:
-                                  - built-in error values shall be specified in this file and those shall use
-                                    CamelCase names
-                                  - cloud provider specific error values must have names that comply with the
-                                    format foo.example.com/CamelCase.
-                                maxLength: 316
-                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                type: string
-                              port:
-                                description: Port is the port number of the service
-                                  port of which status is recorded here
-                                format: int32
-                                type: integer
-                              protocol:
-                                description: |-
-                                  Protocol is the protocol of the service port of which status is recorded here
-                                  The supported values are: "TCP", "UDP", "SCTP"
-                                type: string
-                            required:
-                            - error
-                            - port
-                            - protocol
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
-  name: udpingresses.configuration.konghq.com
-spec:
-  group: configuration.konghq.com
-  names:
-    categories:
-    - kong-ingress-controller
-    kind: UDPIngress
-    listKind: UDPIngressList
-    plural: udpingresses
-    singular: udpingress
-  scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Address of the load balancer
-      jsonPath: .status.loadBalancer.ingress[*].ip
-      name: Address
-      type: string
-    - description: Age
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        description: UDPIngress is the Schema for the udpingresses API.
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec is the UDPIngress specification.
-            properties:
-              rules:
-                description: A list of rules used to configure the Ingress.
-                items:
-                  description: |-
-                    UDPIngressRule represents a rule to apply against incoming requests
-                    wherein no Host matching is available for request routing, only the port
-                    is used to match requests.
-                  properties:
-                    backend:
-                      description: |-
-                        Backend defines the Kubernetes service which accepts traffic from the
-                        listening Port defined above.
-                      properties:
-                        serviceName:
-                          description: Specifies the name of the referenced service.
-                          minLength: 1
-                          type: string
-                        servicePort:
-                          description: Specifies the port of the referenced service.
-                          format: int32
-                          maximum: 65535
-                          minimum: 1
-                          type: integer
-                      required:
-                      - serviceName
-                      - servicePort
-                      type: object
-                    port:
-                      description: |-
-                        Port indicates the port for the Kong proxy to accept incoming traffic
-                        on, which will then be routed to the service Backend.
-                      format: int32
-                      maximum: 65535
-                      minimum: 1
-                      type: integer
-                  required:
-                  - backend
-                  - port
-                  type: object
-                type: array
-            type: object
-          status:
-            description: UDPIngressStatus defines the observed state of UDPIngress.
-            properties:
-              loadBalancer:
-                description: LoadBalancer contains the current status of the load-balancer.
-                properties:
-                  ingress:
-                    description: |-
-                      Ingress is a list containing ingress points for the load-balancer.
-                      Traffic intended for the service should be sent to these ingress points.
-                    items:
-                      description: |-
-                        LoadBalancerIngress represents the status of a load-balancer ingress point:
-                        traffic intended for the service should be sent to an ingress point.
-                      properties:
-                        hostname:
-                          description: |-
-                            Hostname is set for load-balancer ingress points that are DNS based
-                            (typically AWS load-balancers)
-                          type: string
-                        ip:
-                          description: |-
-                            IP is set for load-balancer ingress points that are IP based
-                            (typically GCE or OpenStack load-balancers)
-                          type: string
-                        ipMode:
-                          description: |-
-                            IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
-                            Setting this to "VIP" indicates that traffic is delivered to the node with
-                            the destination set to the load-balancer's IP and port.
-                            Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
-                            the destination set to the node's IP and node port or the pod's IP and port.
-                            Service implementations may use this information to adjust traffic routing.
-                          type: string
-                        ports:
-                          description: |-
-                            Ports is a list of records of service ports
-                            If used, every port defined in the service should have an entry in it
-                          items:
-                            properties:
-                              error:
-                                description: |-
-                                  Error is to record the problem with the service port
-                                  The format of the error shall comply with the following rules:
-                                  - built-in error values shall be specified in this file and those shall use
-                                    CamelCase names
-                                  - cloud provider specific error values must have names that comply with the
-                                    format foo.example.com/CamelCase.
-                                maxLength: 316
-                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                type: string
-                              port:
-                                description: Port is the port number of the service
-                                  port of which status is recorded here
-                                format: int32
-                                type: integer
-                              protocol:
-                                description: |-
-                                  Protocol is the protocol of the service port of which status is recorded here
-                                  The supported values are: "TCP", "UDP", "SCTP"
-                                type: string
-                            required:
-                            - error
-                            - port
-                            - protocol
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-            type: object
-        type: object
     served: true
     storage: true
     subresources:

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
@@ -3,6 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongcacertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -246,6 +247,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -506,6 +508,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -751,6 +754,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1023,6 +1027,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongcredentialacls.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1210,6 +1215,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1397,6 +1403,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1588,6 +1595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1781,6 +1789,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongcredentialjwts.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1998,6 +2007,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2239,6 +2249,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongkeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2557,6 +2568,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongkeysets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2799,6 +2811,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2997,6 +3010,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongpluginbindings.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3387,6 +3401,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3687,6 +3702,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongroutes.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4086,6 +4102,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongservices.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4390,6 +4407,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongsnis.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4575,6 +4593,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongtargets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4765,6 +4784,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongupstreams.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5200,6 +5220,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5484,6 +5505,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -5685,6 +5707,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
+    kubernetes-configuration.konghq.com/version: v1.0.3
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
   group: konnect.konghq.com


### PR DESCRIPTION
#### What this PR does / why we need it:

Bump KGO's kubernetes-configuration CRDs to 1.0.3 with change from https://github.com/Kong/kubernetes-configuration/pull/198 which disallows `konnectID` references (which are not yet implemented).

Release KGO chart 0.4.2.

CRDs updates as per the instruction in https://github.com/Kong/charts/blob/5bf6276477c9e01de3d4c24268770ab267e7558b/charts/gateway-operator/charts/kubernetes-configuration-crds/README.md#L14

```
kustomize build github.com/kong/kubernetes-configuration/config/crd/gateway-operator > ./charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
```

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
