### PR TITLE
feat(kong): apply objectSelector to all admission webhooks

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.1.0
+
+### Changes
+
+* Applied `objectSelector` to all admission webhook configurations, not just
+  the `validations.kong.konghq.com` webhook. This ensures consistent filtering
+  across all webhook entries.
+  [#1497](https://github.com/Kong/charts/pull/1497)
+
 ## 3.0.2
 
 ### Added

--- a/charts/kong/Chart.yaml
+++ b/charts/kong/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kong
 sources:
   - https://github.com/Kong/charts/tree/main/charts/kong
-version: 3.0.2
+version: 3.1.0
 appVersion: "3.9"
 dependencies:
   - name: postgresql

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-admin
   namespace: default
 spec:
@@ -63,7 +63,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -119,7 +119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -144,7 +144,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -1060,6 +1060,16 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+        - key: infra
+          operator: In
+          values:
+            - cloud
+      matchLabels:
+        app.kubernetes.io/instance: kong-test
     rules:
       - apiGroups:
           - ""
@@ -1090,6 +1100,16 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
+        - key: infra
+          operator: In
+          values:
+            - cloud
+      matchLabels:
+        app.kubernetes.io/instance: kong-test
     rules:
       - apiGroups:
           - ""
@@ -1129,6 +1149,8 @@ webhooks:
           operator: In
           values:
             - cloud
+      matchLabels:
+        app.kubernetes.io/instance: kong-test
     rules:
       - apiGroups:
           - configuration.konghq.com

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1039,7 +1039,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/admission-webhook-filtersecrets-false.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-filtersecrets-false.snap
@@ -1,29 +1,5 @@
 # chartsnap: snapshot_version=v3
 ---
-# Source: kong/templates/pdb.yaml
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: chartsnap-kong
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  maxUnavailable: 50%
-  unhealthyPodEvictionPolicy: IfHealthyBudget
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: kong
-      helm.sh/chart: kong-3.0.2
-      app.kubernetes.io/instance: "chartsnap"
-      app.kubernetes.io/managed-by: "Helm"
-      app.kubernetes.io/version: "3.9"
-      app.kubernetes.io/component: app
----
 # Source: kong/templates/service-account.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -758,7 +734,7 @@ metadata:
     app.kubernetes.io/version: "3.9"
     app.kubernetes.io/component: app
 spec:
-  replicas: 2
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
@@ -814,8 +790,6 @@ spec:
           value: "/dev/stderr"
         - name: KONG_ADMIN_LISTEN
           value: "127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl"
-        - name: KONG_ANONYMOUS_REPORTS
-          value: "off"
         - name: KONG_CLUSTER_LISTEN
           value: "off"
         - name: KONG_DATABASE
@@ -896,8 +870,6 @@ spec:
               fieldPath: metadata.namespace
         - name: CONTROLLER_ADMISSION_WEBHOOK_LISTEN
           value: "0.0.0.0:8080"
-        - name: CONTROLLER_ANONYMOUS_REPORTS
-          value: "false"
         - name: CONTROLLER_ELECTION_ID
           value: "kong-ingress-controller-leader-kong"
         - name: CONTROLLER_INGRESS_CLASS
@@ -963,8 +935,6 @@ spec:
           value: "/dev/stderr"
         - name: KONG_ADMIN_LISTEN
           value: "127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl"
-        - name: KONG_ANONYMOUS_REPORTS
-          value: "off"
         - name: KONG_CLUSTER_LISTEN
           value: "off"
         - name: KONG_DATABASE
@@ -1033,8 +1003,8 @@ spec:
             path: /status/ready
             port: status
             scheme: HTTP
-          initialDelaySeconds: 1
-          periodSeconds: 1
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 5
         livenessProbe:
@@ -1103,6 +1073,8 @@ webhooks:
   matchPolicy: Equivalent
   name: secrets.credentials.validation.ingress-controller.konghq.com
   objectSelector:
+    matchLabels:
+      app.kubernetes.io/instance: kong-custom
     matchExpressions:
     - key: "konghq.com/credential"
       operator: "Exists"
@@ -1110,10 +1082,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
-    - key: owner
-      operator: NotIn
+    - key: environment
+      operator: In
       values:
-      - helm
+      - production
   rules:
   - apiGroups:
     - ""
@@ -1136,15 +1108,17 @@ webhooks:
   matchPolicy: Equivalent
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
+    matchLabels:
+      app.kubernetes.io/instance: kong-custom
     matchExpressions:
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
-    - key: owner
-      operator: NotIn
+    - key: environment
+      operator: In
       values:
-      - helm
+      - production
   rules:
   - apiGroups:
     - ""
@@ -1160,10 +1134,12 @@ webhooks:
   matchPolicy: Equivalent
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
+    - key: environment
+      operator: In
       values:
-      - helm
+      - production
+    matchLabels:
+      app.kubernetes.io/instance: kong-custom
   failurePolicy: Ignore
   sideEffects: None
   admissionReviewVersions: ["v1beta1"]

--- a/charts/kong/ci/__snapshots__/admission-webhook-filtersecrets-false.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-filtersecrets-false.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1057,7 +1057,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/certificate-values.snap
+++ b/charts/kong/ci/__snapshots__/certificate-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1091,6 +1091,66 @@ spec:
         secret:
           secretName: chartsnap-kong-validation-webhook-keypair
 ---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-admin
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-admin-cert
+  commonName: kong.example
+  dnsNames:
+  - "kong.example"
+  renewBefore: 168h0m0s
+  duration: 1848h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-proxy-cert
+  commonName: app.example
+  dnsNames:
+  - "app.example"
+  renewBefore: 168h0m0s
+  duration: 1848h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-cluster
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-cluster-cert
+  commonName: kong_clustering
+  dnsNames:
+  - "kong_clustering"
+  renewBefore: 168h0m0s
+  duration: 1848h0m0s
+---
 # Source: kong/templates/admission-webhook.yaml
 kind: ValidatingWebhookConfiguration
 apiVersion: admissionregistration.k8s.io/v1
@@ -1098,7 +1158,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1226,63 +1286,3 @@ webhooks:
     service:
       name: chartsnap-kong-validation-webhook
       namespace: default
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-admin
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-admin-cert
-  commonName: kong.example
-  dnsNames:
-  - "kong.example"
-  renewBefore: 168h0m0s
-  duration: 1848h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-proxy
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-proxy-cert
-  commonName: app.example
-  dnsNames:
-  - "app.example"
-  renewBefore: 168h0m0s
-  duration: 1848h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-cluster
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-cluster-cert
-  commonName: kong_clustering
-  dnsNames:
-  - "kong_clustering"
-  renewBefore: 168h0m0s
-  duration: 1848h0m0s

--- a/charts/kong/ci/__snapshots__/certificate-values.snap
+++ b/charts/kong/ci/__snapshots__/certificate-values.snap
@@ -1091,66 +1091,6 @@ spec:
         secret:
           secretName: chartsnap-kong-validation-webhook-keypair
 ---
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-admin
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-admin-cert
-  commonName: kong.example
-  dnsNames:
-  - "kong.example"
-  renewBefore: 168h0m0s
-  duration: 1848h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-proxy
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-proxy-cert
-  commonName: app.example
-  dnsNames:
-  - "app.example"
-  renewBefore: 168h0m0s
-  duration: 1848h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-cluster
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-cluster-cert
-  commonName: kong_clustering
-  dnsNames:
-  - "kong_clustering"
-  renewBefore: 168h0m0s
-  duration: 1848h0m0s
----
 # Source: kong/templates/admission-webhook.yaml
 kind: ValidatingWebhookConfiguration
 apiVersion: admissionregistration.k8s.io/v1
@@ -1181,6 +1121,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1204,14 +1148,14 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1282,3 +1226,63 @@ webhooks:
     service:
       name: chartsnap-kong-validation-webhook
       namespace: default
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-admin
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-admin-cert
+  commonName: kong.example
+  dnsNames:
+  - "kong.example"
+  renewBefore: 168h0m0s
+  duration: 1848h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-proxy-cert
+  commonName: app.example
+  dnsNames:
+  - "app.example"
+  renewBefore: 168h0m0s
+  duration: 1848h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-cluster
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-cluster-cert
+  commonName: kong_clustering
+  dnsNames:
+  - "kong_clustering"
+  renewBefore: 168h0m0s
+  duration: 1848h0m0s

--- a/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
+++ b/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1093,6 +1093,66 @@ spec:
         secret:
           secretName: chartsnap-kong-validation-webhook-keypair
 ---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-admin
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-admin-cert
+  commonName: kong.example
+  dnsNames:
+  - "kong.example"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-proxy-cert
+  commonName: app.example
+  dnsNames:
+  - "app.example"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-cluster
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-cluster-cert
+  commonName: kong_clustering
+  dnsNames:
+  - "kong_clustering"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
 # Source: kong/templates/admission-webhook.yaml
 kind: ValidatingWebhookConfiguration
 apiVersion: admissionregistration.k8s.io/v1
@@ -1100,7 +1160,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -1228,63 +1288,3 @@ webhooks:
     service:
       name: chartsnap-kong-validation-webhook
       namespace: default
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-admin
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-admin-cert
-  commonName: kong.example
-  dnsNames:
-  - "kong.example"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-proxy
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-proxy-cert
-  commonName: app.example
-  dnsNames:
-  - "app.example"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-cluster
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-cluster-cert
-  commonName: kong_clustering
-  dnsNames:
-  - "kong_clustering"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s

--- a/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
+++ b/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
@@ -1093,66 +1093,6 @@ spec:
         secret:
           secretName: chartsnap-kong-validation-webhook-keypair
 ---
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-admin
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-admin-cert
-  commonName: kong.example
-  dnsNames:
-  - "kong.example"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-proxy
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-proxy-cert
-  commonName: app.example
-  dnsNames:
-  - "app.example"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-cluster
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.9"
-spec:
-  secretName: chartsnap-kong-cluster-cert
-  commonName: kong_clustering
-  dnsNames:
-  - "kong_clustering"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
 # Source: kong/templates/admission-webhook.yaml
 kind: ValidatingWebhookConfiguration
 apiVersion: admissionregistration.k8s.io/v1
@@ -1183,6 +1123,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1206,14 +1150,14 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1284,3 +1228,63 @@ webhooks:
     service:
       name: chartsnap-kong-validation-webhook
       namespace: default
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-admin
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-admin-cert
+  commonName: kong.example
+  dnsNames:
+  - "kong.example"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-proxy-cert
+  commonName: app.example
+  dnsNames:
+  - "app.example"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-cluster
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  secretName: chartsnap-kong-cluster-cert
+  commonName: kong_clustering
+  dnsNames:
+  - "kong_clustering"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -494,7 +494,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -558,7 +558,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -593,7 +593,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -603,7 +603,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -622,7 +622,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -632,7 +632,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -660,7 +660,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -688,7 +688,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -712,7 +712,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1022,7 +1022,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -1043,6 +1043,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1066,14 +1070,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -54,7 +54,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -503,7 +503,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -523,7 +523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -609,7 +609,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -656,7 +656,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -696,7 +696,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -725,7 +725,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -750,7 +750,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1059,7 +1059,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -1080,6 +1080,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1103,14 +1107,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -1066,6 +1066,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1089,14 +1093,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
+++ b/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
@@ -1074,6 +1074,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1097,14 +1101,14 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""

--- a/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
+++ b/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -495,7 +495,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -516,7 +516,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -586,7 +586,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -607,7 +607,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -619,7 +619,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -633,7 +633,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -649,7 +649,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -663,7 +663,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -691,7 +691,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -720,7 +720,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -741,7 +741,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1051,7 +1051,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/enterprise-manager-cert-values.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-manager-cert-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -695,7 +695,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -719,7 +719,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -747,7 +747,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -775,7 +775,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -804,7 +804,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -825,7 +825,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.10"
@@ -1245,6 +1245,110 @@ spec:
         secret:
           secretName: chartsnap-kong-validation-webhook-keypair
 ---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-admin
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.10"
+spec:
+  secretName: chartsnap-kong-admin-cert
+  commonName: kong-admin.example.com
+  dnsNames:
+  - "admin.kong.example.com"
+  - "api.kong.example.com"
+  - "kong-admin.example.com"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-portal
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.10"
+spec:
+  secretName: chartsnap-kong-portal-cert
+  commonName: developer.example
+  dnsNames:
+  - "developer.example"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-manager
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.10"
+spec:
+  secretName: chartsnap-kong-manager-cert
+  commonName: kong-manager.example.com
+  dnsNames:
+  - "manager.kong.example.com"
+  - "gui.kong.example.com"
+  - "kong-manager.example.com"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.10"
+spec:
+  secretName: chartsnap-kong-proxy-cert
+  commonName: app.example
+  dnsNames:
+  - "app.example"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
+# Source: kong/templates/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: chartsnap-kong-cluster
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.1.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.10"
+spec:
+  secretName: chartsnap-kong-cluster-cert
+  commonName: kong_clustering
+  dnsNames:
+  - "kong_clustering"
+  renewBefore: 360h0m0s
+  duration: 2160h0m0s
+---
 # Source: kong/templates/admission-webhook.yaml
 kind: ValidatingWebhookConfiguration
 apiVersion: admissionregistration.k8s.io/v1
@@ -1252,7 +1356,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.10"
@@ -1380,107 +1484,3 @@ webhooks:
     service:
       name: chartsnap-kong-validation-webhook
       namespace: default
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-admin
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.10"
-spec:
-  secretName: chartsnap-kong-admin-cert
-  commonName: kong-admin.example.com
-  dnsNames:
-  - "admin.kong.example.com"
-  - "api.kong.example.com"
-  - "kong-admin.example.com"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-portal
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.10"
-spec:
-  secretName: chartsnap-kong-portal-cert
-  commonName: developer.example
-  dnsNames:
-  - "developer.example"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-manager
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.10"
-spec:
-  secretName: chartsnap-kong-manager-cert
-  commonName: kong-manager.example.com
-  dnsNames:
-  - "manager.kong.example.com"
-  - "gui.kong.example.com"
-  - "kong-manager.example.com"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-proxy
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.10"
-spec:
-  secretName: chartsnap-kong-proxy-cert
-  commonName: app.example
-  dnsNames:
-  - "app.example"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s
----
-# Source: kong/templates/certificate.yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: chartsnap-kong-cluster
-  namespace: default
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.10"
-spec:
-  secretName: chartsnap-kong-cluster-cert
-  commonName: kong_clustering
-  dnsNames:
-  - "kong_clustering"
-  renewBefore: 360h0m0s
-  duration: 2160h0m0s

--- a/charts/kong/ci/__snapshots__/enterprise-manager-cert-values.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-manager-cert-values.snap
@@ -1245,6 +1245,142 @@ spec:
         secret:
           secretName: chartsnap-kong-validation-webhook-keypair
 ---
+# Source: kong/templates/admission-webhook.yaml
+kind: ValidatingWebhookConfiguration
+apiVersion: admissionregistration.k8s.io/v1
+metadata:
+  name: chartsnap-kong-default-validations
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.0.2
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.10"
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: '###DYNAMIC_FIELD###'
+    service:
+      name: chartsnap-kong-validation-webhook
+      namespace: default
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: secrets.credentials.validation.ingress-controller.konghq.com
+  objectSelector:
+    matchExpressions:
+    - key: "konghq.com/credential"
+      operator: "Exists"
+    - key: "konghq.com/credential"
+      operator: "NotIn"
+      values:
+      - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    caBundle: '###DYNAMIC_FIELD###'
+    service:
+      name: chartsnap-kong-validation-webhook
+      namespace: default
+  failurePolicy: Ignore
+  matchPolicy: Equivalent
+  name: secrets.plugins.validation.ingress-controller.konghq.com
+  objectSelector:
+    matchExpressions:
+    - key: "konghq.com/credential"
+      operator: "NotIn"
+      values:
+      - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - secrets
+  sideEffects: None
+- name: validations.kong.konghq.com
+  matchPolicy: Equivalent
+  objectSelector:
+    matchExpressions:
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
+  failurePolicy: Ignore
+  sideEffects: None
+  admissionReviewVersions: ["v1beta1"]
+  rules:
+  - apiGroups:
+    - configuration.konghq.com
+    apiVersions:
+    - '*'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kongconsumers
+    - kongplugins
+    - kongclusterplugins
+    - kongingresses
+  - apiGroups:
+    - ''
+    apiVersions:
+    - 'v1'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - services
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - 'v1'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+  - apiGroups:
+    - gateway.networking.k8s.io
+    apiVersions:
+    - 'v1alpha2'
+    - 'v1beta1'
+    - 'v1'
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+    - httproutes
+  clientConfig:
+    caBundle: '###DYNAMIC_FIELD###'
+    service:
+      name: chartsnap-kong-validation-webhook
+      namespace: default
+---
 # Source: kong/templates/certificate.yaml
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -1348,135 +1484,3 @@ spec:
   - "kong_clustering"
   renewBefore: 360h0m0s
   duration: 2160h0m0s
----
-# Source: kong/templates/admission-webhook.yaml
-kind: ValidatingWebhookConfiguration
-apiVersion: admissionregistration.k8s.io/v1
-metadata:
-  name: chartsnap-kong-default-validations
-  labels:
-    app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
-    app.kubernetes.io/instance: "chartsnap"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "3.10"
-webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    caBundle: '###DYNAMIC_FIELD###'
-    service:
-      name: chartsnap-kong-validation-webhook
-      namespace: default
-  failurePolicy: Ignore
-  matchPolicy: Equivalent
-  name: secrets.credentials.validation.ingress-controller.konghq.com
-  objectSelector:
-    matchExpressions:
-    - key: "konghq.com/credential"
-      operator: "Exists"
-    - key: "konghq.com/credential"
-      operator: "NotIn"
-      values:
-      - "konnect"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    caBundle: '###DYNAMIC_FIELD###'
-    service:
-      name: chartsnap-kong-validation-webhook
-      namespace: default
-  failurePolicy: Ignore
-  matchPolicy: Equivalent
-  name: secrets.plugins.validation.ingress-controller.konghq.com
-  objectSelector:
-    matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
-    - key: "konghq.com/credential"
-      operator: "NotIn"
-      values:
-      - "konnect"
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - secrets
-  sideEffects: None
-- name: validations.kong.konghq.com
-  matchPolicy: Equivalent
-  objectSelector:
-    matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
-  failurePolicy: Ignore
-  sideEffects: None
-  admissionReviewVersions: ["v1beta1"]
-  rules:
-  - apiGroups:
-    - configuration.konghq.com
-    apiVersions:
-    - '*'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - kongconsumers
-    - kongplugins
-    - kongclusterplugins
-    - kongingresses
-  - apiGroups:
-    - ''
-    apiVersions:
-    - 'v1'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - services
-  - apiGroups:
-    - networking.k8s.io
-    apiVersions:
-    - 'v1'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - ingresses
-  - apiGroups:
-    - gateway.networking.k8s.io
-    apiVersions:
-    - 'v1alpha2'
-    - 'v1beta1'
-    - 'v1'
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - gateways
-    - httproutes
-  clientConfig:
-    caBundle: '###DYNAMIC_FIELD###'
-    service:
-      name: chartsnap-kong-validation-webhook
-      namespace: default

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.5"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.5"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.5"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-portalapi
   namespace: default
 spec:
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-portal
   namespace: default
 spec:
@@ -100,7 +100,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -128,7 +128,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.6"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -152,7 +152,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.6"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.6"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -1101,6 +1101,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1124,14 +1128,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -654,7 +654,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -692,7 +692,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -744,7 +744,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -1103,6 +1103,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1126,14 +1130,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -526,7 +526,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -625,7 +625,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -654,7 +654,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -664,7 +664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -692,7 +692,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -744,7 +744,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1069,7 +1069,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -1090,6 +1090,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1113,14 +1117,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -516,7 +516,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -619,7 +619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -634,7 +634,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -644,7 +644,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -663,7 +663,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -673,7 +673,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -701,7 +701,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -729,7 +729,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -753,7 +753,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1063,7 +1063,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1122,7 +1122,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -1143,6 +1143,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1166,14 +1170,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -1027,6 +1027,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1050,14 +1054,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.1-rbac-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -478,7 +478,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -542,7 +542,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -562,7 +562,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -577,7 +577,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -587,7 +587,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -606,7 +606,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -616,7 +616,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -644,7 +644,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -672,7 +672,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -696,7 +696,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1006,7 +1006,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
@@ -1086,6 +1086,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1109,14 +1113,14 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1063,7 +1063,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1065,7 +1065,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
@@ -1088,6 +1088,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1111,14 +1115,14 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""

--- a/charts/kong/ci/__snapshots__/kong-ingress-with-konnect-license.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-with-konnect-license.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -60,7 +60,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -525,7 +525,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -546,7 +546,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -616,7 +616,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -637,7 +637,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -649,7 +649,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -663,7 +663,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -679,7 +679,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -693,7 +693,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -714,7 +714,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -860,7 +860,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/kong-ingress-with-konnect-license.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-with-konnect-license.snap
@@ -883,6 +883,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -906,14 +910,14 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""

--- a/charts/kong/ci/__snapshots__/pdb-always-allow.snap
+++ b/charts/kong/ci/__snapshots__/pdb-always-allow.snap
@@ -1110,6 +1110,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1133,14 +1137,14 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""

--- a/charts/kong/ci/__snapshots__/pdb-always-allow.snap
+++ b/charts/kong/ci/__snapshots__/pdb-always-allow.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kong
-      helm.sh/chart: kong-3.0.2
+      helm.sh/chart: kong-3.1.0
       app.kubernetes.io/instance: "chartsnap"
       app.kubernetes.io/managed-by: "Helm"
       app.kubernetes.io/version: "3.9"
@@ -32,7 +32,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -45,7 +45,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -62,7 +62,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -77,7 +77,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -527,7 +527,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -548,7 +548,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -618,7 +618,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -639,7 +639,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -651,7 +651,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -665,7 +665,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -681,7 +681,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -695,7 +695,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -723,7 +723,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -752,7 +752,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -773,7 +773,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1087,7 +1087,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/pdb-default.snap
+++ b/charts/kong/ci/__snapshots__/pdb-default.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kong
-      helm.sh/chart: kong-3.0.2
+      helm.sh/chart: kong-3.1.0
       app.kubernetes.io/instance: "chartsnap"
       app.kubernetes.io/managed-by: "Helm"
       app.kubernetes.io/version: "3.9"
@@ -32,7 +32,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -45,7 +45,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -62,7 +62,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -77,7 +77,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -527,7 +527,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -548,7 +548,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -618,7 +618,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -639,7 +639,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -651,7 +651,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -665,7 +665,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -681,7 +681,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -695,7 +695,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -723,7 +723,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -752,7 +752,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -773,7 +773,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1087,7 +1087,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -713,7 +713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -737,7 +737,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1047,7 +1047,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -1068,6 +1068,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1091,14 +1095,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -1066,6 +1066,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1089,14 +1093,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: my-kong-sa
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
+++ b/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
@@ -1086,6 +1086,10 @@ webhooks:
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""
@@ -1109,14 +1113,14 @@ webhooks:
   name: secrets.plugins.validation.ingress-controller.konghq.com
   objectSelector:
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
     - key: "konghq.com/credential"
       operator: "NotIn"
       values:
       - "konnect"
+    - key: owner
+      operator: NotIn
+      values:
+      - helm
   rules:
   - apiGroups:
     - ""

--- a/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
+++ b/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
@@ -8,7 +8,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -21,7 +21,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -38,7 +38,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -53,7 +53,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -503,7 +503,7 @@ metadata:
   name: chartsnap-kong
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -524,7 +524,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -594,7 +594,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -615,7 +615,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -627,7 +627,7 @@ spec:
     targetPort: webhook
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -641,7 +641,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -657,7 +657,7 @@ spec:
     targetPort: cstatus
   selector:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -671,7 +671,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -699,7 +699,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -728,7 +728,7 @@ metadata:
   namespace: default
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"
@@ -749,7 +749,7 @@ spec:
         traffic.sidecar.istio.io/includeInboundPorts: ""
       labels:
         app.kubernetes.io/name: kong
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         app.kubernetes.io/instance: "chartsnap"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/version: "3.9"
@@ -1063,7 +1063,7 @@ metadata:
   name: chartsnap-kong-default-validations
   labels:
     app.kubernetes.io/name: kong
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
     app.kubernetes.io/instance: "chartsnap"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/version: "3.9"

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -1066,6 +1066,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1089,14 +1093,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -18,7 +18,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -74,7 +74,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.4"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -98,7 +98,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.4"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.4"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -1153,6 +1153,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1176,14 +1180,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -581,7 +581,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -616,7 +616,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -645,7 +645,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -655,7 +655,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -683,7 +683,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -735,7 +735,7 @@ spec:
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
         environment: test
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -1108,7 +1108,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1132,7 +1132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -155,7 +155,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -174,7 +174,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -238,7 +238,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default
   namespace: default
 rules:
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-kong-test
   namespace: kong-test
 rules:
@@ -964,7 +964,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -984,7 +984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default
   namespace: default
 roleRef:
@@ -1004,7 +1004,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-kong-test
   namespace: kong-test
 roleRef:
@@ -1024,7 +1024,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -1039,7 +1039,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -1049,7 +1049,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -1068,7 +1068,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -1078,7 +1078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1142,7 +1142,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -1171,7 +1171,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1521,7 +1521,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1545,7 +1545,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -1566,6 +1566,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1596,6 +1600,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -121,7 +121,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-custom-dbless-config
   namespace: default
 ---
@@ -40,7 +40,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -129,7 +129,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -371,7 +371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -1705,6 +1705,10 @@ webhooks:
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""
@@ -1728,14 +1732,14 @@ webhooks:
     name: secrets.plugins.validation.ingress-controller.konghq.com
     objectSelector:
       matchExpressions:
-        - key: owner
-          operator: NotIn
-          values:
-            - helm
         - key: konghq.com/credential
           operator: NotIn
           values:
             - konnect
+        - key: owner
+          operator: NotIn
+          values:
+            - helm
     rules:
       - apiGroups:
           - ""

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 ---
@@ -36,7 +36,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-ca-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook-keypair
   namespace: default
 type: kubernetes.io/tls
@@ -71,7 +71,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-bash-wait-for-postgres
   namespace: default
 ---
@@ -83,7 +83,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 rules:
   - apiGroups:
@@ -531,7 +531,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -550,7 +550,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 rules:
@@ -614,7 +614,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 roleRef:
@@ -684,7 +684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-validation-webhook
   namespace: default
 spec:
@@ -699,7 +699,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -709,7 +709,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-metrics
   namespace: default
 spec:
@@ -728,7 +728,7 @@ spec:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
 ---
 apiVersion: v1
 kind: Service
@@ -738,7 +738,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-manager
   namespace: default
 spec:
@@ -766,7 +766,7 @@ metadata:
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
     enable-metrics: "true"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -794,7 +794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong
   namespace: default
 spec:
@@ -823,7 +823,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
         version: "3.9"
     spec:
       automountServiceAccountToken: false
@@ -1423,7 +1423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-init-migrations
   namespace: default
 spec:
@@ -1439,7 +1439,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
       name: kong-init-migrations
     spec:
       automountServiceAccountToken: false
@@ -1660,7 +1660,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-proxy
   namespace: default
 spec:
@@ -1684,7 +1684,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-default-validations
 webhooks:
   - admissionReviewVersions:
@@ -1824,7 +1824,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-post-upgrade-migrations
   namespace: default
 spec:
@@ -1840,7 +1840,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
       name: kong-post-upgrade-migrations
     spec:
       automountServiceAccountToken: false
@@ -2067,7 +2067,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kong
     app.kubernetes.io/version: "3.9"
-    helm.sh/chart: kong-3.0.2
+    helm.sh/chart: kong-3.1.0
   name: chartsnap-kong-pre-upgrade-migrations
   namespace: default
 spec:
@@ -2083,7 +2083,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: kong
         app.kubernetes.io/version: "3.9"
-        helm.sh/chart: kong-3.0.2
+        helm.sh/chart: kong-3.1.0
       name: kong-pre-upgrade-migrations
     spec:
       automountServiceAccountToken: false

--- a/charts/kong/ci/admission-webhook-configuration.yaml
+++ b/charts/kong/ci/admission-webhook-configuration.yaml
@@ -5,6 +5,8 @@ ingressController:
     timeoutSeconds: 5
     filterSecrets: true
     objectSelector:
+      matchLabels:
+        app.kubernetes.io/instance: kong-test
       matchExpressions:
       - key: owner
         operator: NotIn

--- a/charts/kong/ci/admission-webhook-filtersecrets-false.yaml
+++ b/charts/kong/ci/admission-webhook-filtersecrets-false.yaml
@@ -1,0 +1,13 @@
+ingressController:
+  enabled: true
+  admissionWebhook:
+    enabled: true
+    filterSecrets: false
+    objectSelector:
+      matchLabels:
+        app.kubernetes.io/instance: kong-custom
+      matchExpressions:
+      - key: environment
+        operator: In
+        values:
+        - production

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -1925,3 +1925,18 @@ envFrom:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render the konnect exclusion expression and user-provided matchExpressions
+from admissionWebhook.objectSelector. These always appear together at the
+end of the matchExpressions list for secrets webhooks.
+*/}}
+{{- define "kong.admissionWebhook.objectSelector.konnectExclusionAndUserExpressions" -}}
+- key: "konghq.com/credential"
+  operator: "NotIn"
+  values:
+  - "konnect"
+{{- with .Values.ingressController.admissionWebhook.objectSelector.matchExpressions }}
+{{ toYaml . }}
+{{- end -}}
+{{- end -}}

