### PR TITLE
fix(kgo): add permission for operating `BackendTLSPolicy` in RBAC resources

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changes
 
 - Added permissions to `get/list/watch` `backendtlspolicies` and `update/patch`
-  `backendtlspolicies/status` to enable TLSBackendPolicy controller in KIC.
+  `backendtlspolicies/status` to enable BackendTLSPolicy controller in KIC.
   [#1230](https://github.com/Kong/charts/pull/1230)
 
 ## 0.4.3

--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.4
+
+### Changes
+
+- Added permissions to `get/list/watch` `backendtlspolicies` and `update/patch`
+  `backendtlspolicies/status` to enable TLSBackendPolicy controller in KIC.
+  [#1230](https://github.com/Kong/charts/pull/1230)
+
 ## 0.4.3
 
 ### Changes

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.4.3
+version: 0.4.4
 appVersion: "1.4"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
@@ -346,6 +346,7 @@ rules:
   - tcproutes
   - tlsroutes
   - udproutes
+  - backendtlspolicies
   verbs:
   - get
   - list
@@ -356,6 +357,7 @@ rules:
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
+  - backendtlspolicies/status
   verbs:
   - get
   - patch

--- a/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.3
+        helm.sh/chart: gateway-operator-0.4.4
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -818,7 +818,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -895,7 +895,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.3
+        helm.sh/chart: gateway-operator-0.4.4
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -810,7 +810,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -887,7 +887,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -346,6 +346,7 @@ rules:
   - tcproutes
   - tlsroutes
   - udproutes
+  - backendtlspolicies
   verbs:
   - get
   - list
@@ -356,6 +357,7 @@ rules:
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
+  - backendtlspolicies/status
   verbs:
   - get
   - patch

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.3
+        helm.sh/chart: gateway-operator-0.4.4
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -810,7 +810,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -887,7 +887,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -346,6 +346,7 @@ rules:
   - tcproutes
   - tlsroutes
   - udproutes
+  - backendtlspolicies
   verbs:
   - get
   - list
@@ -356,6 +357,7 @@ rules:
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
+  - backendtlspolicies/status
   verbs:
   - get
   - patch

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.3
+        helm.sh/chart: gateway-operator-0.4.4
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -812,7 +812,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -889,7 +889,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -346,6 +346,7 @@ rules:
   - tcproutes
   - tlsroutes
   - udproutes
+  - backendtlspolicies
   verbs:
   - get
   - list
@@ -356,6 +357,7 @@ rules:
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
+  - backendtlspolicies/status
   verbs:
   - get
   - patch

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -346,6 +346,7 @@ rules:
   - tcproutes
   - tlsroutes
   - udproutes
+  - backendtlspolicies
   verbs:
   - get
   - list
@@ -356,6 +357,7 @@ rules:
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
+  - backendtlspolicies/status
   verbs:
   - get
   - patch

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"
@@ -719,7 +719,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.3
+        helm.sh/chart: gateway-operator-0.4.4
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         a: "b"
@@ -810,7 +810,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"
@@ -888,7 +888,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.3
+        helm.sh/chart: gateway-operator-0.4.4
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -810,7 +810,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -887,7 +887,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -346,6 +346,7 @@ rules:
   - tcproutes
   - tlsroutes
   - udproutes
+  - backendtlspolicies
   verbs:
   - get
   - list
@@ -356,6 +357,7 @@ rules:
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
+  - backendtlspolicies/status
   verbs:
   - get
   - patch

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.3
+        helm.sh/chart: gateway-operator-0.4.4
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -812,7 +812,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -889,7 +889,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.3
+    helm.sh/chart: gateway-operator-0.4.4
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -346,6 +346,7 @@ rules:
   - tcproutes
   - tlsroutes
   - udproutes
+  - backendtlspolicies
   verbs:
   - get
   - list
@@ -356,6 +357,7 @@ rules:
   - gatewayclasses/status
   - gateways/status
   - grpcroutes/status
+  - backendtlspolicies/status
   verbs:
   - get
   - patch

--- a/charts/gateway-operator/templates/rbac-resources.yaml
+++ b/charts/gateway-operator/templates/rbac-resources.yaml
@@ -336,6 +336,7 @@ rules:
       - tcproutes
       - tlsroutes
       - udproutes
+      - backendtlspolicies
     verbs:
       - get
       - list
@@ -346,6 +347,7 @@ rules:
       - gatewayclasses/status
       - gateways/status
       - grpcroutes/status
+      - backendtlspolicies/status
     verbs:
       - get
       - patch


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Since KIC 3.4 adds controller for reconciling `BackendTLSPolicy`. KGO needs permissions to operate it for deploying KIC.
It is also required for the e2e tests for upgrading from `nightly` image of KGO.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
