### PR TITLE
chore: document how to disable webhook in kube-system ns

### DIFF
--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -137,3 +137,29 @@ for setting a password:
 If you have already upgraded, the old password is lost. You will need to
 delete the Helm release and the Postgres PersistentVolumeClaim before
 re-installing with a non-random password.
+
+### Kong's admission webhook interrupts Kubernetes control plane operations
+
+Kubernetes control plane components rely on resources within the `kube-system` namespace.
+Modifying or rejecting requests in this namespace using an admission webhook may cause
+unintended disruptions to cluster operations, including failures in critical services like
+`kube-dns`. By default, Kong's admission webhook is configured with no namespace selector, 
+which means it will intercept requests for resources in all namespaces, including `kube-system`.
+
+#### Solution
+
+To ensure Kong's admission webhook does not interfere with the control plane, you can configure
+it to exclude the `kube-system` namespace by setting `ingressController.admissionWebhook.namespaceSelector`.
+
+This can be done by adding the following to your `values.yaml`:
+
+```yaml
+ingressController:
+  admissionWebhook:
+      namespaceSelector:
+        matchExpressions:
+          - key: kubernetes.io/metadata.name
+            operator: NotIn
+            values:
+              - kube-system
+```

--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -143,7 +143,7 @@ re-installing with a non-random password.
 Kubernetes control plane components rely on resources within the `kube-system` namespace.
 Modifying or rejecting requests in this namespace using an admission webhook may cause
 unintended disruptions to cluster operations, including failures in critical services like
-`kube-dns`. By default, Kong's admission webhook is configured with no namespace selector, 
+`kube-dns`. By default, KIC's admission webhook is configured with no namespace selector, 
 which means it will intercept requests for resources in all namespaces, including `kube-system`.
 
 #### Solution

--- a/charts/kong/FAQs.md
+++ b/charts/kong/FAQs.md
@@ -148,7 +148,7 @@ which means it will intercept requests for resources in all namespaces, includin
 
 #### Solution
 
-To ensure Kong's admission webhook does not interfere with the control plane, you can configure
+To ensure KIC's admission webhook does not interfere with the control plane, you can configure
 it to exclude the `kube-system` namespace by setting `ingressController.admissionWebhook.namespaceSelector`.
 
 This can be done by adding the following to your `values.yaml`:


### PR DESCRIPTION
#### What this PR does / why we need it:

Adds a FAQ entry to address a problem that might make KIC's admission webhook interrupt Kubernetes control plane services.

#### Which issue this PR fixes
Closes https://github.com/Kong/charts/issues/1196.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