--- a/charts/kong/templates/admission-webhook.yaml
+++ b/charts/kong/templates/admission-webhook.yaml
@@ -64,14 +64,14 @@ webhooks:
   timeoutSeconds: {{ . }}
   {{- end }}
   objectSelector:
+    {{- with .Values.ingressController.admissionWebhook.objectSelector.matchLabels }}
+    matchLabels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     matchExpressions:
     - key: "konghq.com/credential"
       operator: "Exists"
-    {{- /* Do not validate Konnect credentials, these are targeted for KGO */}}
-    - key: "konghq.com/credential"
-      operator: "NotIn"
-      values:
-      - "konnect"
+    {{- include "kong.admissionWebhook.objectSelector.konnectExclusionAndUserExpressions" . | nindent 4 }}
   rules:
   - apiGroups:
     - ""
@@ -108,26 +108,22 @@ webhooks:
   {{- end }}
   {{- if .Values.ingressController.admissionWebhook.filterSecrets }}
   objectSelector:
+    {{- with .Values.ingressController.admissionWebhook.objectSelector.matchLabels }}
+    matchLabels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     matchExpressions:
     - key: "konghq.com/validate"
       operator: "Exists"
-    {{- /* Do not validate Konnect credentials, these are targeted for KGO */}}
-    - key: "konghq.com/credential"
-      operator: "NotIn"
-      values:
-      - "konnect"
+    {{- include "kong.admissionWebhook.objectSelector.konnectExclusionAndUserExpressions" . | nindent 4 }}
   {{- else }}
   objectSelector:
+    {{- with .Values.ingressController.admissionWebhook.objectSelector.matchLabels }}
+    matchLabels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     matchExpressions:
-    - key: owner
-      operator: NotIn
-      values:
-      - helm
-    {{- /* Do not validate Konnect credentials, these are targeted for KGO */}}
-    - key: "konghq.com/credential"
-      operator: "NotIn"
-      values:
-      - "konnect"
+    {{- include "kong.admissionWebhook.objectSelector.konnectExclusionAndUserExpressions" . | nindent 4 }}
   {{- end }}
   rules:
   - apiGroups:

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -619,7 +619,11 @@ ingressController:
     #        values:
     #          - kube-system
     namespaceSelector: {}
-    # ObjectSelector specifies which objects to match against validations.kong.konghq.com webhook webhook
+    # objectSelector specifies label selectors applied to all admission webhooks.
+    # For the secrets webhooks (credentials and plugins), chart-required expressions
+    # (e.g. credential type filtering, konnect exclusion) are always included
+    # in addition to any expressions you specify here.
+    # This is useful for scoping webhooks per Kong instance in multi-instance clusters.
     objectSelector:
       matchExpressions:
       - key: owner


### PR DESCRIPTION
## Summary

- **Problem**: In multi-instance clusters (e.g. kong-main, kong-internal), each Kong instance's admission webhooks intercept all matching secrets cluster-wide. The `admissionWebhook.objectSelector` only applied to webhook 2 (CRD validation), silently ignoring webhooks 0 (credentials) and 1 (plugins). Users had to resort to Kustomize postRenderers to scope those webhooks.
- **Fix**: `objectSelector` now applies to all 3 webhooks. For secrets webhooks, user-provided `matchLabels` and `matchExpressions` are merged with chart-required functional expressions (credential filtering, konnect exclusion). A shared helper in `_helpers.tpl` reduces template duplication.
- **New CI test**: `admission-webhook-filtersecrets-false.yaml` exercises the `filterSecrets: false` path with a custom objectSelector.

