### PR TITLE
fix(gateway-operator): changeable host network value for gw-operator

### DIFF
--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
         {{ include "kong.renderTpl" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.tolerations }}
       tolerations:
       {{ toYaml . | nindent 8 }}

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -117,3 +117,7 @@ certsDir:
 # Override the default deployment selector labels. This is useful if you don't want
 # to use the defaults or are migrating to this chart and want to use existing labels.
 # selectorLabels: []
+
+# Deploy the deployment in host network.
+# May be required to set to true if Calico CNI is used.
+hostNetwork: false


### PR DESCRIPTION

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Adding ability to change gateway-operator host network value by helm values. it's required when calico cni is used

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
