### PR TITLE
kgo: add 1.6 ClusterRole

### DIFF
--- a/charts/gateway-operator/CHANGELOG.md
+++ b/charts/gateway-operator/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.5
+
+### Added
+
+- Add `ClusterRole` for 1.6.
+  [#1295](https://github.com/Kong/charts/pull/1295)
+
 ## 0.5.4
 
 ### Added

--- a/charts/gateway-operator/Chart.yaml
+++ b/charts/gateway-operator/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: gateway-operator
 sources:
   - https://github.com/Kong/charts/tree/main/charts/gateway-operator
-version: 0.5.4
+version: 0.5.5
 appVersion: "1.5"
 annotations:
   artifacthub.io/prerelease: "false"

--- a/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/effective-version-1-6-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/effective-version-1-6-values.snap
@@ -7,7 +7,7 @@ metadata:
   name: controller-manager
   namespace: default
 ---
-# Source: gateway-operator/templates/cluster-role-1.5.yaml
+# Source: gateway-operator/templates/cluster-role-1.6.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -486,6 +486,8 @@ rules:
   resources:
   - clusterrolebindings
   - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - create
   - delete
@@ -494,15 +496,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
 ---
 # Source: gateway-operator/templates/rbac-resources.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -717,16 +710,6 @@ spec:
         app: chartsnap-gateway-operator
         version: "1.5"
     spec:
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: component
-                operator: NotIn
-                values:
-                - dummy
-            topologyKey: kubernetes.io/hostname
       containers:
       - name: manager
         env:
@@ -740,7 +723,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: "docker.io/kong/gateway-operator:1.5"
+        image: "docker.io/kong/nightly-gateway-operator-oss:20250409"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-args-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/extra-labels-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     a: "b"
@@ -711,7 +711,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         a: "b"

--- a/charts/gateway-operator/ci/__snapshots__/image-pull-secrest-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/image-pull-secrest-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/kgo-1-4-0-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/kgo-1-4-0-values.snap
@@ -696,7 +696,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -718,7 +718,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/kube-rbac-proxy-removed-in-1-5-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/kube-rbac-proxy-removed-in-1-5-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/gateway-operator/ci/__snapshots__/tolerations-values.snap
@@ -688,7 +688,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: gateway-operator
-    helm.sh/chart: gateway-operator-0.5.4
+    helm.sh/chart: gateway-operator-0.5.5
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/version: "1.5"
     app.kubernetes.io/component: kgo
@@ -710,7 +710,7 @@ spec:
       labels:
         control-plane: controller-manager
         app.kubernetes.io/name: gateway-operator
-        helm.sh/chart: gateway-operator-0.5.4
+        helm.sh/chart: gateway-operator-0.5.5
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/version: "1.5"
         app.kubernetes.io/component: kgo

--- a/charts/gateway-operator/ci/effective-version-1-6-values.yaml
+++ b/charts/gateway-operator/ci/effective-version-1-6-values.yaml
@@ -1,0 +1,18 @@
+image:
+  repository: docker.io/kong/nightly-gateway-operator-oss
+  tag: "20250409"
+  effectiveSemver: "1.6.0"
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8081
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+env:
+  anonymous_reports: "false"

--- a/charts/gateway-operator/templates/cluster-role-1.6.yaml
+++ b/charts/gateway-operator/templates/cluster-role-1.6.yaml
@@ -1,0 +1,490 @@
+{{- if (semverCompare "1.6.x" (include "kong.effectiveVersion" .)) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "kong.fullname" . }}-manager-role
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - serviceaccounts
+    - services
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - secrets/finalizers
+    verbs:
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - services/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - admissionregistration.k8s.io
+    resources:
+    - validatingwebhookconfigurations
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - autoscaling
+    resources:
+    - horizontalpodautoscalers
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - watch
+  - apiGroups:
+    - cert-manager.io
+    resources:
+    - certificates
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - configuration.konghq.com
+    resources:
+    - ingressclassparameterses
+    - kongclusterplugins
+    - kongcustomentities
+    - kongingresses
+    - konglicenses
+    - kongupstreampolicies
+    - tcpingresses
+    - udpingresses
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - configuration.konghq.com
+    resources:
+    - kongcacertificates
+    - kongcertificates
+    - kongconsumergroups
+    - kongconsumers
+    - kongdataplaneclientcertificates
+    - kongkeys
+    - kongkeysets
+    - kongservices
+    - kongsnis
+    - kongtargets
+    - kongupstreams
+    - kongvaults
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - configuration.konghq.com
+    resources:
+    - kongcacertificates/finalizers
+    - kongcacertificates/status
+    - kongcertificates/finalizers
+    - kongcertificates/status
+    - kongconsumergroups/finalizers
+    - kongconsumers/finalizers
+    - kongcredentialacls/finalizers
+    - kongcredentialacls/status
+    - kongcredentialapikeys/finalizers
+    - kongcredentialapikeys/status
+    - kongcredentialbasicauths/finalizers
+    - kongcredentialbasicauths/status
+    - kongcredentialhmacs/finalizers
+    - kongcredentialhmacs/status
+    - kongcredentialjwts/finalizers
+    - kongcredentialjwts/status
+    - kongdataplaneclientcertificates/finalizers
+    - kongdataplaneclientcertificates/status
+    - kongkeys/finalizers
+    - kongkeys/status
+    - kongkeysets/finalizers
+    - kongkeysets/status
+    - kongpluginbindings/status
+    - kongroutes/finalizers
+    - kongroutes/status
+    - kongservices/finalizers
+    - kongservices/status
+    - kongsnis/finalizers
+    - kongsnis/status
+    - kongtargets/finalizers
+    - kongtargets/status
+    - kongupstreams/finalizers
+    - kongupstreams/status
+    - kongvaults/finalizers
+    verbs:
+    - patch
+    - update
+  - apiGroups:
+    - configuration.konghq.com
+    resources:
+    - kongclusterplugins/status
+    - kongconsumergroups/status
+    - kongconsumers/status
+    - kongcustomentities/status
+    - kongingresses/status
+    - konglicenses/status
+    - kongplugins/status
+    - kongupstreampolicies/status
+    - kongvaults/status
+    - tcpingresses/status
+    - udpingresses/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - configuration.konghq.com
+    resources:
+    - kongcredentialacls
+    - kongcredentialapikeys
+    - kongcredentialbasicauths
+    - kongcredentialhmacs
+    - kongcredentialjwts
+    - kongpluginbindings
+    - kongplugins
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - configuration.konghq.com
+    resources:
+    - kongroutes
+    verbs:
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - gateway-operator.konghq.com
+    resources:
+    - aigateways
+    - controlplanes
+    - dataplanes
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - gateway-operator.konghq.com
+    resources:
+    - aigateways/finalizers
+    - controlplanes/finalizers
+    - dataplanes/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - gateway-operator.konghq.com
+    resources:
+    - aigateways/status
+    - controlplanes/status
+    - dataplanes/status
+    - kongplugininstallations/status
+    - konnectextensions/finalizers
+    - konnectextensions/status
+    verbs:
+    - patch
+    - update
+  - apiGroups:
+    - gateway-operator.konghq.com
+    resources:
+    - controlplane
+    - dataplanemetricsextensions
+    - gatewayconfigurations
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - gateway-operator.konghq.com
+    resources:
+    - kongplugininstallations
+    - konnectextensions
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - gateway.networking.k8s.io
+    resources:
+    - backendtlspolicies
+    - gatewayclasses
+    - grpcroutes
+    - referencegrants
+    - tcproutes
+    - tlsroutes
+    - udproutes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - gateway.networking.k8s.io
+    resources:
+    - backendtlspolicies/status
+    verbs:
+    - patch
+    - update
+  - apiGroups:
+    - gateway.networking.k8s.io
+    resources:
+    - gatewayclasses/status
+    - gateways/status
+    - grpcroutes/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - gateway.networking.k8s.io
+    resources:
+    - gateways
+    - httproutes
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - gateway.networking.k8s.io
+    resources:
+    - gateways/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - gateway.networking.k8s.io
+    resources:
+    - httproutes/status
+    - tcproutes/status
+    - tlsroutes/status
+    - udproutes/status
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - gateway.networking.k8s.io
+    resources:
+    - referencegrants/status
+    verbs:
+    - get
+  - apiGroups:
+    - incubator.ingress-controller.konghq.com
+    resources:
+    - kongservicefacades
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - incubator.ingress-controller.konghq.com
+    resources:
+    - kongservicefacades/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - konnect.konghq.com
+    resources:
+    - konnectapiauthconfigurations
+    - konnectcloudgatewaydataplanegroupconfigurations
+    - konnectcloudgatewaynetworks
+    - konnectextensions
+    - konnectgatewaycontrolplanes
+    verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - konnect.konghq.com
+    resources:
+    - konnectapiauthconfigurations/finalizers
+    - konnectapiauthconfigurations/status
+    - konnectcloudgatewaydataplanegroupconfigurations/finalizers
+    - konnectcloudgatewaydataplanegroupconfigurations/status
+    - konnectcloudgatewaynetworks/finalizers
+    - konnectcloudgatewaynetworks/status
+    - konnectextensions/finalizers
+    - konnectextensions/status
+    - konnectgatewaycontrolplanes/finalizers
+    - konnectgatewaycontrolplanes/status
+    verbs:
+    - patch
+    - update
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingressclasses
+    - ingresses
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingresses/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - networkpolicies
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - policy
+    resources:
+    - poddisruptionbudgets
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - clusterrolebindings
+    - clusterroles
+    - rolebindings
+    - roles
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+{{- end }}


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `ClusterRole` for 1.6.

Release KGO chart 0.5.5 so that it can be used with nightlies and `image.effectiveSemver` set to `1.6`

#### Which issue this PR fixes

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
