### PR TITLE
chore(ci): don't run lint-test before release in release workflow

### DIFF
--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -9,70 +9,9 @@ on:
 permissions:
   contents: read
 
-env:
-  # Specify this here because these tests rely on ktf to run kind for cluster creation.
-  KIND_VERSION: v0.23.0
-
 jobs:
-  lint-test:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        kubernetes-version:
-          # renovate: datasource=docker depName=kindest/node
-          - "1.31.4"
-        chart-name:
-          - kong
-          - ingress
-          - gateway-operator
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up Helm
-        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
-
-      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
-        with:
-          python-version: "3.11"
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
-
-      - name: Add dependency chart repos
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add kong https://charts.konghq.com
-
-      - name: Run chart-testing (lint)
-        run: ct lint --target-branch main --charts ${{ matrix.chart-name }}
-        working-directory: charts
-
-      - name: setup testing environment (kind-cluster)
-        env:
-          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
-          CHART_NAME: ${{ matrix.chart-name }}
-        run: ./scripts/test-env.sh
-
-      - name: run chart-testing (install)
-        run: ct install --target-branch main --charts ${{ matrix.chart-name }}
-        working-directory: charts
-        if: matrix.chart-name == 'kong'
-
-      - name: run integration tests (integration)
-        env:
-          CHART_NAME: ${{ matrix.chart-name }}
-        run: ./scripts/test-run.sh
-
-      - name: cleanup integration tests (cleanup)
-        run: ./scripts/test-env.sh cleanup
-
   release:
-    timeout-minutes: 30
-    needs: lint-test
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -99,5 +38,5 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_SKIP_EXISTING: true


### PR DESCRIPTION
#### What this PR does / why we need it:

`lint-test` is already run as part of each PR's CI so not point to wait another 20 minutes before releasing a chart.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
