### PR TITLE
feat(kgo): drop kube-rbac-proxy, expose metrics by default for 1.5+

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.4.8
+
+## Changes
+
+- Remove kube-rbac-proxy for operator versions 1.5+.
+  In order to controler metrics endpoint access for these version please see
+  [kubernetes-sigs/kubebuilder/discussions/3907][kubebuilder_discussion_3907].
+  Operator exposes `--metrics-access-filter` flag to control access to the metrics endpoint.
+  [#1243](https://github.com/Kong/charts/pull/1243)
+
+[kubebuilder_discussion_3907]: https://github.com/kubernetes-sigs/kubebuilder/discussions/3907
+
 ## 0.4.7
 
 ## Changes

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.4.7
+version: 0.4.8
 appVersion: "1.4"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.7
+    helm.sh/chart: gateway-operator-0.4.8
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.7
+        helm.sh/chart: gateway-operator-0.4.8
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -735,7 +735,7 @@ spec:
         - name: GATEWAY_OPERATOR_HEALTH_PROBE_BIND_ADDRESS
           value: ":8081"
         - name: GATEWAY_OPERATOR_METRICS_BIND_ADDRESS
-          value: "127.0.0.1:8080"
+          value: "0.0.0.0:8080"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -772,6 +772,9 @@ spec:
         ports:
         - containerPort: 8081
           name: probe
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
           protocol: TCP
         volumeMounts:
         - name: chartsnap-gateway-operator-certs-dir

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.7
+    helm.sh/chart: gateway-operator-0.4.8
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.7
+        helm.sh/chart: gateway-operator-0.4.8
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -735,7 +735,7 @@ spec:
         - name: GATEWAY_OPERATOR_HEALTH_PROBE_BIND_ADDRESS
           value: ":8081"
         - name: GATEWAY_OPERATOR_METRICS_BIND_ADDRESS
-          value: "127.0.0.1:8080"
+          value: "0.0.0.0:8080"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -772,6 +772,9 @@ spec:
         ports:
         - containerPort: 8081
           name: probe
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
           protocol: TCP
         volumeMounts:
         - name: chartsnap-gateway-operator-certs-dir

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.7
+    helm.sh/chart: gateway-operator-0.4.8
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.7
+        helm.sh/chart: gateway-operator-0.4.8
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -737,7 +737,7 @@ spec:
         - name: GATEWAY_OPERATOR_HEALTH_PROBE_BIND_ADDRESS
           value: ":8081"
         - name: GATEWAY_OPERATOR_METRICS_BIND_ADDRESS
-          value: "127.0.0.1:8080"
+          value: "0.0.0.0:8080"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -774,6 +774,9 @@ spec:
         ports:
         - containerPort: 8081
           name: probe
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
           protocol: TCP
         volumeMounts:
         - name: chartsnap-gateway-operator-certs-dir

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.7
+    helm.sh/chart: gateway-operator-0.4.8
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"
@@ -719,7 +719,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.7
+        helm.sh/chart: gateway-operator-0.4.8
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         a: "b"
@@ -735,7 +735,7 @@ spec:
         - name: GATEWAY_OPERATOR_HEALTH_PROBE_BIND_ADDRESS
           value: ":8081"
         - name: GATEWAY_OPERATOR_METRICS_BIND_ADDRESS
-          value: "127.0.0.1:8080"
+          value: "0.0.0.0:8080"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -772,6 +772,9 @@ spec:
         ports:
         - containerPort: 8081
           name: probe
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
           protocol: TCP
         volumeMounts:
         - name: chartsnap-gateway-operator-certs-dir

--- a/charts/gateway-operator/ci/__snapshots__/kube-rbac-proxy-removed-in-1-5-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/kube-rbac-proxy-removed-in-1-5-values.snap
@@ -669,7 +669,7 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller-manager
 ---
@@ -725,16 +725,6 @@ spec:
         app: chartsnap-gateway-operator
         version: "1.4"
     spec:
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: component
-                operator: NotIn
-                values:
-                - dummy
-            topologyKey: kubernetes.io/hostname
       containers:
       - name: manager
         env:
@@ -748,7 +738,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/gateway-operator:1.4"
+        image: "docker.io/kong/nightly-gateway-operator-oss:20250130"
         livenessProbe:
           httpGet:
             path: /healthz
@@ -787,24 +777,6 @@ spec:
         volumeMounts:
         - name: chartsnap-gateway-operator-certs-dir
           mountPath: /tmp/k8s-webhook-server/serving-certs
-      - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
       securityContext:
         runAsNonRoot: true
       serviceAccountName: controller-manager

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.7
+    helm.sh/chart: gateway-operator-0.4.8
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.7
+        helm.sh/chart: gateway-operator-0.4.8
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -735,7 +735,7 @@ spec:
         - name: GATEWAY_OPERATOR_HEALTH_PROBE_BIND_ADDRESS
           value: ":8081"
         - name: GATEWAY_OPERATOR_METRICS_BIND_ADDRESS
-          value: "127.0.0.1:8080"
+          value: "0.0.0.0:8080"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -772,6 +772,9 @@ spec:
         ports:
         - containerPort: 8081
           name: probe
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
           protocol: TCP
         volumeMounts:
         - name: chartsnap-gateway-operator-certs-dir

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.7
+    helm.sh/chart: gateway-operator-0.4.8
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.7
+        helm.sh/chart: gateway-operator-0.4.8
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo
@@ -737,7 +737,7 @@ spec:
         - name: GATEWAY_OPERATOR_HEALTH_PROBE_BIND_ADDRESS
           value: ":8081"
         - name: GATEWAY_OPERATOR_METRICS_BIND_ADDRESS
-          value: "127.0.0.1:8080"
+          value: "0.0.0.0:8080"
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -774,6 +774,9 @@ spec:
         ports:
         - containerPort: 8081
           name: probe
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
           protocol: TCP
         volumeMounts:
         - name: chartsnap-gateway-operator-certs-dir

--- a/charts/gateway-operator/ci/kube-rbac-proxy-removed-in-1-5-values.yaml
+++ b/charts/gateway-operator/ci/kube-rbac-proxy-removed-in-1-5-values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: docker.io/kong/nightly-gateway-operator-oss
+  tag: "20250130"
+  effectiveSemver: "1.5.0"
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+env:
+  anonymous_reports: "false"

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -73,8 +73,12 @@ spec:
         - containerPort: 8081
           name: probe
           protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
+{{- if (semverCompare "< 1.5.0" (include "kong.effectiveVersion" .Values.image)) }}
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
@@ -88,6 +92,7 @@ spec:
           protocol: TCP
         resources:
 {{ toYaml .Values.kubeRBACProxy.resources | indent 10 }}
+{{- end }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ template "kong.serviceAccountName" . }}

