### PR TITLE
chore(kgo): bump kong/kubernetes-configuration to v1.0.8

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.7
+
+## Changes
+
+- Bumped `kong/kubernetes-configuration` CRDs to 1.0.8.
+  [#1238](https://github.com/Kong/charts/pull/1238)
+
 ## 0.4.6
 
 ### Changes

--- a/charts/gateway-operator/Chart.lock
+++ b/charts/gateway-operator/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 1.1.0
 - name: kubernetes-configuration-crds
   repository: ""
-  version: 1.0.7
-digest: sha256:4379649a3d91c891221d14e61a409226e46e52cf322ee9edce9807a201c58b7a
-generated: "2025-01-22T11:35:39.653481+01:00"
+  version: 1.0.8
+digest: sha256:c03fa0214878f1b9b8b8d7890c22cd6d19cc4a95fa4236b4f55eb6b73e1db62f
+generated: "2025-01-23T15:58:39.886944+01:00"

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.4.6
+version: 0.4.7
 appVersion: "1.4"
 annotations:
   artifacthub.io/prerelease: "false"
@@ -24,5 +24,5 @@ dependencies:
     version: 1.1.0
     condition: gwapi-experimental-crds.enabled
   - name: kubernetes-configuration-crds
-    version: 1.0.7
+    version: 1.0.8
     condition: kubernetes-configuration-crds.enabled

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: kubernetes-configuration-crds
-version: 1.0.7
-appVersion: "1.0.7"
+version: 1.0.8
+appVersion: "1.0.8"
 description: A Helm chart for Kong's Kubernetes Configuration CRDs

--- a/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
+++ b/charts/gateway-operator/charts/kubernetes-configuration-crds/crds/kubernetes-configuration-crds.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongcacertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -79,16 +79,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -247,7 +253,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -329,16 +335,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -508,7 +520,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -586,16 +598,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -754,7 +772,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -857,16 +875,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -1027,7 +1051,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongcredentialacls.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1215,7 +1239,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1403,7 +1427,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1595,7 +1619,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -1789,7 +1813,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongcredentialjwts.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2007,7 +2031,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2085,16 +2109,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -2249,7 +2279,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongkeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2321,16 +2351,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -2385,15 +2421,11 @@ spec:
                     - name
                     type: object
                   type:
-                    allOf:
-                    - enum:
-                      - konnectID
-                      - namespacedRef
-                    - enum:
-                      - namespacedRef
                     description: |-
                       Type defines type of the KeySet object reference. It can be one of:
                       - namespacedRef
+                    enum:
+                    - namespacedRef
                     type: string
                 required:
                 - type
@@ -2568,7 +2600,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongkeysets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -2640,16 +2672,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -2811,7 +2849,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3010,7 +3048,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongpluginbindings.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3090,16 +3128,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -3401,7 +3445,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3702,7 +3746,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongroutes.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -3775,16 +3819,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -4104,7 +4154,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongservices.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4189,16 +4239,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -4409,7 +4465,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongsnis.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4595,7 +4651,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongtargets.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4786,7 +4842,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongupstreams.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -4868,16 +4924,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -5222,7 +5284,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com
@@ -5327,16 +5389,22 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
+                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
+                      KonnectID might not be available for all the resources.
+                      Consult the specific resource documentation for more information.
                     enum:
+                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: konnectID type is not supported
+                  rule: '!has(self.type) || self.type != ''konnectID'''
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')
@@ -5507,7 +5575,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com
@@ -5709,7 +5777,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.0.7
+    kubernetes-configuration.konghq.com/version: v1.0.8
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.6
+    helm.sh/chart: gateway-operator-0.4.7
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.6
+        helm.sh/chart: gateway-operator-0.4.7
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.6
+    helm.sh/chart: gateway-operator-0.4.7
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.6
+        helm.sh/chart: gateway-operator-0.4.7
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.6
+    helm.sh/chart: gateway-operator-0.4.7
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.6
+        helm.sh/chart: gateway-operator-0.4.7
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.6
+    helm.sh/chart: gateway-operator-0.4.7
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.6
+        helm.sh/chart: gateway-operator-0.4.7
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.6
+    helm.sh/chart: gateway-operator-0.4.7
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"
@@ -719,7 +719,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.6
+        helm.sh/chart: gateway-operator-0.4.7
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         a: "b"

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.6
+    helm.sh/chart: gateway-operator-0.4.7
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.6
+        helm.sh/chart: gateway-operator-0.4.7
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.6
+    helm.sh/chart: gateway-operator-0.4.7
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.6
+        helm.sh/chart: gateway-operator-0.4.7
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps KCFG CRDs to v1.0.8.

#### Which issue this PR fixes

Part of https://github.com/Kong/gateway-operator/issues/1043.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
