### PR TITLE
fix(kgo): fix ports.dataplane.gateway-operator.konghq.com ValidatingAdmissionPolicy rules

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.5
+
+### Changes
+
+- Fix rules of `ValidatingAdmissionPolicy` validating `DataPlane` ports.
+  [#1215](https://github.com/Kong/charts/pull/1215)
+
 ## 0.4.4
 
 ### Changes
@@ -12,7 +19,7 @@
 
 ### Changes
 
-- Added `ValidatingAdmissionPolicy` and ``ValidatingAdmissionPolicyBinding` for
+- Added `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` for
   validating `DataPlane` ports.
   [#1215](https://github.com/Kong/charts/pull/1215)
 

--- a/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
@@ -834,18 +834,17 @@ spec:
       resources:
       - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -865,27 +864,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 # Source: gateway-operator/templates/validation-policy-dataplane.yaml

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -826,18 +826,17 @@ spec:
       resources:
       - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -857,27 +856,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 # Source: gateway-operator/templates/validation-policy-dataplane.yaml

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -826,18 +826,17 @@ spec:
       resources:
       - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -857,27 +856,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 # Source: gateway-operator/templates/validation-policy-dataplane.yaml

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -828,18 +828,17 @@ spec:
       resources:
       - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -859,27 +858,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 # Source: gateway-operator/templates/validation-policy-dataplane.yaml

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -827,18 +827,17 @@ spec:
       resources:
       - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -858,27 +857,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 # Source: gateway-operator/templates/validation-policy-dataplane.yaml

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -826,18 +826,17 @@ spec:
       resources:
       - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -857,27 +856,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 # Source: gateway-operator/templates/validation-policy-dataplane.yaml

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -828,18 +828,17 @@ spec:
       resources:
       - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -859,27 +858,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 # Source: gateway-operator/templates/validation-policy-dataplane.yaml

--- a/charts/gateway-operator/templates/validation-policy-dataplane.yaml
+++ b/charts/gateway-operator/templates/validation-policy-dataplane.yaml
@@ -19,18 +19,17 @@ spec:
         resources:
           - "dataplanes"
   variables:
-  - name: network
-    expression: object.spec.network
-  - name: services
-    expression: variables.network.services
   - name: ingressPorts
-    expression: variables.services.ingress.ports
+    expression: object.spec.network.services.ingress.ports
   - name: podTemplateSpec
     expression: object.spec.deployment.podTemplateSpec
+  - name: proxyContainers
+    expression: |
+      variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')
   - name: proxyContainer
     expression: |
-      variables.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy') ?
-        variables.podTemplateSpec.spec.containers.filter(c, c.name == 'proxy')[0] :
+      variables.proxyContainers.size() > 0 ?
+        variables.proxyContainers[0] :
         null
   - name: envFilteredPortMaps
     expression: |
@@ -50,27 +49,35 @@ spec:
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envPortMaps == null ||
-      variables.ingressPorts.all(p, variables.envPortMaps.
-                split(",").
-                exists(pm,
-                    pm.split(":")[1].trim() == string(p.targetPort)
-                    )
-                )
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envPortMaps != null &&
+        variables.ingressPorts.all(p, variables.envPortMaps.
+                  split(",").
+                  exists(pm,
+                      pm.split(":")[1].trim() == string(p.targetPort)
+                      )
+                  )
+      )
     reason: Invalid
   - messageExpression: "'Each port from spec.network.services.ingress.ports has to have an accompanying port in KONG_PROXY_LISTEN env'"
     expression: |
       !has(object.spec.network) ||
       !has(object.spec.network.services) ||
-      variables.ingressPorts == null ||
-      variables.envProxyListen == null ||
-      variables.ingressPorts.all(p, variables.envProxyListen.
-                split(",").
-                exists(pm,
-                  pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+      !has(object.spec.network.services.ingress) ||
+      !has(object.spec.network.services.ingress.ports) ||
+      (
+        has(variables.proxyContainer.env) &&
+        variables.envProxyListen != null &&
+        variables.ingressPorts.all(p, variables.envProxyListen.
+                  split(",").
+                  exists(pm,
+                    pm.trim().split(" ")[0].split(":")[1].trim() == string(p.targetPort)
+                    )
                   )
-                )
+      )
     reason: Invalid
 ---
 apiVersion: admissionregistration.k8s.io/v1


### PR DESCRIPTION
#### What this PR does / why we need it:

`ValidatingAdmissionPolicy` added in #1215 had incomplete rules causing:

```
resourceVersion should not be set on objects to be created
```

errors. This PR fixes it.

Related change in KGO: https://github.com/Kong/gateway-operator/pull/1067

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