--- a/charts/gateway-operator/templates/rbac-resources.yaml
+++ b/charts/gateway-operator/templates/rbac-resources.yaml
@@ -650,6 +650,10 @@ spec:
     - name: https
       port: 8443
       protocol: TCP
+{{ if (semverCompare "< 1.5.0" (include "kong.effectiveVersion" .Values.image)) }}
       targetPort: https
+{{- else }}
+      targetPort: metrics
+{{- end }}
   selector:
     control-plane: controller-manager

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -1,7 +1,15 @@
 image:
   repository: docker.io/kong/gateway-operator
-  tag: 1.4
+  tag: "1.4"
+  # Optionally set a semantic version for version-gated features. This can normally
+  # be left unset. You only need to set this if your tag is not a semver string,
+  # such as when you are using a "next" tag. Set this to the effective semantic
+  # version of your tag: for example if using a "nightly" image for an unreleased 1.5.0
+  # version, set this to "1.5.0".
+  effectiveSemver: ""
 
+# Deprecated: KGO versions 1.5+ do not use kube-rbac-proxy.
+# Use --metrics-access-filter flag instead to control access to metrics endpoint.
 kubeRBACProxy:
   # Additional pod containers in the controller.
   image: gcr.io/kubebuilder/kube-rbac-proxy


### PR DESCRIPTION
#### What this PR does / why we need it:

Follow up for https://github.com/Kong/gateway-operator/pull/956

Changes:

- remove kube-rbac-proxy container for KGO 1.5+
- expose metrics by default on 0.0.0.0:8080

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
