### PR TITLE
chore(ingress): bump kong chart dependency to the one using 3.9 release

### DIFF
--- a/charts/ingress/CHANGELOG.md
+++ b/charts/ingress/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.18.0
+
+- Bumped dependencies on `kong/kong` chart to `==2.47.0`. Review the [kong chart
+  changelog](https://github.com/Kong/charts/blob/main/charts/kong/CHANGELOG.md#2470)
+  for details.
+
 ## 0.17.0
 
 ### Fixes

--- a/charts/ingress/Chart.lock
+++ b/charts/ingress/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.46.0
+  version: 2.47.0
 - name: kong
   repository: https://charts.konghq.com
-  version: 2.46.0
-digest: sha256:d7c7090a4ca302ca0c507ec7d6c20c79b38f7f15c5150a48db8913725d2f2622
-generated: "2024-12-19T16:21:50.48581+01:00"
+  version: 2.47.0
+digest: sha256:cb300dea964d25ccaaa1b4bd7028bd0753691cb645d843bf4fc8346f51d843f1
+generated: "2025-02-14T11:05:04.710606+01:00"

--- a/charts/ingress/Chart.yaml
+++ b/charts/ingress/Chart.yaml
@@ -8,16 +8,16 @@ maintainers:
 name: ingress
 sources:
   - https://github.com/Kong/charts/tree/main/charts/ingress
-version: 0.17.0
-appVersion: "3.8"
+version: 0.18.0
+appVersion: "3.9"
 dependencies:
   - name: kong
-    version: "=2.46.0"
+    version: "=2.47.0"
     repository: https://charts.konghq.com
     alias: controller
     condition: controller.enabled
   - name: kong
-    version: "=2.46.0"
+    version: "=2.47.0"
     repository: https://charts.konghq.com
     alias: gateway
     condition: gateway.enabled

--- a/charts/ingress/ci/.chartsnap.yaml
+++ b/charts/ingress/ci/.chartsnap.yaml
@@ -38,3 +38,10 @@ dynamicFields:
       - /webhooks/0/clientConfig/caBundle
       - /webhooks/1/clientConfig/caBundle
       - /webhooks/2/clientConfig/caBundle
+  - apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    name: chartsnap-controller-default-validations
+    jsonPath:
+      - /webhooks/0/clientConfig/caBundle
+      - /webhooks/1/clientConfig/caBundle
+      - /webhooks/2/clientConfig/caBundle

--- a/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
+++ b/charts/ingress/ci/__snapshots__/gateway-discovery-values.snap
@@ -5,8 +5,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller
   namespace: default
 ---
@@ -17,8 +17,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: gateway-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: gateway-2.47.0
   name: chartsnap-gateway
   namespace: default
 ---
@@ -32,8 +32,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -48,8 +48,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -64,8 +64,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller-admin-api-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -80,8 +80,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller-admin-api-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -93,8 +93,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller
 rules:
   - apiGroups:
@@ -541,8 +541,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -560,8 +560,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller
   namespace: default
 rules:
@@ -624,8 +624,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller
   namespace: default
 roleRef:
@@ -644,8 +644,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller-validation-webhook
   namespace: default
 spec:
@@ -659,8 +659,8 @@ spec:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
 ---
 apiVersion: v1
 kind: Service
@@ -669,8 +669,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller-metrics
   namespace: default
 spec:
@@ -688,8 +688,8 @@ spec:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
 ---
 apiVersion: v1
 kind: Service
@@ -698,8 +698,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: gateway-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: gateway-2.47.0
   name: chartsnap-gateway-admin
   namespace: default
 spec:
@@ -722,8 +722,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: gateway-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: gateway-2.47.0
   name: chartsnap-gateway-manager
   namespace: default
 spec:
@@ -749,9 +749,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: gateway-2.46.0
+    helm.sh/chart: gateway-2.47.0
   name: chartsnap-gateway-proxy
   namespace: default
 spec:
@@ -778,8 +778,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
   name: chartsnap-controller
   namespace: default
 spec:
@@ -804,9 +804,9 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: controller
-        app.kubernetes.io/version: "3.8"
-        helm.sh/chart: controller-2.46.0
-        version: "3.8"
+        app.kubernetes.io/version: "3.9"
+        helm.sh/chart: controller-2.47.0
+        version: "3.9"
     spec:
       automountServiceAccountToken: false
       containers:
@@ -936,8 +936,8 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gateway
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: gateway-2.46.0
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: gateway-2.47.0
   name: chartsnap-gateway
   namespace: default
 spec:
@@ -960,9 +960,9 @@ spec:
         app.kubernetes.io/instance: chartsnap
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: gateway
-        app.kubernetes.io/version: "3.8"
-        helm.sh/chart: gateway-2.46.0
-        version: "3.8"
+        app.kubernetes.io/version: "3.9"
+        helm.sh/chart: gateway-2.47.0
+        version: "3.9"
     spec:
       automountServiceAccountToken: false
       containers:
@@ -1019,7 +1019,7 @@ spec:
               value: "off"
             - name: KONG_NGINX_DAEMON
               value: "off"
-          image: kong:3.8
+          image: kong:3.9
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:
@@ -1134,7 +1134,7 @@ spec:
               value: 0.0.0.0:8100, [::]:8100
             - name: KONG_STREAM_LISTEN
               value: "off"
-          image: kong:3.8
+          image: kong:3.9
           imagePullPolicy: IfNotPresent
           name: clear-stale-pid
           resources: {}
@@ -1188,10 +1188,9 @@ metadata:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: controller
-    app.kubernetes.io/version: "3.8"
-    helm.sh/chart: controller-2.46.0
-  name: chartsnap-controller-validations
-  namespace: default
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: controller-2.47.0
+  name: chartsnap-controller-default-validations
 webhooks:
   - admissionReviewVersions:
       - v1

--- a/charts/ingress/ci/__snapshots__/kic-3.4-values.snap
+++ b/charts/ingress/ci/__snapshots__/kic-3.4-values.snap
@@ -8,10 +8,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 ---
 # Source: ingress/charts/gateway/templates/service-account.yaml
 apiVersion: v1
@@ -21,10 +21,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.46.0
+    helm.sh/chart: gateway-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 ---
 # Source: ingress/charts/controller/templates/admission-webhook.yaml
 apiVersion: v1
@@ -34,10 +34,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 type: kubernetes.io/tls
 data:
   tls.crt: '###DYNAMIC_FIELD###'
@@ -51,10 +51,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 type: kubernetes.io/tls
 data:
   tls.crt: '###DYNAMIC_FIELD###'
@@ -68,10 +68,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 type: kubernetes.io/tls
 data:
   tls.crt: '###DYNAMIC_FIELD###'
@@ -85,10 +85,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 type: kubernetes.io/tls
 data:
   tls.crt: '###DYNAMIC_FIELD###'
@@ -100,10 +100,10 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
   name: chartsnap-controller
 rules:
 - apiGroups:
@@ -550,10 +550,10 @@ metadata:
   name: chartsnap-controller
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -571,10 +571,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 rules:
 - apiGroups:
   - ""
@@ -641,10 +641,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -662,10 +662,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 spec:
   ports:
   - name: webhook
@@ -674,10 +674,10 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
     app.kubernetes.io/component: app
 ---
 # Source: ingress/charts/controller/templates/controller-service-metrics.yaml
@@ -688,10 +688,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 spec:
   ports:
   - name: cmetrics
@@ -704,10 +704,10 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
     app.kubernetes.io/component: app
 ---
 # Source: ingress/charts/gateway/templates/service-kong-admin.yaml
@@ -718,10 +718,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.46.0
+    helm.sh/chart: gateway-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 spec:
   type: ClusterIP
   ports:
@@ -743,10 +743,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.46.0
+    helm.sh/chart: gateway-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 spec:
   type: NodePort
   ports:
@@ -771,10 +771,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.46.0
+    helm.sh/chart: gateway-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
 spec:
   type: LoadBalancer
@@ -800,10 +800,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
     app.kubernetes.io/component: app
 spec:
   replicas: 1
@@ -823,13 +823,13 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: controller
-        helm.sh/chart: controller-2.46.0
+        helm.sh/chart: controller-2.47.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/version: "3.8"
+        app.kubernetes.io/version: "3.9"
         app.kubernetes.io/component: app
         app: chartsnap-controller
-        version: "3.8"
+        version: "3.9"
     spec:
       serviceAccountName: chartsnap-controller
       automountServiceAccountToken: false
@@ -959,10 +959,10 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: gateway
-    helm.sh/chart: gateway-2.46.0
+    helm.sh/chart: gateway-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
     app.kubernetes.io/component: app
 spec:
   replicas: 1
@@ -980,19 +980,19 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: gateway
-        helm.sh/chart: gateway-2.46.0
+        helm.sh/chart: gateway-2.47.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/version: "3.8"
+        app.kubernetes.io/version: "3.9"
         app.kubernetes.io/component: app
         app: chartsnap-gateway
-        version: "3.8"
+        version: "3.9"
     spec:
       serviceAccountName: chartsnap-gateway
       automountServiceAccountToken: false
       initContainers:
       - name: clear-stale-pid
-        image: kong:3.8
+        image: kong:3.9
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -1067,7 +1067,7 @@ spec:
           mountPath: /tmp
       containers:
       - name: "proxy"
-        image: kong:3.8
+        image: kong:3.9
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -1209,14 +1209,13 @@ spec:
 kind: ValidatingWebhookConfiguration
 apiVersion: admissionregistration.k8s.io/v1
 metadata:
-  name: chartsnap-controller-validations
-  namespace: default
+  name: chartsnap-controller-default-validations
   labels:
     app.kubernetes.io/name: controller
-    helm.sh/chart: controller-2.46.0
+    helm.sh/chart: controller-2.47.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.8"
+    app.kubernetes.io/version: "3.9"
 webhooks:
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
#### What this PR does / why we need it:

Bumps `kong/ingress`' dependency on `kong/kong` to `2.47.0` (the one bumping Kong Gateway to 3.9). Releases `kong/ingress`.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
