### PR TITLE
ci(release): use chart-releaser changed_charts output instead of manual version diff

### DIFF
--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -47,34 +47,14 @@ jobs:
           helm repo add kong https://charts.konghq.com
 
       - name: Run chart-releaser
+        id: chart_releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_SKIP_EXISTING: true
 
-      # Publish kong-operator chart to DockerHub (OCI) when its version changes
-      - name: Determine if kong-operator chart version changed
-        id: kong_operator_oci
-        shell: bash
-        run: |
-          set -euo pipefail
-          NEW_VERSION=$(grep -E '^version:' "charts/kong-operator/Chart.yaml" | awk '{print $2}')
-          SHA="${{ github.event.before }}"
-          if git show "$SHA:charts/kong-operator/Chart.yaml" >/dev/null 2>&1; then
-            OLD_VERSION=$(git show "$SHA:charts/kong-operator/Chart.yaml" | grep -E '^version:' | awk '{print $2}')
-          else
-            OLD_VERSION=""
-          fi
-          echo "new=${NEW_VERSION} old=${OLD_VERSION}"
-          if [ -n "${NEW_VERSION}" ] && [ "${NEW_VERSION}" != "${OLD_VERSION}" ]; then
-            echo "publish_oci=true" >> "$GITHUB_OUTPUT"
-            echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish_oci=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Login to DockerHub (OCI)
-        if: ${{ steps.kong_operator_oci.outputs.publish_oci == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ contains(steps.chart_releaser.outputs.changed_charts, 'kong-operator') && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         env:
           DOCKERHUB_USERNAME: ${{ env.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ env.DOCKERHUB_TOKEN }}
@@ -82,7 +62,7 @@ jobs:
           helm registry login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_TOKEN" registry-1.docker.io
 
       - name: Prepare and push kong-operator-chart to DockerHub (OCI)
-        if: ${{ steps.kong_operator_oci.outputs.publish_oci == 'true' && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
+        if: ${{ contains(steps.chart_releaser.outputs.changed_charts, 'kong-operator') && env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -94,4 +74,5 @@ jobs:
           grep -E '^name:' "${WORKDIR}/kong-operator-chart/Chart.yaml"
           # Package and push to kong/kong-operator-chart
           helm package "${WORKDIR}/kong-operator-chart"
-          helm push "kong-operator-chart-${{ steps.kong_operator_oci.outputs.version }}.tgz" oci://registry-1.docker.io/kong
+          VERSION=$(grep -E '^version:' charts/kong-operator/Chart.yaml | awk '{print $2}')
+          helm push "kong-operator-chart-${VERSION}.tgz" oci://registry-1.docker.io/kong


### PR DESCRIPTION

<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:


Replace the manual comparison step with the
changed_charts output already provided by helm/chart-releaser-action.

Thanks, @pmalek, for pointing out.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
