### PR TITLE
chore(kong): set postgres default image repository, name and tag to `''`

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
+## 3.0.0
+
+### Changes
+
+* Default Postgres repository, image name and tag are set to `""`.
+  This requires users that use the db backed installations to specify these.
+  The default Bitnami Postgres image is not available anymore, for more details
+  please see: <https://github.com/bitnami/containers/issues/83267>.
+  [#1373](https://github.com/Kong/charts/pull/1373)
+
 ## 2.52.0
+
+### Changes
 
 * Added `migrations.waitContainer.securityContext` to allow setting a security context on the migrations wait-for-postgres init container.
 * Added `certificates.manager` configuration to enable separate cert-manager certificate generation for Kong Manager (admin GUI).

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 2.52.0
+version: 3.0.0
 appVersion: "3.9"
 dependencies:
   - name: postgresql

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -178,6 +178,10 @@ after updating externally supplied ConfigMap content.
 
 #### Using the Postgres sub-chart
 
+> **NOTE**: Due to Bitnami images not being maintained anymore, starting with
+> Kong chart 3.0 users have to specify the Postgres image themselves via
+> `postgresql.image.registry`, `postgresql.image.repository` and `postgresql.image.tag`.
+
 The chart can optionally spawn a Postgres instance using [Bitnami's Postgres
 chart](https://github.com/bitnami/charts/blob/master/bitnami/postgresql/README.md)
 as a sub-chart. Set `postgresql.enabled=true` to enable the sub-chart. Enabling
@@ -187,6 +191,8 @@ The Postgres sub-chart is best used to quickly provision temporary environments
 without installing and configuring your database separately. For longer-lived
 environments, we recommend you manage your database outside the Kong Helm
 release.
+You can find a guide for using Cloud Native PostgreSQL with Kong
+[on our documentation site](https://developer.konghq.com/gateway/install/kubernetes/on-prem/).
 
 ##### Postgres sub-chart considerations for OpenShift
 

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-admin
   namespace: default
 spec:
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -119,7 +119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -144,7 +144,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1039,7 +1039,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/certificate-values.snap
+++ b/charts/kong/ci/__snapshots__/certificate-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1099,7 +1099,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1119,7 +1119,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1139,7 +1139,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1158,7 +1158,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
+++ b/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1101,7 +1101,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1121,7 +1121,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1141,7 +1141,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1160,7 +1160,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -494,7 +494,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -558,7 +558,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -593,7 +593,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -603,7 +603,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -622,7 +622,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -632,7 +632,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -660,7 +660,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -688,7 +688,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -712,7 +712,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1022,7 +1022,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -523,7 +523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -609,7 +609,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -656,7 +656,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -696,7 +696,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -725,7 +725,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -750,7 +750,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1059,7 +1059,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
+++ b/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -495,7 +495,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -516,7 +516,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -586,7 +586,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -607,7 +607,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -619,7 +619,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -633,7 +633,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -649,7 +649,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -663,7 +663,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -691,7 +691,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -720,7 +720,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -741,7 +741,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1051,7 +1051,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/enterprise-manager-cert-values.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-manager-cert-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -695,7 +695,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -719,7 +719,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -747,7 +747,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -775,7 +775,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -804,7 +804,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -825,7 +825,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.10"
@@ -1253,7 +1253,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -1275,7 +1275,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -1295,7 +1295,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -1317,7 +1317,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -1337,7 +1337,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -1356,7 +1356,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.5"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.5"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -654,7 +654,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -692,7 +692,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -744,7 +744,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -654,7 +654,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -692,7 +692,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -744,7 +744,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1069,7 +1069,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -516,7 +516,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -619,7 +619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -634,7 +634,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -644,7 +644,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -663,7 +663,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -673,7 +673,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -701,7 +701,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -729,7 +729,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -753,7 +753,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1063,7 +1063,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1122,7 +1122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -478,7 +478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -542,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -562,7 +562,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -577,7 +577,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -587,7 +587,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -606,7 +606,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -616,7 +616,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -644,7 +644,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -672,7 +672,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -696,7 +696,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1006,7 +1006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1063,7 +1063,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1065,7 +1065,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/kong-ingress-with-konnect-license.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-with-konnect-license.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -60,7 +60,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -525,7 +525,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -546,7 +546,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -616,7 +616,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -637,7 +637,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -649,7 +649,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -663,7 +663,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -679,7 +679,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -693,7 +693,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -714,7 +714,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -860,7 +860,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/pdb-always-allow.snap
+++ b/charts/kong/ci/__snapshots__/pdb-always-allow.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kong
-      helm.sh/chart: kong-2.52.0
+      helm.sh/chart: kong-3.0.0
       app.kubernetes.io/instance: "chartsnap"
       app.kubernetes.io/managed-by: "Helm"
       app.kubernetes.io/version: "3.9"
@@ -32,7 +32,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -45,7 +45,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -62,7 +62,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -77,7 +77,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -527,7 +527,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -548,7 +548,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -618,7 +618,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -639,7 +639,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -651,7 +651,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -665,7 +665,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -681,7 +681,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -695,7 +695,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -723,7 +723,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -752,7 +752,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -773,7 +773,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1087,7 +1087,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/pdb-default.snap
+++ b/charts/kong/ci/__snapshots__/pdb-default.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kong
-      helm.sh/chart: kong-2.52.0
+      helm.sh/chart: kong-3.0.0
       app.kubernetes.io/instance: "chartsnap"
       app.kubernetes.io/managed-by: "Helm"
       app.kubernetes.io/version: "3.9"
@@ -32,7 +32,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -45,7 +45,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -62,7 +62,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -77,7 +77,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -527,7 +527,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -548,7 +548,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -618,7 +618,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -639,7 +639,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -651,7 +651,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -665,7 +665,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -681,7 +681,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -695,7 +695,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -723,7 +723,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -752,7 +752,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -773,7 +773,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1087,7 +1087,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -713,7 +713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -737,7 +737,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1047,7 +1047,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: my-kong-sa
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
+++ b/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1063,7 +1063,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.4"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.4"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
         environment: test
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -1108,7 +1108,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1132,7 +1132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -155,7 +155,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -174,7 +174,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -238,7 +238,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default
   namespace: default
 rules:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-kong-test
   namespace: kong-test
 rules:
@@ -964,7 +964,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -984,7 +984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default
   namespace: default
 roleRef:
@@ -1004,7 +1004,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-kong-test
   namespace: kong-test
 roleRef:
@@ -1024,7 +1024,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -1039,7 +1039,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -1049,7 +1049,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -1068,7 +1068,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -1078,7 +1078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1142,7 +1142,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -1171,7 +1171,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1521,7 +1521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1545,7 +1545,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -121,7 +121,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -129,7 +129,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -371,7 +371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -6,9 +6,24 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
+---
+apiVersion: v1
+data:
+  password: a29uZw==
+  postgres-password: '###DYNAMIC_FIELD###'
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+type: Opaque
 ---
 apiVersion: v1
 data:
@@ -21,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,10 +52,28 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
+---
+apiVersion: v1
+data:
+  wait.sh: |
+    until timeout 2 bash -c "9<>/dev/tcp/${KONG_PG_HOST}/${KONG_PG_PORT}"
+      do echo "waiting for db - trying ${KONG_PG_HOST}:${KONG_PG_PORT}"
+      sleep 2
+    done
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: kong-3.0.0
+  name: chartsnap-kong-bash-wait-for-postgres
+  namespace: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -50,7 +83,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +531,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +614,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -597,11 +630,61 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  name: chartsnap-postgresql-hl
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: postgresql
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: null
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+spec:
+  ports:
+    - name: tcp-postgresql
+      nodePort: null
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/name: postgresql
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
     app.kubernetes.io/instance: chartsnap
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +699,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +709,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +728,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +766,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -740,7 +823,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-2.52.0
+        helm.sh/chart: kong-3.0.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -845,13 +928,22 @@ spec:
             - name: KONG_CLUSTER_LISTEN
               value: "off"
             - name: KONG_DATABASE
-              value: "off"
+              value: postgres
             - name: KONG_KIC
               value: "on"
             - name: KONG_LUA_PACKAGE_PATH
               value: /opt/?.lua;/opt/?/init.lua;;
             - name: KONG_NGINX_WORKER_PROCESSES
               value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
             - name: KONG_PORTAL_API_ACCESS_LOG
               value: /dev/stdout
             - name: KONG_PORTAL_API_ERROR_LOG
@@ -966,13 +1058,22 @@ spec:
             - name: KONG_CLUSTER_LISTEN
               value: "off"
             - name: KONG_DATABASE
-              value: "off"
+              value: postgres
             - name: KONG_KIC
               value: "on"
             - name: KONG_LUA_PACKAGE_PATH
               value: /opt/?.lua;/opt/?/init.lua;;
             - name: KONG_NGINX_WORKER_PROCESSES
               value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
             - name: KONG_PORTAL_API_ACCESS_LOG
               value: /dev/stdout
             - name: KONG_PORTAL_API_ERROR_LOG
@@ -1021,6 +1122,96 @@ spec:
               name: chartsnap-kong-prefix-dir
             - mountPath: /tmp
               name: chartsnap-kong-tmp
+        - args:
+            - /bin/bash
+            - -c
+            - export KONG_NGINX_DAEMON=on KONG_PREFIX=`mktemp -d` KONG_KEYRING_ENABLED=off; until kong start; do echo 'waiting for db'; sleep 1; done; kong stop
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+          image: kong:3.9
+          imagePullPolicy: IfNotPresent
+          name: wait-for-db
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -1050,6 +1241,413 @@ spec:
                         apiVersion: v1
                         fieldPath: metadata.namespace
                       path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    ignore-check.kube-linter.io/no-read-only-root-fs: writable fs is required
+  labels:
+    app.kubernetes.io/component: primary
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-11.9.13
+  name: chartsnap-postgresql
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: primary
+      app.kubernetes.io/instance: chartsnap
+      app.kubernetes.io/name: postgresql
+  serviceName: chartsnap-postgresql-hl
+  template:
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: primary
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+        helm.sh/chart: postgresql-11.9.13
+      name: chartsnap-postgresql
+    spec:
+      affinity:
+        nodeAffinity: null
+        podAffinity: null
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/component: primary
+                    app.kubernetes.io/instance: chartsnap
+                    app.kubernetes.io/name: postgresql
+                namespaces:
+                  - default
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+      containers:
+        - env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: /bitnami/postgresql
+            - name: PGDATA
+              value: /bitnami/postgresql/data
+            - name: POSTGRES_USER
+              value: kong
+            - name: POSTGRES_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: postgres-password
+                  name: chartsnap-postgresql
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: POSTGRES_DB
+              value: kong
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: error
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: pgaudit
+          image: docker.io/bitnamilegacy/postgresql:13.11.0-debian-11-r20
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "kong" -d "dbname=kong" -h 127.0.0.1 -p 5432
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: postgresql
+          ports:
+            - containerPort: 5432
+              name: tcp-postgresql
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "kong" -d "dbname=kong" -h 127.0.0.1 -p 5432
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+          resources:
+            limits: {}
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+            - mountPath: /bitnami/postgresql
+              name: data
+      hostIPC: false
+      hostNetwork: false
+      initContainers: null
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: default
+      volumes:
+        - emptyDir:
+            medium: Memory
+          name: dshm
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 8Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    app.kubernetes.io/component: init-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: kong-3.0.0
+  name: chartsnap-kong-init-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
+    metadata:
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: init-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.9"
+        helm.sh/chart: kong-3.0.0
+      name: kong-init-migrations
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - bootstrap
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.9
+          imagePullPolicy: IfNotPresent
+          name: kong-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.9
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
         - name: webhook-cert
           secret:
             secretName: chartsnap-kong-validation-webhook-keypair
@@ -1062,7 +1660,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1086,7 +1684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-2.52.0
+    helm.sh/chart: kong-3.0.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:
@@ -1209,3 +1807,487 @@ webhooks:
           - gateways
           - httproutes
     sideEffects: None
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/component: post-upgrade-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: kong-3.0.0
+  name: chartsnap-kong-post-upgrade-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
+    metadata:
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: post-upgrade-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.9"
+        helm.sh/chart: kong-3.0.0
+      name: kong-post-upgrade-migrations
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - finish
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.9
+          imagePullPolicy: IfNotPresent
+          name: kong-post-upgrade-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.9
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    app.kubernetes.io/component: pre-upgrade-migrations
+    app.kubernetes.io/instance: chartsnap
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/version: "3.9"
+    helm.sh/chart: kong-3.0.0
+  name: chartsnap-kong-pre-upgrade-migrations
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
+    metadata:
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        sidecar.istio.io/inject: "false"
+      labels:
+        app.kubernetes.io/component: pre-upgrade-migrations
+        app.kubernetes.io/instance: chartsnap
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: kong
+        app.kubernetes.io/version: "3.9"
+        helm.sh/chart: kong-3.0.0
+      name: kong-pre-upgrade-migrations
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - args:
+            - kong
+            - migrations
+            - up
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.9
+          imagePullPolicy: IfNotPresent
+          name: kong-upgrade-migrations
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /kong_prefix/
+              name: chartsnap-kong-prefix-dir
+            - mountPath: /tmp
+              name: chartsnap-kong-tmp
+      initContainers:
+        - command:
+            - bash
+            - /wait_postgres/wait.sh
+          env:
+            - name: CLIENT_ID
+              value: exampleId
+            - name: KONG_ADMIN_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_API_URI
+              value: http://
+            - name: KONG_ADMIN_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_GUI_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_ADMIN_GUI_API_URL
+              value: http://
+            - name: KONG_ADMIN_GUI_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ADMIN_LISTEN
+              value: 127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl
+            - name: KONG_ANONYMOUS_REPORTS
+              value: "off"
+            - name: KONG_CLUSTER_LISTEN
+              value: "off"
+            - name: KONG_DATABASE
+              value: postgres
+            - name: KONG_KIC
+              value: "on"
+            - name: KONG_LUA_PACKAGE_PATH
+              value: /opt/?.lua;/opt/?/init.lua;;
+            - name: KONG_NGINX_WORKER_PROCESSES
+              value: "2"
+            - name: KONG_PG_HOST
+              value: chartsnap-postgresql
+            - name: KONG_PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: chartsnap-postgresql
+            - name: KONG_PG_PORT
+              value: "5432"
+            - name: KONG_PORTAL_API_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PORTAL_API_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PORT_MAPS
+              value: 80:8000, 443:8443
+            - name: KONG_PREFIX
+              value: /kong_prefix/
+            - name: KONG_PROXY_ACCESS_LOG
+              value: /dev/stdout
+            - name: KONG_PROXY_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_PROXY_LISTEN
+              value: 0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl
+            - name: KONG_PROXY_STREAM_ACCESS_LOG
+              value: /dev/stdout basic
+            - name: KONG_PROXY_STREAM_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_ROUTER_FLAVOR
+              value: traditional
+            - name: KONG_STATUS_ACCESS_LOG
+              value: "off"
+            - name: KONG_STATUS_ERROR_LOG
+              value: /dev/stderr
+            - name: KONG_STATUS_LISTEN
+              value: 0.0.0.0:8100, [::]:8100
+            - name: KONG_STREAM_LISTEN
+              value: "off"
+            - name: KONG_NGINX_DAEMON
+              value: "off"
+          image: kong:3.9
+          imagePullPolicy: IfNotPresent
+          name: wait-for-postgres
+          resources: {}
+          volumeMounts:
+            - mountPath: /wait_postgres
+              name: chartsnap-kong-bash-wait-for-postgres
+      restartPolicy: OnFailure
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: chartsnap-kong
+      volumes:
+        - emptyDir:
+            sizeLimit: 256Mi
+          name: chartsnap-kong-prefix-dir
+        - emptyDir:
+            sizeLimit: 1Gi
+          name: chartsnap-kong-tmp
+        - name: chartsnap-kong-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3607
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+        - configMap:
+            defaultMode: 493
+            name: chartsnap-kong-bash-wait-for-postgres
+          name: chartsnap-kong-bash-wait-for-postgres
+        - name: webhook-cert
+          secret:
+            secretName: chartsnap-kong-validation-webhook-keypair

--- a/charts/kong/ci/test5-values.yaml
+++ b/charts/kong/ci/test5-values.yaml
@@ -1,5 +1,5 @@
 # This tests the following unrelated aspects of Ingress Controller
-# - ingressController deploys
+# - ingressController deploys with a database
 # - TODO remove this test when https://github.com/Kong/charts/issues/295 is solved
 #   and its associated wait-for-db workaround is removed.
 #   This test is similar to test2-values.yaml, but lacks a stream listen.
@@ -11,10 +11,20 @@ ingressController:
   env:
     anonymous_reports: "false"
 postgresql:
-  enabled: false
+  image:
+    registry: "docker.io"
+    repository: "bitnamilegacy/postgresql"
+    tag: "13.11.0-debian-11-r20"
+  enabled: true
+  auth:
+    username: kong
+    password: kong
+  service:
+    ports:
+      postgresql: 5432
 env:
   anonymous_reports: "off"
-  database: "off"
+  database: "postgres"
 # Added example for customEnv
 customEnv:
   client_id: "exampleId"

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -747,8 +747,7 @@ ingressController:
 # Postgres sub-chart parameters
 # -----------------------------------------------------------------------------
 
-# Kong can run without a database or use either Postgres or Cassandra
-# as a backend datatstore for it's configuration.
+# Kong can run without a database or use Postgres as a backend datatstore for it's configuration.
 # By default, this chart installs Kong without a database.
 
 # If you would like to use a database, there are two options:
@@ -772,10 +771,14 @@ postgresql:
   auth:
     username: kong
     database: kong
+  # Default bitnami/postgres image is not available anymore, see:
+  # https://github.com/bitnami/containers/issues/83267 for details.
+  # If you want to use a DB backed Kong installation with Postgres,
+  # provide your own image here.
   image:
-    # use postgres < 14 until is https://github.com/Kong/kong/issues/8533 resolved and released
-    # enterprise (kong-gateway) supports postgres 14
-    tag: 13.11.0-debian-11-r20
+    registry: ""
+    repository: ""
+    tag: ""
   service:
     ports:
       postgresql: "5432"


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR removes the defaults for postgres image, tag and repo which is a consequence of https://github.com/bitnami/containers/issues/83267.

From now on users will have to provide these value by themselves or use an externally managed postgres instances (as described in the guide https://developer.konghq.com/gateway/install/kubernetes/on-prem/#postgres-database).

Release `kong` chart 3.0.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
