### PR TITLE
feat(kong): support Service.spec.trafficDistribution for zone-aware routing

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+* Added `trafficDistribution` setting for Kong Services to support zone-aware
+  routing (`PreferClose`). Requires Kubernetes >= 1.31 (beta) / >= 1.33 (GA).
+  [#1525](https://github.com/Kong/charts/pull/1525)
+
 ## 3.2.0
 
 ### Changes

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -723,6 +723,7 @@ or `ingress` sections, as it is used only for stream listens.
 | SVC.clusterIP                     | k8s service clusterIP                                                                     |                          |
 | SVC.ipFamilyPolicy                | k8s service's ipFamilyPolicy. Options: SingleStack, PreferDualStack, RequireDualStack     |                          |
 | SVC.ipFamilies                    | k8s service's ipFamilies                                                                  | `[]`                     |
+| SVC.trafficDistribution           | k8s service's trafficDistribution (K8s >=1.31 beta, >=1.33 GA). Options: PreferClose      |                          |
 | SVC.loadBalancerClass             | loadBalancerClass to use for LoadBalancer provisionning                                   |                          |
 | SVC.loadBalancerSourceRanges      | Limit service access to CIDRs if set and service type is `LoadBalancer`                   | `[]`                     |
 | SVC.loadBalancerIP                | Reuse an existing ingress static IP for the service                                       |                          |

--- a/charts/kong/ci/__snapshots__/service-trafficdistribution-values.snap
+++ b/charts/kong/ci/__snapshots__/service-trafficdistribution-values.snap
@@ -1,0 +1,386 @@
+# chartsnap: snapshot_version=v3
+---
+# Source: kong/templates/service-account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chartsnap-kong
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.2.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+---
+# Source: kong/templates/config-dbless.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chartsnap-kong-custom-dbless-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.2.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+data:
+  kong.yml: |
+    _format_version: "1.1"
+    services:
+      - name: example.com
+        url: http://example.com
+        routes:
+        - name: example
+          paths:
+          - "/example"
+---
+# Source: kong/templates/service-kong-cluster.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-kong-cluster
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.2.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  type: ClusterIP
+  ports:
+  - name: kong-cluster-tls
+    port: 8005
+    targetPort: 8005
+    protocol: TCP
+  trafficDistribution: PreferClose
+  selector:
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: "chartsnap"
+---
+# Source: kong/templates/service-kong-manager.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-kong-manager
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.2.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+spec:
+  type: NodePort
+  ports:
+  - name: kong-manager
+    port: 8002
+    targetPort: 8002
+    protocol: TCP
+  - name: kong-manager-tls
+    port: 8445
+    targetPort: 8445
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: "chartsnap"
+---
+# Source: kong/templates/service-kong-proxy.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: chartsnap-kong-proxy
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.2.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+    enable-metrics: "true"
+spec:
+  type: LoadBalancer
+  ports:
+  - name: kong-proxy
+    port: 80
+    targetPort: 8000
+    protocol: TCP
+  - name: kong-proxy-tls
+    port: 443
+    targetPort: 8443
+    protocol: TCP
+  trafficDistribution: PreferClose
+  selector:
+    app.kubernetes.io/name: kong
+    app.kubernetes.io/component: app
+    app.kubernetes.io/instance: "chartsnap"
+---
+# Source: kong/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartsnap-kong
+  namespace: default
+  labels:
+    app.kubernetes.io/name: kong
+    helm.sh/chart: kong-3.2.0
+    app.kubernetes.io/instance: "chartsnap"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/version: "3.9"
+    app.kubernetes.io/component: app
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kong
+      app.kubernetes.io/component: app
+      app.kubernetes.io/instance: "chartsnap"
+  template:
+    metadata:
+      annotations:
+        kuma.io/service-account-token-volume: chartsnap-kong-token
+        checksum/dbless.config: 95c0309e6b27de23d64edae3a3602472635243f133fba88af3034ed4d5703d4a
+        kuma.io/gateway: "enabled"
+        traffic.sidecar.istio.io/includeInboundPorts: ""
+      labels:
+        app.kubernetes.io/name: kong
+        helm.sh/chart: kong-3.2.0
+        app.kubernetes.io/instance: "chartsnap"
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/version: "3.9"
+        app.kubernetes.io/component: app
+        app: chartsnap-kong
+        version: "3.9"
+    spec:
+      serviceAccountName: chartsnap-kong
+      automountServiceAccountToken: false
+      initContainers:
+      - name: clear-stale-pid
+        image: kong:3.9
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        resources: {}
+        command:
+        - "rm"
+        - "-vrf"
+        - "$KONG_PREFIX/pids"
+        env:
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_GUI_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_GUI_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_LISTEN
+          value: "127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl"
+        - name: KONG_ANONYMOUS_REPORTS
+          value: "off"
+        - name: KONG_CLUSTER_LISTEN
+          value: "0.0.0.0:8005 ssl, [::]:8005 ssl"
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_DECLARATIVE_CONFIG
+          value: "/kong_dbless/kong.yml"
+        - name: KONG_LUA_PACKAGE_PATH
+          value: "/opt/?.lua;/opt/?/init.lua;;"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_PORTAL_API_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PORTAL_API_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
+        - name: KONG_PREFIX
+          value: "/kong_prefix/"
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PROXY_LISTEN
+          value: "0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl"
+        - name: KONG_PROXY_STREAM_ACCESS_LOG
+          value: "/dev/stdout basic"
+        - name: KONG_PROXY_STREAM_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ROUTER_FLAVOR
+          value: "traditional"
+        - name: KONG_STATUS_ACCESS_LOG
+          value: "off"
+        - name: KONG_STATUS_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_STATUS_LISTEN
+          value: "0.0.0.0:8100, [::]:8100"
+        - name: KONG_STREAM_LISTEN
+          value: "off"
+        volumeMounts:
+        - name: chartsnap-kong-prefix-dir
+          mountPath: /kong_prefix/
+        - name: chartsnap-kong-tmp
+          mountPath: /tmp
+        - name: kong-custom-dbless-config-volume
+          mountPath: /kong_dbless/
+      containers:
+      - name: "proxy"
+        image: kong:3.9
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+        env:
+        - name: KONG_ADMIN_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_GUI_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_ADMIN_GUI_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ADMIN_LISTEN
+          value: "127.0.0.1:8444 http2 ssl, [::1]:8444 http2 ssl"
+        - name: KONG_ANONYMOUS_REPORTS
+          value: "off"
+        - name: KONG_CLUSTER_LISTEN
+          value: "0.0.0.0:8005 ssl, [::]:8005 ssl"
+        - name: KONG_DATABASE
+          value: "off"
+        - name: KONG_DECLARATIVE_CONFIG
+          value: "/kong_dbless/kong.yml"
+        - name: KONG_LUA_PACKAGE_PATH
+          value: "/opt/?.lua;/opt/?/init.lua;;"
+        - name: KONG_NGINX_WORKER_PROCESSES
+          value: "2"
+        - name: KONG_PORTAL_API_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PORTAL_API_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PORT_MAPS
+          value: "80:8000, 443:8443"
+        - name: KONG_PREFIX
+          value: "/kong_prefix/"
+        - name: KONG_PROXY_ACCESS_LOG
+          value: "/dev/stdout"
+        - name: KONG_PROXY_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_PROXY_LISTEN
+          value: "0.0.0.0:8000, [::]:8000, 0.0.0.0:8443 http2 ssl, [::]:8443 http2 ssl"
+        - name: KONG_PROXY_STREAM_ACCESS_LOG
+          value: "/dev/stdout basic"
+        - name: KONG_PROXY_STREAM_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_ROUTER_FLAVOR
+          value: "traditional"
+        - name: KONG_STATUS_ACCESS_LOG
+          value: "off"
+        - name: KONG_STATUS_ERROR_LOG
+          value: "/dev/stderr"
+        - name: KONG_STATUS_LISTEN
+          value: "0.0.0.0:8100, [::]:8100"
+        - name: KONG_STREAM_LISTEN
+          value: "off"
+        - name: KONG_NGINX_DAEMON
+          value: "off"
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - kong
+              - quit
+              - --wait=15
+        ports:
+        - name: proxy
+          containerPort: 8000
+          protocol: TCP
+        - name: proxy-tls
+          containerPort: 8443
+          protocol: TCP
+        - name: status
+          containerPort: 8100
+          protocol: TCP
+        - name: cluster-tls
+          containerPort: 8005
+          protocol: TCP
+        volumeMounts:
+        - name: chartsnap-kong-prefix-dir
+          mountPath: /kong_prefix/
+        - name: chartsnap-kong-tmp
+          mountPath: /tmp
+        - name: kong-custom-dbless-config-volume
+          mountPath: /kong_dbless/
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status/ready
+            port: status
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 5
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: status
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources: {}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: chartsnap-kong-prefix-dir
+        emptyDir:
+          sizeLimit: 256Mi
+      - name: chartsnap-kong-tmp
+        emptyDir:
+          sizeLimit: 1Gi
+      - name: chartsnap-kong-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
+      - name: kong-custom-dbless-config-volume
+        configMap:
+          name: chartsnap-kong-custom-dbless-config

--- a/charts/kong/ci/service-trafficdistribution-values.yaml
+++ b/charts/kong/ci/service-trafficdistribution-values.yaml
@@ -1,0 +1,34 @@
+# render Services with explicit trafficDistribution configuration
+
+proxy:
+  trafficDistribution: PreferClose
+
+cluster:
+  enabled: true
+  trafficDistribution: PreferClose
+  tls:
+    enabled: true
+
+ingressController:
+  enabled: false
+
+dblessConfig:
+  config: |
+    _format_version: "1.1"
+    services:
+      - name: example.com
+        url: http://example.com
+        routes:
+        - name: example
+          paths:
+          - "/example"
+
+# NOTE: The purpose of those values below is to:
+# - to speed up, the test
+# - to prevent anonymous reports from being sent
+readinessProbe:
+  initialDelaySeconds: 1
+  periodSeconds: 1
+
+env:
+  anonymous_reports: "off"

--- a/charts/kong/templates/_helpers.tpl
+++ b/charts/kong/templates/_helpers.tpl
@@ -269,6 +269,9 @@ spec:
   {{- if .externalTrafficPolicy }}
   externalTrafficPolicy: {{ .externalTrafficPolicy }}
   {{- end }}
+  {{- if .trafficDistribution }}
+  trafficDistribution: {{ .trafficDistribution }}
+  {{- end }}
   {{- if .clusterIP }}
   {{- if (or (not (eq .clusterIP "None")) (and (eq .type "ClusterIP") (eq .clusterIP "None"))) }}
   clusterIP: {{ .clusterIP }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -158,6 +158,7 @@ admin:
   loadBalancerClass:
   ipFamilyPolicy:
   ipFamilies: []
+  trafficDistribution:
   # To specify annotations or labels for the admin service, add them to the respective
   # "annotations" or "labels" dictionaries below.
   annotations: {}
@@ -263,6 +264,7 @@ cluster:
   loadBalancerClass:
   ipFamilyPolicy:
   ipFamilies: []
+  trafficDistribution:
 
   # Kong cluster ingress settings. Useful if you want to split CP and DP
   # in different clusters.
@@ -289,6 +291,7 @@ proxy:
   loadBalancerClass: ""
   ipFamilyPolicy:
   ipFamilies: []
+  trafficDistribution:
   # Configures optional firewall rules and in the VPC network to only allow certain source ranges.
   loadBalancerSourceRanges: []
   # Override proxy Service name
@@ -419,6 +422,7 @@ udpProxy:
   loadBalancerClass:
   ipFamilyPolicy:
   ipFamilies: []
+  trafficDistribution:
   # To specify annotations or labels for the proxy service, add them to the respective
   # "annotations" or "labels" dictionaries below.
   annotations: {}
@@ -1195,6 +1199,7 @@ manager:
   loadBalancerClass:
   ipFamilyPolicy:
   ipFamilies: []
+  trafficDistribution:
   # To specify annotations or labels for the Manager service, add them to the respective
   # "annotations" or "labels" dictionaries below.
   annotations: {}
@@ -1244,6 +1249,7 @@ portal:
   loadBalancerClass:
   ipFamilyPolicy:
   ipFamilies: []
+  trafficDistribution:
   # To specify annotations or labels for the Portal service, add them to the respective
   # "annotations" or "labels" dictionaries below.
   annotations: {}
@@ -1293,6 +1299,7 @@ portalapi:
   loadBalancerClass:
   ipFamilyPolicy:
   ipFamilies: []
+  trafficDistribution:
   # To specify annotations or labels for the Portal API service, add them to the respective
   # "annotations" or "labels" dictionaries below.
   annotations: {}
@@ -1353,6 +1360,7 @@ clustertelemetry:
   loadBalancerClass:
   ipFamilyPolicy:
   ipFamilies: []
+  trafficDistribution:
 
   # Kong clustertelemetry ingress settings. Useful if you want to split
   # CP and DP in different clusters.


### PR DESCRIPTION
#### What this PR does / why we need it

Exposes Kubernetes `Service.spec.trafficDistribution` (beta in K8s 1.31, GA in 1.33) as a configurable field on every Service the `kong/kong` chart renders. Setting `PreferClose` instructs kube-proxy / EndpointSlice controllers to prefer endpoints in the same zone as the client, falling back to cross-zone endpoints otherwise — the modern GA replacement for the older `service.kubernetes.io/topology-mode` annotation and Topology Aware Hints.

For multi-AZ Kong deployments this matters for two reasons:

1. **Cross-AZ egress cost.** Hyperscalers charge per-GB for inter-AZ traffic. Routing in-zone when possible can materially reduce the bill for high-throughput proxy fleets.
2. **Latency.** In-zone hops shave a few ms vs. cross-AZ, which adds up on tail latency for chatty north-south traffic.

This is opt-in: when unset, the field is omitted from the rendered Service and behaviour is unchanged.

Structurally the change mirrors #1508 (`ipFamilyPolicy` / `ipFamilies`) — a single optional field on every block that flows through the `kong.service` template helper.

#### Which issue this PR fixes

*(no issue tracked — happy to open one if maintainers prefer)*

#### Special notes for your reviewer

- All eight Service blocks that already follow the `ipFamilyPolicy`/`ipFamilies` pattern in `values.yaml` (`admin`, `cluster`, `proxy`, `udpProxy`, `manager`, `portal`, `portalapi`, `clustertelemetry`) gain a documented `trafficDistribution:` field for consistency.
- `make test.golden.update` was run locally; only the new `service-trafficdistribution-values.snap` was added — no existing snapshots changed (as expected, since the rendered output is unchanged when the field is unset).
- The umbrella `kong/ingress` chart inherits the change automatically through its two `kong/kong` sub-releases.
- A natural follow-up would be exposing `internalTrafficPolicy` for symmetry (also a top-level `Service.spec` field, GA since 1.26). Happy to send a separate PR for that if of interest — kept this one focused.

#### Checklist

- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
