### PR TITLE
kong: generate Gateway API RBAC policy rules by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,12 +89,16 @@ endef
 export GOLDEN_TEST_FAILURE_MSG
 
 .PHONY: _chartsnap
-.PHONY: _chartsnap
 _chartsnap: _chartsnap.deps
-	helm chartsnap -c ./charts/$(CHART) -f ./charts/$(CHART)/ci/ $(CHARTSNAP_ARGS) \
+	helm chartsnap \
+		-c ./charts/$(CHART) \
+		-f ./charts/$(CHART)/ci/ \
+		$(CHARTSNAP_ARGS) \
 		-- \
 		--api-versions cert-manager.io/v1 \
 		--api-versions gateway.networking.k8s.io/v1 \
+		--api-versions gateway.networking.k8s.io/v1beta1 \
+		--api-versions gateway.networking.k8s.io/v1alpha2 \
 		--api-versions admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy \
 		--api-versions admissionregistration.k8s.io/v1/ValidatingAdmissionPolicyBinding
 

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.50.0
 
 ### Changes
 
@@ -9,6 +9,10 @@
   `ingressController.konnect.license.enabled` is set to `true` that enables
   the synchronization of license with Konnect.
   [#1331](https://github.com/Kong/charts/pull/1331)
+* Generate Gateway API RBAC policy rules by default.
+  Users can disable this by setting `.ingressController.rbac.gatewayAPI.enabled`
+  to `false`.
+  [#1332](https://github.com/Kong/charts/pull/1332)
 
 ## 2.49.0
 

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.49.0
+version: 2.50.0
 appVersion: "3.9"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-admin
   namespace: default
 spec:
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -119,7 +119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -144,7 +144,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1039,7 +1039,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/certificate-values.snap
+++ b/charts/kong/ci/__snapshots__/certificate-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1099,7 +1099,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1119,7 +1119,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1139,7 +1139,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1158,7 +1158,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
+++ b/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1101,7 +1101,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1121,7 +1121,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1141,7 +1141,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1160,7 +1160,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -494,7 +494,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -558,7 +558,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -593,7 +593,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -603,7 +603,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -622,7 +622,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -632,7 +632,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -660,7 +660,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -688,7 +688,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -712,7 +712,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1022,7 +1022,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -523,7 +523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -609,7 +609,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -656,7 +656,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -696,7 +696,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -725,7 +725,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -750,7 +750,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1059,7 +1059,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
+++ b/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -495,7 +495,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -516,7 +516,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -586,7 +586,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -607,7 +607,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -619,7 +619,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -633,7 +633,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -649,7 +649,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -663,7 +663,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -691,7 +691,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -720,7 +720,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -741,7 +741,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1051,7 +1051,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.5"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.5"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -654,7 +654,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -692,7 +692,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -744,7 +744,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -654,7 +654,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -692,7 +692,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -744,7 +744,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1069,7 +1069,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -516,7 +516,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -619,7 +619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -634,7 +634,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -644,7 +644,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -663,7 +663,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -673,7 +673,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -701,7 +701,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -729,7 +729,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -753,7 +753,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1063,7 +1063,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1122,7 +1122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -478,7 +478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -542,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -562,7 +562,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -577,7 +577,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -587,7 +587,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -606,7 +606,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -616,7 +616,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -644,7 +644,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -672,7 +672,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -696,7 +696,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1006,7 +1006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1063,7 +1063,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1065,7 +1065,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/kong-ingress-with-konnect-license.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-with-konnect-license.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -60,7 +60,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -525,7 +525,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -546,7 +546,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -616,7 +616,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -637,7 +637,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -649,7 +649,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -663,7 +663,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -679,7 +679,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -693,7 +693,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -714,7 +714,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -860,7 +860,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/pdb-always-allow.snap
+++ b/charts/kong/ci/__snapshots__/pdb-always-allow.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kong
-      helm.sh/chart: kong-2.49.0
+      helm.sh/chart: kong-2.50.0
       app.kubernetes.io/instance: "chartsnap"
       app.kubernetes.io/managed-by: "Helm"
       app.kubernetes.io/version: "3.9"
@@ -32,7 +32,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -45,7 +45,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -62,7 +62,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -77,7 +77,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -527,7 +527,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -548,7 +548,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -618,7 +618,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -639,7 +639,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -651,7 +651,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -665,7 +665,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -681,7 +681,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -695,7 +695,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -723,7 +723,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -752,7 +752,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -773,7 +773,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1087,7 +1087,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/pdb-default.snap
+++ b/charts/kong/ci/__snapshots__/pdb-default.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kong
-      helm.sh/chart: kong-2.49.0
+      helm.sh/chart: kong-2.50.0
       app.kubernetes.io/instance: "chartsnap"
       app.kubernetes.io/managed-by: "Helm"
       app.kubernetes.io/version: "3.9"
@@ -32,7 +32,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -45,7 +45,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -62,7 +62,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -77,7 +77,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -527,7 +527,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -548,7 +548,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -618,7 +618,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -639,7 +639,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -651,7 +651,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -665,7 +665,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -681,7 +681,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -695,7 +695,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -723,7 +723,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -752,7 +752,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -773,7 +773,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1087,7 +1087,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -713,7 +713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -737,7 +737,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1047,7 +1047,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: my-kong-sa
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
+++ b/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1063,7 +1063,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.4"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.4"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
         environment: test
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -1108,7 +1108,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1132,7 +1132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -78,7 +78,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -90,7 +90,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -188,7 +188,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -207,7 +207,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -271,7 +271,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default
   namespace: default
 rules:
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -654,7 +654,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default
   namespace: default
 roleRef:
@@ -724,7 +724,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -739,7 +739,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -749,7 +749,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -768,7 +768,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -778,7 +778,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -842,7 +842,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -871,7 +871,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1501,7 +1501,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1517,7 +1517,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1753,7 +1753,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1777,7 +1777,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:
@@ -1914,7 +1914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1930,7 +1930,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -2172,7 +2172,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -2188,7 +2188,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -121,7 +121,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -129,7 +129,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -371,7 +371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -71,7 +71,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -83,7 +83,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -550,7 +550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -614,7 +614,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -684,7 +684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -699,7 +699,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -709,7 +709,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -728,7 +728,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
 ---
 apiVersion: v1
 kind: Service
@@ -738,7 +738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -766,7 +766,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -794,7 +794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -823,7 +823,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1424,7 +1424,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1440,7 +1440,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1661,7 +1661,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1685,7 +1685,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:
@@ -1821,7 +1821,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1837,7 +1837,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -2064,7 +2064,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.49.0
+    helm.sh/chart: kong-2.50.0
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -2080,7 +2080,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.49.0
+        helm.sh/chart: kong-2.50.0
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1330,7 +1330,7 @@ resource roles into their separate templates.
   - get
   - list
   - watch
-{{- if or (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha3") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
+{{- if or (.Values.ingressController.rbac.gatewayAPI.enabled) (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha3") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -1579,7 +1579,7 @@ resource roles into their separate templates.
   - get
   - patch
   - update
-{{- if or (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
+{{- if or (.Values.ingressController.rbac.gatewayAPI.enabled) (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
@@ -1798,7 +1798,7 @@ Kubernetes Cluster-scoped resources it uses to build Kong configuration.
   - list
   - watch
 {{- end }}
-{{- if or (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
+{{- if or (.Values.ingressController.rbac.gatewayAPI.enabled) (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1alpha2") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1beta1") (.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1")}}
 - apiGroups:
   - gateway.networking.k8s.io
   resources:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -654,6 +654,10 @@ ingressController:
     # - `KongClusterPlugin`
     # - `KongVault`, `KongLicense` (KIC 3.1 and above)
     enableClusterRoles: true
+    gatewayAPI:
+      # Specifies whether RBAC policy rules for Gateway API resources should
+      # be generated regardless of the presence of Gateway API CRDs in the cluster.
+      enabled: true
 
   # general properties
   livenessProbe:


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR makes it so that `kong` chart will generate Gateway API RBAC policy rules by default.

This can be disabled by setting `.ingressController.rbac.gatewayAPI.enabled` to `false`.

Release `kong` `2.50.0`.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
