### PR TITLE
feat(kgo): add node selector to deployment

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.3
+
+## Changes
+
+- Add the option to define a `nodeSelector` to the Kong Gateway Operator controller pod.
+  [#1262](https://github.com/Kong/charts/pull/1262)
+
 ## 0.5.2
 
 ### Fixes

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.5.2
+version: 0.5.3
 appVersion: "1.5"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/node-selector-values.yaml
+++ b/charts/gateway-operator/ci/node-selector-values.yaml
@@ -1,0 +1,16 @@
+nodeSelector:
+  kubernetes.io/os: linux
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+env:
+  anonymous_reports: "false"

--- a/charts/gateway-operator/templates/deployment.yaml
+++ b/charts/gateway-operator/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       affinity:
       {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+      {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       containers:
       - name: manager
         {{ with .Values.args -}}

--- a/charts/gateway-operator/values.yaml
+++ b/charts/gateway-operator/values.yaml
@@ -44,6 +44,10 @@ extraLabels: {}
 # Labels to be added to KGO pods
 podLabels: {}
 
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
 # Install KIC's CRDs
 kic-crds:
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

The idea is to add an option to specify the node on which the KGO controller should be scheduled. This feature can be helpful when clusters have dedicated nodes for specific use cases

#### Special notes for your reviewer:

I'm not sure if I forgot to run something locally, in any case, just let me know

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
