### PR TITLE
Kong chart: scope IngressClass controller name by ingress class

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+* Align `IngressClass.spec.controller` and Gateway API
+  `CONTROLLER_GATEWAY_API_CONTROLLER_NAME` with `ingressController.ingressClass`
+  when using multiple controllers or a non-default ingress class.
+
 ## 3.2.0
 
 ### Changes

--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Changes
 
-* Align `IngressClass.spec.controller` and Gateway API
-  `CONTROLLER_GATEWAY_API_CONTROLLER_NAME` with `ingressController.ingressClass`
+* Align `IngressClass.spec.controller` with `ingressController.ingressClass`
   when using multiple controllers or a non-default ingress class.
 
 ## 3.2.0

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -502,6 +502,7 @@ The name of the Service which will be used by the controller to update the Ingre
   {{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" true -}}
   {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" ( include "kong.controller-publish-service" . ) -}}
   {{- $_ := set $autoEnv "CONTROLLER_INGRESS_CLASS" .Values.ingressController.ingressClass -}}
+  {{- $_ := set $autoEnv "CONTROLLER_GATEWAY_API_CONTROLLER_NAME" (printf "ingress-controllers.konghq.com/-%s" .Values.ingressController.ingressClass) -}}
   {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}
 
   {{- if .Values.ingressController.admissionWebhook.enabled }}

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -502,7 +502,6 @@ The name of the Service which will be used by the controller to update the Ingre
   {{- $_ := set $autoEnv "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY" true -}}
   {{- $_ := set $autoEnv "CONTROLLER_PUBLISH_SERVICE" ( include "kong.controller-publish-service" . ) -}}
   {{- $_ := set $autoEnv "CONTROLLER_INGRESS_CLASS" .Values.ingressController.ingressClass -}}
-  {{- $_ := set $autoEnv "CONTROLLER_GATEWAY_API_CONTROLLER_NAME" (printf "ingress-controllers.konghq.com/-%s" .Values.ingressController.ingressClass) -}}
   {{- $_ := set $autoEnv "CONTROLLER_ELECTION_ID" (printf "kong-ingress-controller-leader-%s" .Values.ingressController.ingressClass) -}}
 
   {{- if .Values.ingressController.admissionWebhook.enabled }}

--- a/charts/kong/templates/ingress-class.yaml
+++ b/charts/kong/templates/ingress-class.yaml
@@ -29,5 +29,5 @@ metadata:
   labels:
   {{- include "kong.metaLabels" . | nindent 4 }}
 spec:
-  controller: ingress-controllers.konghq.com/kong
+  controller: ingress-controllers.konghq.com/{{ .Values.ingressController.ingressClass }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does / why we need it:
The chart previously set `IngressClass.spec.controller` to a fixed value (`ingress-controllers.konghq.com/kong`). That makes every deployment advertise the same controller identity, which breaks expectations when multiple Kong Ingress Controller instances use different `ingressController.ingressClass` values.
This PR:
- Sets `spec.controller` on the managed `IngressClass` to `ingress-controllers.konghq.com/{{ .Values.ingressController.ingressClass }}` so it matches the configured ingress class.
An Ingress resource that targets a given ingress class resolves to the correct controller instance.

#### Which issue this PR fixes
- Related: #1079 (multiple instances - chart now aligns IngressClass with `ingressController.ingressClass`)

#### Special notes for your reviewer:

#### Checklist
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
