### PR TITLE
fix(kgo): fix effective semver

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.5.1
+
+### Fixes
+
+- Fix `ClusterRole` permissions for `.Values.image.tag`s and `.Values.image.effectiveSemver`s
+  not using a full semver format (e.g. `1.4.0`) but `1.4`.
+  [#1281](https://github.com/Kong/charts/pull/1281)
+
 ## 0.5.0
 
 ### Changes

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.5.0
+version: 0.5.1
 appVersion: "1.5"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/affinity-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     a: "b"
@@ -711,7 +711,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         a: "b"

--- a/charts/gateway-operator/ci/__snapshots__/kgo-1-4-0-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/kgo-1-4-0-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/kgo-1-4-0-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/kgo-1-4-0-values.snap
@@ -1,0 +1,807 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: gateway-operator/templates/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-manager
+  namespace: default
+---
+# Source: gateway-operator/templates/cluster-role-lte-1.4.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chartsnap-gateway-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  - serviceaccounts/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - ingressclassparameterses
+  - kongclusterplugins
+  - kongcustomentities
+  - kongingresses
+  - konglicenses
+  - kongupstreampolicies
+  - tcpingresses
+  - udpingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongcacertificates
+  - kongcertificates
+  - kongconsumergroups
+  - kongconsumers
+  - kongcredentialacls
+  - kongcredentialapikeys
+  - kongcredentialbasicauths
+  - kongcredentialhmacs
+  - kongcredentialjwts
+  - kongdataplaneclientcertificates
+  - kongkeys
+  - kongkeysets
+  - kongroutes
+  - kongservices
+  - kongsnis
+  - kongtargets
+  - kongupstreams
+  - kongvaults
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongcacertificates/finalizers
+  - kongcacertificates/status
+  - kongcertificates/finalizers
+  - kongcertificates/status
+  - kongconsumergroups/finalizers
+  - kongconsumers/finalizers
+  - kongcredentialacls/finalizers
+  - kongcredentialacls/status
+  - kongcredentialapikeys/finalizers
+  - kongcredentialapikeys/status
+  - kongcredentialbasicauths/finalizers
+  - kongcredentialbasicauths/status
+  - kongcredentialhmacs/finalizers
+  - kongcredentialhmacs/status
+  - kongcredentialjwts/finalizers
+  - kongcredentialjwts/status
+  - kongdataplaneclientcertificates/finalizers
+  - kongdataplaneclientcertificates/status
+  - kongkeys/finalizers
+  - kongkeys/status
+  - kongkeysets/finalizers
+  - kongkeysets/status
+  - kongpluginbindings/status
+  - kongroutes/finalizers
+  - kongroutes/status
+  - kongservices/finalizers
+  - kongservices/status
+  - kongsnis/finalizers
+  - kongsnis/status
+  - kongtargets/finalizers
+  - kongtargets/status
+  - kongupstreams/finalizers
+  - kongupstreams/status
+  - kongvaults/finalizers
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongclusterplugins/status
+  - kongconsumergroups/status
+  - kongconsumers/status
+  - kongcustomentities/status
+  - kongingresses/status
+  - konglicenses/status
+  - kongplugins/status
+  - kongupstreampolicies/status
+  - kongvaults/status
+  - tcpingresses/status
+  - udpingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - configuration.konghq.com
+  resources:
+  - kongpluginbindings
+  - kongplugins
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway-operator.konghq.com
+  resources:
+  - aigateways
+  - controlplanes
+  - dataplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway-operator.konghq.com
+  resources:
+  - aigateways/finalizers
+  - controlplanes/finalizers
+  - dataplanes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway-operator.konghq.com
+  resources:
+  - aigateways/status
+  - controlplanes/status
+  - dataplanes/status
+  - kongplugininstallations/status
+  - konnectextensions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway-operator.konghq.com
+  resources:
+  - dataplanemetricsextensions
+  - gatewayconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway-operator.konghq.com
+  resources:
+  - kongplugininstallations
+  - konnectextensions
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway-operator.konghq.com
+  resources:
+  - konnectextensions/finalizers
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  - grpcroutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  - udproutes
+  - backendtlspolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses/status
+  - gateways/status
+  - grpcroutes/status
+  - backendtlspolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  - httproutes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes/status
+  - tcproutes/status
+  - tlsroutes/status
+  - udproutes/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants/status
+  verbs:
+  - get
+- apiGroups:
+  - incubator.ingress-controller.konghq.com
+  resources:
+  - kongservicefacades
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - incubator.ingress-controller.konghq.com
+  resources:
+  - kongservicefacades/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectapiauthconfigurations
+  - konnectgatewaycontrolplanes
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectapiauthconfigurations/finalizers
+  - konnectgatewaycontrolplanes/finalizers
+  - konnectgatewaycontrolplanes/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - konnect.konghq.com
+  resources:
+  - konnectapiauthconfigurations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings/status
+  - clusterroles/status
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: chartsnap-gateway-operator-kong-mtls-secret-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - patch
+  - update
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chartsnap-gateway-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chartsnap-gateway-operator-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chartsnap-gateway-operator-kong-mtls-secret-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-gateway-operator-kong-mtls-secret-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: default
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chartsnap-gateway-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-gateway-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: default
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chartsnap-gateway-operator-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chartsnap-gateway-operator-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: default
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: chartsnap-gateway-operator-leader-election-role
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: chartsnap-gateway-operator-leader-election-rolebinding
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: chartsnap-gateway-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: default
+---
+# Source: gateway-operator/templates/rbac-resources.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: chartsnap-gateway-operator-metrics-service
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+# Source: gateway-operator/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: kgo
+  name: chartsnap-gateway-operator
+  namespace: default
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/component: kgo
+---
+# Source: gateway-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: gateway-operator
+    helm.sh/chart: gateway-operator-0.5.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/version: "1.5"
+    app.kubernetes.io/component: kgo
+  name: chartsnap-gateway-operator-controller-manager
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gateway-operator
+      app.kubernetes.io/component: kgo
+      app.kubernetes.io/instance: "chartsnap"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+        app.kubernetes.io/name: gateway-operator
+        helm.sh/chart: gateway-operator-0.5.0
+        app.kubernetes.io/instance: "chartsnap"
+        app.kubernetes.io/version: "1.5"
+        app.kubernetes.io/component: kgo
+        app: chartsnap-gateway-operator
+        version: "1.5"
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: GATEWAY_OPERATOR_ANONYMOUS_REPORTS
+          value: "false"
+        - name: GATEWAY_OPERATOR_HEALTH_PROBE_BIND_ADDRESS
+          value: ":8081"
+        - name: GATEWAY_OPERATOR_METRICS_BIND_ADDRESS
+          value: "0.0.0.0:8080"
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: "docker.io/kong/gateway-operator:1.4"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 1
+          periodSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 1
+          periodSeconds: 1
+        resources:
+          limits:
+            cpu: 500m
+            memory: 256Mi
+          requests:
+            cpu: 10m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - containerPort: 8081
+          name: probe
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        volumeMounts:
+        - name: chartsnap-gateway-operator-certs-dir
+          mountPath: /tmp/k8s-webhook-server/serving-certs
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        securityContext:
+          readOnlyRootFilesystem: true
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: chartsnap-gateway-operator-certs-dir
+        emptyDir:
+          sizeLimit: 256Mi

--- a/charts/gateway-operator/ci/__snapshots__/kube-rbac-proxy-removed-in-1-5-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/kube-rbac-proxy-removed-in-1-5-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.0
+    helm.sh/chart: gateway-operator-0.5.1
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.0
+        helm.sh/chart: gateway-operator-0.5.1
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/kgo-1-4-0-values.yaml
+++ b/charts/gateway-operator/ci/kgo-1-4-0-values.yaml
@@ -1,0 +1,16 @@
+image:
+  tag: "1.4"
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+env:
+  anonymous_reports: "false"

--- a/charts/gateway-operator/templates/_helpers.tpl
+++ b/charts/gateway-operator/templates/_helpers.tpl
@@ -106,15 +106,15 @@ Create a list of env vars based on the values of the `env` and `customEnv` maps.
 {{- define "kong.effectiveVersion" -}}
 {{- $effectiveSemver := .Values.image.effectiveSemver -}}
 {{- if $effectiveSemver -}}
-  {{- if regexMatch "^[0-9]+.[0-9]+.[0-9]+" $effectiveSemver -}}
-  {{- regexFind "^[0-9]+.[0-9]+.[0-9]+" $effectiveSemver -}}
+  {{- if regexMatch "^[0-9]+.[0-9]+(\\.[0-9]+)?" $effectiveSemver -}}
+  {{- regexFind "^[0-9]+.[0-9]+(\\.[0-9]+)?" $effectiveSemver -}}
   {{- else -}}
   {{- $effectiveSemver -}}
   {{- end -}}
 {{- else -}}
   {{- $tag := (trimSuffix "-redhat" .Values.image.tag) -}}
-  {{- if regexMatch "^[0-9]+.[0-9]+.[0-9]+" $tag -}}
-  {{- regexFind "^[0-9]+.[0-9]+.[0-9]+" $tag -}}
+  {{- if regexMatch "^[0-9]+.[0-9]+(\\.[0-9]+)?" $tag -}}
+  {{- regexFind "^[0-9]+.[0-9]+(\\.[0-9]+)?" $tag -}}
   {{- else -}}
   {{- .Chart.AppVersion -}}
   {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR fixes the regex that checks the `.Values.image.effectiveSemver` or `.Values.image.tag`.

Up until now if the provided value had e.g. only 2 segments like `1.4`, the regex wouldn't match it and `"kong.effectiveVersion"`would return the `.Chart.AppVersion`.

This PR fixes it.

Current workaround is to specify the full semver in `.Values.image.effectiveSemver` or `.Values.image.tag`.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