## Behavioral change with default values

| Webhook | Before | After |
|---------|--------|-------|
| 0 (credentials) | `credential Exists` + `credential NotIn konnect` | Same + `owner NotIn helm` from objectSelector |
| 1 (plugins, filterSecrets=false) | `owner NotIn helm` + `credential NotIn konnect` | `credential NotIn konnect` + `owner NotIn helm` from objectSelector (same set, different source) |
| 1 (plugins, filterSecrets=true) | `validate Exists` + `credential NotIn konnect` | Same + `owner NotIn helm` from objectSelector |
| 2 (CRD validation) | objectSelector passthrough | Unchanged |

## Backward compatibility

- Default behavior is preserved: the default `objectSelector` includes `owner NotIn helm`, which was already hardcoded in webhook 1 (filterSecrets=false). For webhooks 0 and 1 (filterSecrets=true), `owner NotIn helm` is a new addition that's safe — Helm-owned secrets don't carry `konghq.com/credential` or `konghq.com/validate` labels anyway.
- If a user overrides `objectSelector` and omits `owner NotIn helm`, they own that choice — same contract as webhook 2 today.

## Test plan

- [x] `helm template` with default values — verified all 3 webhooks render correctly
- [x] `helm template` with custom objectSelector including matchLabels — verified all 3 webhooks include them
- [x] `helm template` with `objectSelector: {}` (via `--set-json`) — verified hardcoded functional expressions preserved
- [x] `helm template` with filterSecrets=false + custom objectSelector — verified correct rendering
- [x] `make _chartsnap CHART=kong CHARTSNAP_ARGS="-u"` — all 33 snapshots updated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)