### PR TITLE
chore(deps): bump kong/kubernetes-configuration to v1.0.7

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fix rules of `ValidatingAdmissionPolicy` validating `DataPlane` ports.
   [#1215](https://github.com/Kong/charts/pull/1215)
-- Bumped `kong/kubernetes-configuration` CRDs to 1.1.0.
+- Bumped `kong/kubernetes-configuration` CRDs to 1.0.7.
   [#1231](https://github.com/Kong/charts/pull/1231)
 
 ## 0.4.4

--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix rules of `ValidatingAdmissionPolicy` validating `DataPlane` ports.
   [#1215](https://github.com/Kong/charts/pull/1215)
+- Bumped `kong/kubernetes-configuration` CRDs to 1.1.0.
+  [#1231](https://github.com/Kong/charts/pull/1231)
 
 ## 0.4.4
 

--- a/charts/gateway-operator/Chart.lock
+++ b/charts/gateway-operator/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.0
 - name: kubernetes-configuration-crds
   repository: ""
-  version: 1.0.3
-digest: sha256:2e65234a2398cd6b463374f55abc6c88f51ec8c6535304ff6cce7a81c468526f
-generated: "2025-01-07T18:13:01.488691+01:00"
+  version: 1.0.7
+digest: sha256:4379649a3d91c891221d14e61a409226e46e52cf322ee9edce9807a201c58b7a
+generated: "2025-01-22T11:35:39.653481+01:00"

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.4.4
+version: 0.4.5
 appVersion: "1.4"
 annotations:
   artifacthub.io/prerelease: "false"
@@ -24,5 +24,5 @@ dependencies:
     version: 1.1.0
     condition: gwapi-experimental-crds.enabled
   - name: kubernetes-configuration-crds
-    version: 1.0.3
+    version: 1.0.7
     condition: kubernetes-configuration-crds.enabled

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubernetes-configuration-crds
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.0.7
+appVersion: "1.0.7"
 description: A Helm chart for Kong's Kubernetes Configuration CRDs

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongcacertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -247,7 +247,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -508,7 +508,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -754,7 +754,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1027,7 +1027,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongcredentialacls.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1215,7 +1215,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1403,7 +1403,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1595,7 +1595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1789,7 +1789,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongcredentialjwts.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2007,7 +2007,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2249,7 +2249,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongkeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2568,7 +2568,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongkeysets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2811,7 +2811,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3010,7 +3010,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongpluginbindings.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3401,7 +3401,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3702,7 +3702,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongroutes.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3825,7 +3825,9 @@ spec:
                 type: array
               headers:
                 additionalProperties:
-                  type: string
+                  items:
+                    type: string
+                  type: array
                 description: 'One or more lists of values indexed by header name that
                   will cause this Route to match if present in the request. The `Host`
                   header cannot be used with this attribute: hosts should be specified
@@ -4102,7 +4104,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongservices.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4407,7 +4409,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongsnis.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4593,7 +4595,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongtargets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4784,7 +4786,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongupstreams.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5220,7 +5222,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5505,7 +5507,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -5707,7 +5709,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.3
+    kubernetes-configuration.konghq.com/version: v1.0.7
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.4
+        helm.sh/chart: gateway-operator-0.4.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -818,7 +818,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -902,7 +902,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.4
+        helm.sh/chart: gateway-operator-0.4.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -810,7 +810,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -894,7 +894,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.4
+        helm.sh/chart: gateway-operator-0.4.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -810,7 +810,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -894,7 +894,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.4
+        helm.sh/chart: gateway-operator-0.4.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -812,7 +812,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -896,7 +896,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"
@@ -719,7 +719,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.4
+        helm.sh/chart: gateway-operator-0.4.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         a: "b"
@@ -810,7 +810,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"
@@ -895,7 +895,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.4
+        helm.sh/chart: gateway-operator-0.4.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -810,7 +810,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -894,7 +894,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.4
+        helm.sh/chart: gateway-operator-0.4.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -812,7 +812,7 @@ metadata:
   name: ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:
@@ -896,7 +896,7 @@ metadata:
   name: binding-ports.dataplane.gateway-operator.konghq.com
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.4
+    helm.sh/chart: gateway-operator-0.4.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
 spec:


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps kong/kubernetes-configuration CRDs dependency in the gateway-operator chart to v1.0.7. Also, releases a 0.4.5 version of said chart.

#### Which issue this PR fixes

Part of the fix for https://github.com/Kong/gateway-operator/issues/1043.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
