### PR TITLE
feat(kong): configure clear-stale-pid image

### DIFF
--- a/charts/kong/CHANGELOG.md
+++ b/charts/kong/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+* Added image and command configuration for the `clearStalePid` init container.
+  This allows users to run stale PID cleanup with a utility image when the Kong
+  image does not include shell utilities (e.g. for distroless images).
+  [#1539](https://github.com/Kong/charts/pull/1539)
+
 ## 3.4.0
 
 ### Changes

--- a/charts/kong/README.md
+++ b/charts/kong/README.md
@@ -902,6 +902,9 @@ On the Gateway release side, set either `admin.tls.client.secretName` to the nam
 | ---------------------------------- | ------------------------------------------------------------------------------------- | ------------------- |
 | namespace                          | Namespace to deploy chart resources                                                   |                     |
 | deployment.kong.enabled            | Enable or disable deploying Kong                                                      | `true`              |
+| deployment.kong.initContainers.clearStalePid.enabled | Enable the init container that clears stale PIDs from Kong's prefix directory. | `true` |
+| deployment.kong.initContainers.clearStalePid.image | Image used by the `clear-stale-pid` init container. Defaults to the Kong image when unset. | `{}` |
+| deployment.kong.initContainers.clearStalePid.command | Command used by the `clear-stale-pid` init container. | `["rm", "-vrf", "$(KONG_PREFIX)/pids"]` |
 | deployment.revisionHistoryLimit    | The number of `ReplicaSet`s to retain.                                              | `10`                |
 | deployment.minReadySeconds         | Minimum number of seconds for which newly created pods should be ready without any of its container crashing, for it to be considered available. |                     |
 | deployment.initContainers          | Create initContainers. Please go to Kubernetes doc for the spec of the initContainers |                     |

--- a/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
+++ b/charts/kong/ci/__snapshots__/admin-api-service-clusterip-values.snap
@@ -268,7 +268,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-configuration.snap
@@ -928,7 +928,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/admission-webhook-filtersecrets-false.snap
+++ b/charts/kong/ci/__snapshots__/admission-webhook-filtersecrets-false.snap
@@ -776,9 +776,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/certificate-values.snap
+++ b/charts/kong/ci/__snapshots__/certificate-values.snap
@@ -776,9 +776,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
+++ b/charts/kong/ci/__snapshots__/certificates-enabled-values.snap
@@ -776,9 +776,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-entities-rbac-3.2-values.snap
@@ -909,7 +909,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/custom-labels-values.snap
+++ b/charts/kong/ci/__snapshots__/custom-labels-values.snap
@@ -945,7 +945,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/default-values.snap
+++ b/charts/kong/ci/__snapshots__/default-values.snap
@@ -932,7 +932,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
+++ b/charts/kong/ci/__snapshots__/disable-creating-ingress-class.snap
@@ -768,9 +768,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/enterprise-manager-cert-values.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-manager-cert-values.snap
@@ -852,9 +852,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-basicauth.snap
@@ -304,7 +304,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect-below-360.snap
@@ -309,7 +309,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
+++ b/charts/kong/ci/__snapshots__/enterprise-postgres-openidconnect.snap
@@ -304,7 +304,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-1-values.snap
@@ -941,7 +941,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-2-values.snap
@@ -941,7 +941,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-3-values.snap
@@ -932,7 +932,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-4-values.snap
@@ -950,7 +950,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-5-3.4-rbac-values.snap
@@ -776,9 +776,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
+++ b/charts/kong/ci/__snapshots__/kong-ingress-image-pull-secrets-values.snap
@@ -778,9 +778,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/pdb-always-allow.snap
+++ b/charts/kong/ci/__snapshots__/pdb-always-allow.snap
@@ -800,9 +800,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/pdb-default.snap
+++ b/charts/kong/ci/__snapshots__/pdb-default.snap
@@ -800,9 +800,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
+++ b/charts/kong/ci/__snapshots__/proxy-appprotocol-values.snap
@@ -934,7 +934,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/service-account.snap
+++ b/charts/kong/ci/__snapshots__/service-account.snap
@@ -932,7 +932,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/service-ipfamilies-values.snap
+++ b/charts/kong/ci/__snapshots__/service-ipfamilies-values.snap
@@ -272,7 +272,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
+++ b/charts/kong/ci/__snapshots__/service-proxy-nameoverride-values.snap
@@ -776,9 +776,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/service-trafficdistribution-values.snap
+++ b/charts/kong/ci/__snapshots__/service-trafficdistribution-values.snap
@@ -176,9 +176,9 @@ spec:
             type: RuntimeDefault
         resources: {}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        - rm
+        - -vrf
+        - $(KONG_PREFIX)/pids
         env:
         - name: KONG_ADMIN_ACCESS_LOG
           value: "/dev/stdout"

--- a/charts/kong/ci/__snapshots__/single-image-default-values.snap
+++ b/charts/kong/ci/__snapshots__/single-image-default-values.snap
@@ -932,7 +932,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
+++ b/charts/kong/ci/__snapshots__/test-enterprise-version-3.4-values.snap
@@ -215,7 +215,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/test1-values.snap
+++ b/charts/kong/ci/__snapshots__/test1-values.snap
@@ -945,7 +945,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/test2-values.snap
+++ b/charts/kong/ci/__snapshots__/test2-values.snap
@@ -1388,7 +1388,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/test3-values.snap
+++ b/charts/kong/ci/__snapshots__/test3-values.snap
@@ -244,7 +244,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/test4-values.snap
+++ b/charts/kong/ci/__snapshots__/test4-values.snap
@@ -256,7 +256,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: KONG_ADMIN_ACCESS_LOG
               value: /dev/stdout

--- a/charts/kong/ci/__snapshots__/test5-values.snap
+++ b/charts/kong/ci/__snapshots__/test5-values.snap
@@ -1035,7 +1035,7 @@ spec:
         - command:
             - rm
             - -vrf
-            - $KONG_PREFIX/pids
+            - $(KONG_PREFIX)/pids
           env:
             - name: CLIENT_ID
               value: exampleId

--- a/charts/kong/templates/deployment.yaml
+++ b/charts/kong/templates/deployment.yaml
@@ -100,9 +100,11 @@ spec:
       {{- if .Values.deployment.kong.enabled }}
       initContainers:
       {{- if .Values.deployment.kong.initContainers.clearStalePid.enabled }}
+      {{- $clearStalePid := .Values.deployment.kong.initContainers.clearStalePid }}
+      {{- $clearStalePidImage := default .Values.image $clearStalePid.image }}
       - name: clear-stale-pid
-        image: {{ include "kong.getRepoTag" .Values.image }}
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: {{ include "kong.getRepoTag" $clearStalePidImage }}
+        imagePullPolicy: {{ default .Values.image.pullPolicy $clearStalePidImage.pullPolicy }}
         {{- if .Values.containerSecurityContext.enabled }}
         securityContext:
         {{ toYaml (omit .Values.containerSecurityContext "enabled") | nindent 10 }}
@@ -110,9 +112,7 @@ spec:
         resources:
 {{ toYaml (default .Values.resources .Values.initContainerResources) | indent 10 }}
         command:
-        - "rm"
-        - "-vrf"
-        - "$KONG_PREFIX/pids"
+        {{- toYaml $clearStalePid.command | nindent 8 }}
         env:
         {{- include "kong.env" . | nindent 8 }}
         {{- include "kong.envFrom" .Values.envFrom | nindent 8 }}

--- a/charts/kong/values.yaml
+++ b/charts/kong/values.yaml
@@ -24,6 +24,16 @@ deployment:
       # Enable the init container which clears the stale PIDs from Kong's prefix directory.
       clearStalePid:
         enabled: true
+        # Image used by the clear-stale-pid init container. Defaults to the Kong image
+        # when unset.
+        image: {}
+          # repository: busybox
+          # tag: "1.36"
+          # pullPolicy: IfNotPresent
+        command:
+        - "rm"
+        - "-vrf"
+        - "$(KONG_PREFIX)/pids"
   # The number of old `ReplicaSet`s to retain.
   revisionHistoryLimit: 10
 


### PR DESCRIPTION
<!--
Thank you for contributing to Kong/charts. Please read through our contribution
guidelines to understand our review process: https://github.com/Kong/charts/blob/main/CONTRIBUTING.md

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
when it is merged.
-->

#### What this PR does / why we need it:

For the Kong distroless image, which does not include coreutils, meaning commands like `rm` cannot be used, this PR allows users to customize the clear-stale-pid image so that even if the Kong image is distroless, the process of cleaning up PIDs can still be completed normally.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

Related to https://github.com/Kong/kong/issues/6696

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] PR is based off the current tip of the `main` branch.
- [x] Changes are documented under the "Unreleased" header in CHANGELOG.md
- [x] New or modified sections of values.yaml are documented in the README.md
- [x] Commits follow the [Kong commit message guidelines](https://github.com/Kong/kong/blob/master/CONTRIBUTING.md#commit-message-format)
