### PR TITLE
fix(ci): skip already released chart uploads

### DIFF
--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -6,6 +6,11 @@ on:
       - main
       - release/kong-2.x
 
+concurrency:
+  # Queue release runs per branch so duplicate OCI pushes cannot race each other.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -51,25 +56,17 @@ jobs:
 
           version="$(awk '$1=="version:" { print $2; exit }' charts/kong-operator/Chart.yaml)"
           tag="kong-operator-${version}"
-          status="$(
-            curl -sS -o /dev/null -w '%{http_code}' \
-              -H "Authorization: Bearer ${GH_TOKEN}" \
-              -H "Accept: application/vnd.github+json" \
-              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
-          )"
+          error_file="$(mktemp)"
+          trap 'rm -f "${error_file}"' EXIT
 
-          case "${status}" in
-            200)
-              already_released=true
-              ;;
-            404)
-              already_released=false
-              ;;
-            *)
-              echo "Failed to inspect release '${tag}' (HTTP ${status})." >&2
-              exit 1
-              ;;
-          esac
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>"${error_file}"; then
+            already_released=true
+          elif grep -qE 'release not found|HTTP 404' "${error_file}"; then
+            already_released=false
+          else
+            cat "${error_file}" >&2
+            exit 1
+          fi
 
           {
             echo "version=${version}"

--- a/.github/workflows/release-push.yaml
+++ b/.github/workflows/release-push.yaml
@@ -41,23 +41,64 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add kong https://charts.konghq.com
 
+      - name: Check existing kong-operator release
+        id: kong_operator_release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          version="$(awk '$1=="version:" { print $2; exit }' charts/kong-operator/Chart.yaml)"
+          tag="kong-operator-${version}"
+          status="$(
+            curl -sS -o /dev/null -w '%{http_code}' \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
+          )"
+
+          case "${status}" in
+            200)
+              already_released=true
+              ;;
+            404)
+              already_released=false
+              ;;
+            *)
+              echo "Failed to inspect release '${tag}' (HTTP ${status})." >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "version=${version}"
+            echo "already_released=${already_released}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Run chart-releaser
         id: chart_releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CR_SKIP_EXISTING: true
 
-      - name: Released versions
+      - name: Chart releaser selection
         if: ${{ steps.chart_releaser.outputs.changed_charts != '' }}
         run: |
-          echo "Released charts: ${{ steps.chart_releaser.outputs.changed_charts }}"
-          echo "Chart version: ${{ steps.chart_releaser.outputs.chart_version }}"
+          echo "Selected charts: ${{ steps.chart_releaser.outputs.changed_charts }}"
+          echo "Existing GitHub releases are skipped during upload."
+
+      - name: Skip existing kong-operator OCI push
+        if: ${{ contains(steps.chart_releaser.outputs.changed_charts, 'charts/kong-operator') && steps.kong_operator_release.outputs.already_released == 'true' }}
+        run: |
+          echo "Skipping OCI push for kong-operator-chart:${{ steps.kong_operator_release.outputs.version }} because this chart release already existed before the workflow started."
 
       - name: Check OCI push preconditions
         id: oci_push
         env:
-          PUBLISH_OCI: ${{ contains(steps.chart_releaser.outputs.changed_charts, 'kong-operator') }}
+          PUBLISH_OCI: ${{ contains(steps.chart_releaser.outputs.changed_charts, 'charts/kong-operator') && steps.kong_operator_release.outputs.already_released != 'true' }}
           DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_PUSH_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_PUSH_TOKEN_KO_CHART }}
         run: |
@@ -78,6 +119,8 @@ jobs:
       - name: Prepare and push kong-operator-chart to DockerHub (OCI)
         if: ${{ steps.oci_push.outputs.should_push == 'true' }}
         shell: bash
+        env:
+          KONG_OPERATOR_VERSION: ${{ steps.kong_operator_release.outputs.version }}
         run: |
           set -euo pipefail
           WORKDIR="$(mktemp -d)"
@@ -88,5 +131,4 @@ jobs:
           grep -E '^name:' "${WORKDIR}/kong-operator-chart/Chart.yaml"
           # Package and push to kong/kong-operator-chart
           helm package "${WORKDIR}/kong-operator-chart"
-          VERSION=$(grep -E '^version:' charts/kong-operator/Chart.yaml | awk '{print $2}')
-          helm push "kong-operator-chart-${VERSION}.tgz" oci://registry-1.docker.io/kong
+          helm push "kong-operator-chart-${KONG_OPERATOR_VERSION}.tgz" oci://registry-1.docker.io/kong


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

Last time we found that the kong-operator OCI chart was pushed multiple times.

https://github.com/Kong/charts/actions/runs/23798694723/job/69376167949

The workflow `treats steps.chart_releaser.outputs.changed_charts` as "charts that have been released." However, this output actually means only "charts selected by the diff." As a result, kong will be released normally as version 3.2.0, while kong-operator, even though version 1.2.2 was already released, will still be packaged and trigger the following OCI push and log output.



#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] PR is based off the current tip of the `main` branch.
- [ ] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [ ] New or modified sections of values.yaml are documented in the README.md
- [ ] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
