### PR TITLE
fix(kgo): default image.effectiveSemver to Chart's appVersion

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.9
+
+## Changes
+
+- Fix using non semver tags (e.g. `nightly`) without specifying the
+  `.image.effectiveSemver`. Now the latter default to current chart `appVersion`.
+  [#1246](https://github.com/Kong/charts/pull/1246)
+
 ## 0.4.8
 
 ## Changes

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.4.8
+version: 0.4.9
 appVersion: "1.4"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.8
+    helm.sh/chart: gateway-operator-0.4.9
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.8
+        helm.sh/chart: gateway-operator-0.4.9
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.8
+    helm.sh/chart: gateway-operator-0.4.9
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.8
+        helm.sh/chart: gateway-operator-0.4.9
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.8
+    helm.sh/chart: gateway-operator-0.4.9
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.8
+        helm.sh/chart: gateway-operator-0.4.9
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.8
+    helm.sh/chart: gateway-operator-0.4.9
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.8
+        helm.sh/chart: gateway-operator-0.4.9
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.8
+    helm.sh/chart: gateway-operator-0.4.9
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     a: "b"
@@ -719,7 +719,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.8
+        helm.sh/chart: gateway-operator-0.4.9
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         a: "b"

--- a/charts/gateway-operator/ci/__snapshots__/kube-rbac-proxy-removed-in-1-5-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/kube-rbac-proxy-removed-in-1-5-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.8
+    helm.sh/chart: gateway-operator-0.4.9
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.8
+        helm.sh/chart: gateway-operator-0.4.9
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -727,8 +727,6 @@ spec:
     spec:
       containers:
       - name: manager
-        args:
-        - --zap-log-level=debug
         env:
         - name: GATEWAY_OPERATOR_ANONYMOUS_REPORTS
           value: "false"
@@ -740,7 +738,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/gateway-operator:1.4"
+        image: "docker.io/kong/nightly-gateway-operator-oss:nightly"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.4.8
+    helm.sh/chart: gateway-operator-0.4.9
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.4"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.4.8
+        helm.sh/chart: gateway-operator-0.4.9
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.4"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/nightly-can-be-used-values.yaml
+++ b/charts/gateway-operator/ci/nightly-can-be-used-values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: docker.io/kong/nightly-gateway-operator-oss
+  # NOTE: this tests that the missing effectiveSemver field is handled correctly.
+  tag: "nightly"
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+env:
+  anonymous_reports: "false"

--- a/charts/gateway-operator/templates/_helpers.tpl
+++ b/charts/gateway-operator/templates/_helpers.tpl
@@ -101,23 +101,22 @@ Create a list of env vars based on the values of the `env` and `customEnv` maps.
   mountPath: /tmp/k8s-webhook-server/serving-certs
 {{- end }}
 
-{{/* effectiveVersion takes an image dict from values.yaml. if .effectiveSemver is set, it returns that, else it returns .tag */}}
+{{/* effectiveVersion takes the image dict from values.yaml. */}}
+{{/* if .effectiveSemver is set, it returns that, else it returns .tag */}}
 {{- define "kong.effectiveVersion" -}}
-{{- /* Because Kong Gateway enterprise uses versions with 4 segments and not 3 */ -}}
-{{- /* as semver does, we need to account for that here by extracting */ -}}
-{{- /* first 3 segments for comparison */ -}}
-{{- if .effectiveSemver -}}
-  {{- if regexMatch "^[0-9]+.[0-9]+.[0-9]+" .effectiveSemver -}}
-  {{- regexFind "^[0-9]+.[0-9]+.[0-9]+" .effectiveSemver -}}
+{{- $effectiveSemver := .Values.image.effectiveSemver -}}
+{{- if $effectiveSemver -}}
+  {{- if regexMatch "^[0-9]+.[0-9]+.[0-9]+" $effectiveSemver -}}
+  {{- regexFind "^[0-9]+.[0-9]+.[0-9]+" $effectiveSemver -}}
   {{- else -}}
-  {{- .effectiveSemver -}}
+  {{- $effectiveSemver -}}
   {{- end -}}
 {{- else -}}
-  {{- $tag := (trimSuffix "-redhat" .tag) -}}
-  {{- if regexMatch "^[0-9]+.[0-9]+.[0-9]+" .tag -}}
-  {{- regexFind "^[0-9]+.[0-9]+.[0-9]+" .tag -}}
+  {{- $tag := (trimSuffix "-redhat" .Values.image.tag) -}}
+  {{- if regexMatch "^[0-9]+.[0-9]+.[0-9]+" $tag -}}
+  {{- regexFind "^[0-9]+.[0-9]+.[0-9]+" $tag -}}
   {{- else -}}
-  {{- .tag -}}
+  {{- .Chart.AppVersion -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
           protocol: TCP
         volumeMounts:
         {{- include "kong.volumeMounts" . | nindent 8 }}
-{{- if (semverCompare "< 1.5.0" (include "kong.effectiveVersion" .Values.image)) }}
+{{- if (semverCompare "< 1.5.0" (include "kong.effectiveVersion" .)) }}
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/

--- a/charts/gateway-operator/templates/rbac-resources.yaml
+++ b/charts/gateway-operator/templates/rbac-resources.yaml
@@ -650,7 +650,7 @@ spec:
     - name: https
       port: 8443
       protocol: TCP
-{{ if (semverCompare "< 1.5.0" (include "kong.effectiveVersion" .Values.image)) }}
+{{ if (semverCompare "< 1.5.0" (include "kong.effectiveVersion" .)) }}
       targetPort: https
 {{- else }}
       targetPort: metrics


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow not setting the `image.effectiveSemver` for non semver `image.tag`s.

Now the `image.effectiveSemver` defaults to chart's `appVersion`.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
