### PR TITLE
ci: limit permissions of GITHUB_TOKEN and add actionlint

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -14,6 +14,9 @@ on:
       - release/kong-3.x
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   # Specify this here because these tests rely on ktf to run kind for cluster creation.
   KIND_VERSION: v0.23.0

--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -6,6 +6,9 @@ on:
       - main
       - release/kong-2.x
 
+permissions:
+  contents: read
+
 env:
   # Specify this here because these tests rely on ktf to run kind for cluster creation.
   KIND_VERSION: v0.23.0
@@ -71,6 +74,8 @@ jobs:
     timeout-minutes: 30
     needs: lint-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -4,3 +4,5 @@ kube-linter: "0.7.1"
 chartsnap: "0.4.3"
 # renovate: datasource=github-releases depName=koalaman/shellcheck
 shellcheck: "0.10.0"
+# renovate: datasource=github-releases depName=rhysd/actionlint
+actionlint: "1.7.7"


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Release job has been failing: https://github.com/Kong/charts/actions/runs/12887167527

As part of this PR: 

- GitHub actions' token for actions has been upgraded to write access ( to create releases )
- workflow wide permissions have been limited to `contents: read` (this PR's changes)
- `actionlint` has been added to lint actions' files on CI

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
